### PR TITLE
Handling of labels in AtomicCell

### DIFF
--- a/simulationdataschema/atom_state.py
+++ b/simulationdataschema/atom_state.py
@@ -1,0 +1,581 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import ase
+from typing import Optional
+from structlog.stdlib import BoundLogger
+
+from nomad.units import ureg
+
+from nomad.metainfo import Quantity, SubSection, MEnum
+from nomad.datamodel.data import ArchiveSection
+from nomad.datamodel.metainfo.annotations import ELNAnnotation
+
+
+orbitals = {
+    -1: dict(zip(range(4), ("s", "p", "d", "f"))),
+    0: {0: ""},
+    1: dict(zip(range(-1, 2), ("x", "z", "y"))),
+    2: dict(zip(range(-2, 3), ("xy", "xz", "z^2", "yz", "x^2-y^2"))),
+    3: dict(
+        zip(
+            range(-3, 4),
+            ("x(x^2-3y^2)", "xyz", "xz^2", "z^3", "yz^2", "z(x^2-y^2)", "y(3x^2-y^2)"),
+        )
+    ),
+}
+
+
+class OrbitalState(ArchiveSection):
+    """
+    A base section to define the orbital state of an atom.
+    """
+
+    # TODO: add the relativistic kappa_quantum_number
+    n_quantum_number = Quantity(
+        type=np.int32,
+        description="""
+        Principal quantum number n of the orbital state.
+        """,
+    )
+
+    l_quantum_number = Quantity(
+        type=np.int32,
+        description="""
+        Azimuthal quantum number l of the orbital state.
+        """,
+    )
+
+    ml_quantum_number = Quantity(
+        type=np.int32,
+        description="""
+        Azimuthal projection of the l vector.
+        """,
+    )
+
+    j_quantum_number = Quantity(
+        type=np.float64,
+        shape=["1..2"],
+        description="""
+        Total angular momentum quantum number $j = |l-s| ... l+s$. Necessary with strong
+        L-S coupling or non-collinear spin systems.
+        """,
+    )
+
+    mj_quantum_number = Quantity(
+        type=np.float64,
+        shape=["*"],
+        description="""
+        Azimuthal projection of the $j$ vector. Necessary with strong L-S coupling or
+        non-collinear spin systems.
+        """,
+    )
+
+    ms_quantum_number = Quantity(
+        type=np.int32,
+        description="""
+        Spin quantum number. Set to -1 for spin down and +1 for spin up. In non-collinear spin systems,
+        the projection axis $z$ should also be defined.
+        """,
+    )
+
+    degeneracy = Quantity(
+        type=np.int32,
+        description="""
+        The number of states under the filling constraints applied to the orbital set.
+        This implicitly assumes that all orbitals in the set are degenerate.
+        """,
+    )
+
+    occupation = Quantity(
+        type=np.int32,
+        description="""
+        The number of electrons in the orbital state. The state is fully occupied if
+        occupation = degeneracy.
+        """,
+    )
+
+    def multiplicity(self, quantum_number):
+        return 2 * quantum_number + 1
+
+    def set_degeneracy(self) -> int:
+        """Set the degeneracy based on how specifically determined the quantum state is.
+        This function can be triggered anytime to update the degeneracy."""
+        # TODO: there are certain j (mj) specifications that may straddle just one l value
+        if self.ml_quantum_number is not None:
+            if self.ms_quantum_bool is not None:
+                self.degeneracy = 1
+            else:
+                self.degeneracy = 2
+        elif self.j_quantum_number is not None:
+            degeneracy = 0
+            for jj in self.j_quantum_number:
+                if self.mj_quantum_number is not None:
+                    mjs = RussellSaundersState.generate_MJs(
+                        self.j_quantum_number[0], rising=True
+                    )
+                    degeneracy += len(
+                        [mj for mj in mjs if mj in self.mj_quantum_number]
+                    )
+                else:
+                    degeneracy += RussellSaundersState(jj, 1).degeneracy
+            if self.ms_quantum_bool is not None:
+                self.degeneracy = degeneracy / 2
+            else:
+                self.degeneracy = degeneracy
+        elif self.l_quantum_number is not None:
+            if self.ms_quantum_bool is not None:
+                self.degeneracy = self.get_l_degeneracy() / 2
+            else:
+                self.degeneracy = self.get_l_degeneracy()
+        return self.degeneracy
+
+    def normalize(self, archive, logger):
+        super().normalize(archive, logger)
+
+
+# class Pseudopotential(ArchiveSection):
+#     """
+#     A base section to define the pseudopotential of an atom.
+#     """
+
+#     name = Quantity(
+#         type=str,
+#         shape=[],
+#         description="""
+#         Native code name of the pseudopotential.
+#         """,
+#     )
+
+#     type = Quantity(
+#         type=MEnum("US V", "US MBK", "PAW"),
+#         shape=[],
+#         description="""
+#         Pseudopotential classification.
+#         | abbreviation | description | DOI |
+#         | ------------ | ----------- | --------- |
+#         | `'US'`       | Ultra-soft  | |
+#         | `'PAW'`      | Projector augmented wave | |
+#         | `'V'`        | Vanderbilt | https://doi.org/10.1103/PhysRevB.47.6728 |
+#         | `'MBK'`      | Morrison-Bylander-Kleinman | https://doi.org/10.1103/PhysRevB.41.7892 |
+#         """,
+#     )
+
+#     norm_conserving = Quantity(
+#         type=bool,
+#         shape=[],
+#         description="""
+#         Denotes whether the pseudopotential is norm-conserving.
+#         """,
+#     )
+
+#     cutoff = Quantity(
+#         type=np.float64,
+#         shape=[],
+#         unit="joule",
+#         description="""
+#         Minimum recommended spherical cutoff energy for any plane-wave basis set
+#         using the pseudopotential.
+#         """,
+#     )
+
+#     xc_functional_name = Quantity(
+#         type=str,
+#         shape=["*"],
+#         description="""
+#         Name of the exchange-correlation functional used to generate the pseudopotential.
+#         Follows the libxc naming convention.
+#         """,
+#     )
+
+#     l_max = Quantity(
+#         type=np.int32,
+#         shape=[],
+#         description="""
+#         Maximum angular momentum of the pseudopotential projectors.
+#         """,
+#     )
+
+#     lm_max = Quantity(
+#         type=np.int32,
+#         shape=[],
+#         description="""
+#         Maximum magnetic momentum of the pseudopotential projectors.
+#         """,
+#     )
+
+#     def normalize(self, archive, logger):
+#         super().normalize(archive, logger)
+
+
+class CoreHole(ArchiveSection):
+    """
+    Describes the quantum state of a single hole in an open-shell core state. This is the physical interpretation.
+    For modelling purposes, the electron charge excited may lie between 0 and 1. This follows a so-called Janak state.
+    Sometimes, no electron is actually, excited, but just marked for excitation. This is denoted as an `initial` state.
+    Any missing quantum numbers indicate some level of arbitrariness in the choice of the core hole, represented in the degeneracy.
+    """
+
+    # quantities: list[str] = SingleElectronState.quantities + ["n_electrons_excited"]
+
+    n_electrons_excited = Quantity(
+        type=np.float64,
+        shape=[],
+        description="""
+        The electron charge excited for modelling purposes.
+        Choices that deviate from 0 or 1 typically leverage Janak composition.
+        Unless the `initial` state is chosen, the model corresponds to a single electron being excited in physical reality.
+        """,
+    )
+    occupation = Quantity(
+        type=np.float64,
+        description="""
+        The total number of electrons within the state (as defined by degeneracy)
+        after exciting the model charge.
+        """,
+    )
+    dscf_state = Quantity(
+        type=MEnum("initial", "final"),
+        shape=[],
+        description="""
+        The $\\Delta$-SCF state tag, used to identify the role in the workflow of the same name.
+        Allowed values are `initial` (not to be confused with the _initial-state approximation_) and `final`.
+        """,
+    )
+
+    def __setattr__(self, name, value):
+        if name == "n_electrons_excited":
+            if value < 0.0:
+                raise ValueError("Number of excited electrons must be positive.")
+            if value > 1.0:
+                raise ValueError("Number of excited electrons must be less than 1.")
+        elif name == "dscf_state":
+            if value == "initial":
+                self.n_electrons_excited = 0.0
+                self.degeneracy = 1
+        super().__setattr__(name, value)
+
+    def _extract_orbital(self):
+        """
+        Gather atomic orbitals from `run.method.atom_parameters.core_hole`.
+        Also apply normalization in the process.
+        """
+        # Collect the active orbitals from method
+        methods = self.entry_archive.run[-1].method
+        if not methods:
+            return []
+        atom_params = getattr(methods[-1], "atom_parameters", [])
+        active_orbitals_run = []
+        for param in atom_params:
+            core_hole = param.core_hole
+            if core_hole:
+                active_orbitals_run.append(core_hole)
+        if (
+            len(active_orbitals_run) > 1
+        ):  # FIXME: currently only one set of active orbitals is supported, remove for multiple
+            self.logger.warn(
+                """Multiple sets of active orbitals found.
+                Currently, the topology only supports 1, so only the first set is used."""
+            )
+        # Map the active orbitals to the topology
+        active_orbitals_results = []
+        for active_orbitals in active_orbitals_run:
+            active_orbitals.normalize(None, None)
+            active_orbitals_new = CoreHole()
+            for quantity_name in active_orbitals.quantities:
+                setattr(
+                    active_orbitals_new,
+                    quantity_name,
+                    getattr(active_orbitals, quantity_name),
+                )
+            active_orbitals_new.normalize(None, None)
+            active_orbitals_results.append(active_orbitals_new)
+            break  # FIXME: currently only one set of active orbitals is supported, remove for multiple
+        return active_orbitals_results
+
+    def set_occupation(self) -> float:
+        """Set the occupation based on the number of excited electrons."""
+        if not self.occupation:
+            try:
+                self.occupation = self.set_degeneracy() - self.n_electrons_excited
+            except TypeError:
+                raise AttributeError(
+                    "Cannot set occupation without `n_electrons_excited`."
+                )
+        return self.occupation
+
+    def normalize(self, archive, logger):
+        super().normalize(archive, logger)
+        # self.set_occupation()
+
+
+class HubbardInteractions(ArchiveSection):
+    """
+    A base section to define the Hubbard interactions of the system.
+    """
+
+    orbital_ref = Quantity(
+        type=OrbitalState,
+        shape=["*"],
+        description="""
+        Reference to the OrbitalState sections that are used as a basis to obtain the Hubbard
+        interaction matrices.
+        """,
+    )
+
+    umn = Quantity(
+        type=np.float64,
+        shape=["*", "*"],
+        unit="joule",
+        description="""
+        Value of the local Hubbard interaction matrix. The order of the rows and columns coincide
+        with the elements in `orbital_ref`.
+        """,
+    )
+
+    u = Quantity(
+        type=np.float64,
+        unit="joule",
+        description="""
+        Value of the (intraorbital) Hubbard interaction
+        """,
+        a_eln=ELNAnnotation(component="NumberEditQuantity"),
+    )
+
+    jh = Quantity(
+        type=np.float64,
+        unit="joule",
+        description="""
+        Value of the (interorbital) Hund's coupling.
+        """,
+        a_eln=ELNAnnotation(component="NumberEditQuantity"),
+    )
+
+    up = Quantity(
+        type=np.float64,
+        unit="joule",
+        description="""
+        Value of the (interorbital) Coulomb interaction. In rotational invariant systems, up = u - 2 * jh.
+        """,
+        a_eln=ELNAnnotation(component="NumberEditQuantity"),
+    )
+
+    j = Quantity(
+        type=np.float64,
+        unit="joule",
+        description="""
+        Value of the exchange interaction. In rotational invariant systems, j = jh.
+        """,
+        a_eln=ELNAnnotation(component="NumberEditQuantity"),
+    )
+
+    u_effective = Quantity(
+        type=np.float64,
+        unit="joule",
+        description="""
+        Value of the effective U parameter (u - j).
+        """,
+    )
+
+    slater_integrals = Quantity(
+        type=np.float64,
+        shape=[3],
+        unit="joule",
+        description="""
+        Value of the Slater integrals [F0, F2, F4] in spherical harmonics used to derive
+        the local Hubbard interactions:
+
+            u = ((2.0 / 7.0) ** 2) * (F0 + 5.0 * F2 + 9.0 * F4) / (4.0*np.pi)
+
+            up = ((2.0 / 7.0) ** 2) * (F0 - 5.0 * F2 + 3.0 * 0.5 * F4) / (4.0*np.pi)
+
+            jh = ((2.0 / 7.0) ** 2) * (5.0 * F2 + 15.0 * 0.25 * F4) / (4.0*np.pi)
+
+        See e.g., Elbio Dagotto, Nanoscale Phase Separation and Colossal Magnetoresistance,
+        Chapter 4, Springer Berlin (2003).
+        """,
+    )
+
+    double_counting_correction = Quantity(
+        type=str,
+        description="""
+        Name of the double counting correction algorithm applied.
+        """,
+        a_eln=ELNAnnotation(component="StringEditQuantity"),
+    )
+
+    def resolve_u_interactions(self, logger: BoundLogger) -> Optional[tuple]:
+        """
+        Resolves the Hubbard interactions (u, up, jh) from the Slater integrals (F0, F2, F4).
+
+        Args:
+            logger (BoundLogger): The logger to log messages.
+
+        Returns:
+            (Optional[tuple]): The Hubbard interactions (u, up, jh).
+        """
+        if self.slater_integrals is None or len(self.slater_integrals) == 3:
+            logger.warning(
+                "Could not find `HubbardInteractions.slater_integrals` or the length is not three."
+            )
+            return None
+        f0 = self.slater_integrals[0]
+        f2 = self.slater_integrals[1]
+        f4 = self.slater_integrals[2]
+        u_interaction = (
+            ((2.0 / 7.0) ** 2)
+            * (f0 + 5.0 * f2 + 9.0 * f4)
+            / (4.0 * np.pi)
+            * ureg("joule")
+        )
+        up_interaction = (
+            ((2.0 / 7.0) ** 2)
+            * (f0 - 5.0 * f2 + 3.0 * f4 / 2.0)
+            / (4.0 * np.pi)
+            * ureg("joule")
+        )
+        jh_interaction = (
+            ((2.0 / 7.0) ** 2)
+            * (5.0 * f2 + 15.0 * f4 / 4.0)
+            / (4.0 * np.pi)
+            * ureg("joule")
+        )
+        return u_interaction, up_interaction, jh_interaction
+
+    def resolve_u_effective(self, logger: BoundLogger) -> Optional[np.float64]:
+        """
+        Resolves the effective U parameter (u - j).
+
+        Args:
+            logger (BoundLogger): The logger to log messages.
+
+        Returns:
+            (Optional[np.float64]): The effective U parameter.
+        """
+        if self.u is None or self.j is None:
+            logger.warning(
+                "Could not find `HubbardInteractions.u` or `HubbardInteractions.j`."
+            )
+            return None
+        return self.u - self.j
+
+    def normalize(self, archive, logger):
+        super().normalize(archive, logger)
+
+        # Obtain (u, up, jh) from slater_integrals
+        if self.u is None and self.up is None and self.jh is None:
+            self.u, self.up, self.jh = self.resolve_u_interactions(logger)
+
+        # If u_effective is not available, calculate it
+        if self.u_effective is None:
+            self.u_effective = self.resolve_u_effective(logger)
+
+
+class AtomState(ArchiveSection):
+    """
+    A base section to define each atom state information.
+    """
+
+    # ? constraint to the normal chemical elements (no 'X' as defined in ASE included)
+    chemical_symbol = Quantity(
+        type=MEnum(ase.data.chemical_symbols[1:]),
+        description="""
+        Symbol of the element, e.g. 'H', 'Pb'. This quantity is equivalent to `atomic_numbers`.
+        """,
+    )
+
+    atomic_number = Quantity(
+        type=np.int32,
+        description="""
+        Atomic number Z. This quantity is equivalent to `chemical_symbol`.
+        """,
+    )
+
+    orbitals = SubSection(sub_section=OrbitalState.m_def, repeats=True)
+
+    charge = Quantity(
+        type=np.int32,
+        default=0,
+        description="""
+        Charge of the atom. It is defined as the number of extra electrons or holes in the
+        atom. If the atom is neutral, charge = 0 and the summation of all (if available) the`OrbitalState.occupation`
+        coincides with the `atomic_number`. Otherwise, charge can be any positive integer (+1, +2...)
+        for cations or any negative integer (-1, -2...) for anions.
+
+        Note: for `CoreHole` systems we do not consider the charge of the atom even if
+        we do not store the final `OrbitalState` where the electron was excited to.
+        """,
+        a_eln=ELNAnnotation(component="NumberEditQuantity"),
+    )
+
+    # pseudopotential = SubSection(sub_section=Pseudopotential.m_def, repeats=False)
+
+    core_hole = SubSection(sub_section=CoreHole.m_def, repeats=False)
+
+    hubbard_interactions = SubSection(
+        sub_section=HubbardInteractions.m_def, repeats=False
+    )
+
+    def resolve_chemical_symbol_and_number(self, logger: BoundLogger) -> None:
+        """
+        Resolves the chemical symbol from the atomic number and viceversa.
+
+        Args:
+            logger (BoundLogger): The logger to log messages.
+        """
+        if self.chemical_symbol is None and self.atomic_number is not None:
+            try:
+                self.chemical_symbol = ase.data.chemical_symbols[self.atomic_number]
+            except IndexError:
+                logger.error(
+                    "The `AtomicState.atomic_number` is out of range of the periodic table."
+                )
+                return
+        elif self.chemical_symbol is not None and self.atomic_number is None:
+            try:
+                self.atomic_number = ase.data.atomic_numbers[self.chemical_symbol]
+            except IndexError:
+                logger.error(
+                    "The `AtomicState.chemical_symbol` is not recognized in the periodic table."
+                )
+                return
+
+    def normalize(self, archive, logger):
+        super().normalize(archive, logger)
+
+        # Get chemical_symbol from atomic_number and viceversa
+        self.resolve_chemical_symbol_and_number(logger)

--- a/simulationdataschema/atoms_state.py
+++ b/simulationdataschema/atoms_state.py
@@ -71,7 +71,7 @@ orbitals_map = {
 }
 
 
-class OrbitalState(ArchiveSection):
+class OrbitalsState(ArchiveSection):
     """
     A base section used to define the orbital state of an atom.
     """
@@ -259,14 +259,14 @@ class OrbitalState(ArchiveSection):
 
 class CoreHole(ArchiveSection):
     """
-    A base section used to define the core-hole state of an atom by referencing the `OrbitalState`
+    A base section used to define the core-hole state of an atom by referencing the `OrbitalsState`
     section where the core-hole was generated.
     """
 
     orbital_ref = Quantity(
-        type=OrbitalState,
+        type=OrbitalsState,
         description="""
-        Reference to the OrbitalState section that is used as a basis to obtain the `CoreHole` section.
+        Reference to the OrbitalsState section that is used as a basis to obtain the `CoreHole` section.
         """,
         a_eln=ELNAnnotation(component="ReferenceEditQuantity"),
     )
@@ -334,10 +334,10 @@ class HubbardInteractions(ArchiveSection):
     """
 
     orbitals_ref = Quantity(
-        type=OrbitalState,
+        type=OrbitalsState,
         shape=["*"],
         description="""
-        Reference to the OrbitalState sections that are used as a basis to obtain the Hubbard
+        Reference to the `OrbitalsState` sections that are used as a basis to obtain the Hubbard
         interaction matrices.
         """,
     )
@@ -510,19 +510,19 @@ class AtomsState(ArchiveSection):
         """,
     )
 
-    orbitals = SubSection(sub_section=OrbitalState.m_def, repeats=True)
+    orbitals_state = SubSection(sub_section=OrbitalsState.m_def, repeats=True)
 
     charge = Quantity(
         type=np.int32,
         default=0,
         description="""
         Charge of the atom. It is defined as the number of extra electrons or holes in the
-        atom. If the atom is neutral, charge = 0 and the summation of all (if available) the`OrbitalState.occupation`
+        atom. If the atom is neutral, charge = 0 and the summation of all (if available) the`OrbitalsState.occupation`
         coincides with the `atomic_number`. Otherwise, charge can be any positive integer (+1, +2...)
         for cations or any negative integer (-1, -2...) for anions.
 
         Note: for `CoreHole` systems we do not consider the charge of the atom even if
-        we do not store the final `OrbitalState` where the electron was excited to.
+        we do not store the final `OrbitalsState` where the electron was excited to.
         """,
         a_eln=ELNAnnotation(component="NumberEditQuantity"),
     )

--- a/simulationdataschema/atoms_state.py
+++ b/simulationdataschema/atoms_state.py
@@ -344,9 +344,16 @@ class HubbardInteractions(ArchiveSection):
     A base section to define the Hubbard interactions of the system.
     """
 
+    n_orbitals = Quantity(
+        type=np.int32,
+        description="""
+        Number of orbitals used to define the Hubbard interactions.
+        """,
+    )
+
     orbitals_ref = Quantity(
         type=OrbitalsState,
-        shape=["*"],
+        shape=["n_orbitals"],
         description="""
         Reference to the `OrbitalsState` sections that are used as a basis to obtain the Hubbard
         interaction matrices.
@@ -355,7 +362,7 @@ class HubbardInteractions(ArchiveSection):
 
     u_matrix = Quantity(
         type=np.float64,
-        shape=["*", "*"],
+        shape=["n_orbitals", "n_orbitals"],
         unit="joule",
         description="""
         Value of the local Hubbard interaction matrix. The order of the rows and columns coincide

--- a/simulationdataschema/atoms_state.py
+++ b/simulationdataschema/atoms_state.py
@@ -92,7 +92,7 @@ class OrbitalsState(ArchiveSection):
     )
 
     l_quantum_symbol = Quantity(
-        type=np.int32,
+        type=str,
         description="""
         Azimuthal quantum symbol of the orbital state, "s", "p", "d", "f", etc. This
         quantity is equivalent to `l_quantum_number`.
@@ -107,7 +107,7 @@ class OrbitalsState(ArchiveSection):
     )
 
     ml_quantum_symbol = Quantity(
-        type=np.int32,
+        type=str,
         description="""
         Azimuthal projection symbol of the `l` vector, "x", "y", "z", etc. This quantity is equivalent
         to `ml_quantum_number`.
@@ -141,7 +141,7 @@ class OrbitalsState(ArchiveSection):
     )
 
     ms_quantum_symbol = Quantity(
-        type=np.int32,
+        type=str,
         description="""
         Spin quantum symbol. Set to 'down' for spin down and 'up' for spin up. In non-collinear
         spin systems, the projection axis $z$ should also be defined.
@@ -193,7 +193,7 @@ class OrbitalsState(ArchiveSection):
         }
         # Check if quantity already exists
         quantity = getattr(self, f"{quantum_number}_quantum_{type}")
-        if quantity:
+        if quantity or quantity is None:
             return
 
         # If not, check whether the countertype exists
@@ -207,7 +207,7 @@ class OrbitalsState(ArchiveSection):
             return
 
         # If the counterpart exists, then resolve the quantity from the orbitals_map
-        quantity = getattr(orbitals_map, f"{quantum_number}_{type}s")
+        quantity = orbitals_map.get(f"{quantum_number}_{type}s", {}).get(other_quantity)
         setattr(self, f"{quantum_number}_quantum_{type}", quantity)
 
     def resolve_degeneracy(self) -> Optional[int]:

--- a/simulationdataschema/atoms_state.py
+++ b/simulationdataschema/atoms_state.py
@@ -505,7 +505,7 @@ class HubbardInteractions(ArchiveSection):
             self.u_effective = self.resolve_u_effective(logger)
 
 
-class AtomState(ArchiveSection):
+class AtomsState(ArchiveSection):
     """
     A base section to define each atom state information.
     """

--- a/simulationdataschema/atoms_state.py
+++ b/simulationdataschema/atoms_state.py
@@ -245,7 +245,7 @@ class OrbitalState(ArchiveSection):
                     degeneracy += RussellSaundersState(jj, 1).degeneracy
         return degeneracy
 
-    def normalize(self, archive, logger):
+    def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 
         # Resolving the quantum numbers and symbols if not available
@@ -310,7 +310,7 @@ class CoreHole(ArchiveSection):
                 return
             self.orbital_ref.occupation = degeneracy - self.n_excited_electrons
 
-    def normalize(self, archive, logger):
+    def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 
         # Check if n_excited_electrons is between 0 and 1
@@ -478,7 +478,7 @@ class HubbardInteractions(ArchiveSection):
             return None
         return self.u - self.j
 
-    def normalize(self, archive, logger):
+    def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 
         # Obtain (u, up, jh) from slater_integrals
@@ -557,7 +557,7 @@ class AtomsState(ArchiveSection):
                 )
                 return
 
-    def normalize(self, archive, logger):
+    def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 
         # Get chemical_symbol from atomic_number and viceversa

--- a/simulationdataschema/atoms_state.py
+++ b/simulationdataschema/atoms_state.py
@@ -489,6 +489,13 @@ class HubbardInteractions(ArchiveSection):
         if self.u_effective is None:
             self.u_effective = self.resolve_u_effective(logger)
 
+        # Check if length of `orbitals_ref` is the same as the length of `umn`:
+        if self.umn is not None and self.orbitals_ref is not None:
+            if len(self.umn) != len(self.orbitals_ref):
+                logger.error(
+                    "The length of `HubbardInteractions.umn` does not coincide with length of `HubbardInteractions.orbitals_ref`."
+                )
+
 
 class AtomsState(ArchiveSection):
     """

--- a/simulationdataschema/general.py
+++ b/simulationdataschema/general.py
@@ -193,7 +193,8 @@ class Simulation(BaseSimulation, EntryData):
             logger.error("No system information reported.")
             return
         system_ref = self.model_system[-1]
-        system_ref.is_representative = True
+        # * We define is_representative in the parser
+        # system_ref.is_representative = True
         self.m_cache["system_ref"] = system_ref
 
         # Setting up the `branch_depth` in the parent-child tree

--- a/simulationdataschema/model_method.py
+++ b/simulationdataschema/model_method.py
@@ -47,6 +47,6 @@ class ModelMethod(ArchiveSection):
 
     normalizer_level = 1
 
-    def normalize(self, archive, logger):
+    def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
         self.logger = logger

--- a/simulationdataschema/model_system.py
+++ b/simulationdataschema/model_system.py
@@ -234,9 +234,16 @@ class Cell(GeometricSpace):
         """,
     )
 
+    n_cell_points = Quantity(
+        type=np.int32,
+        description="""
+        Number of cell points.
+        """,
+    )
+
     positions = Quantity(
         type=np.float64,
-        shape=["*", 3],
+        shape=["n_cell_points", 3],
         unit="meter",
         description="""
         Positions of all the atoms in Cartesian coordinates.
@@ -245,7 +252,7 @@ class Cell(GeometricSpace):
 
     velocities = Quantity(
         type=np.float64,
-        shape=["*", 3],
+        shape=["n_cell_points", 3],
         unit="meter / second",
         description="""
         Velocities of the atoms. It is the change in cartesian coordinates of the atom position
@@ -305,9 +312,16 @@ class AtomicCell(Cell):
 
     atoms_state = SubSection(sub_section=AtomsState.m_def, repeats=True)
 
+    n_atoms = Quantity(
+        type=np.int32,
+        description="""
+        Number of atoms in the atomic cell.
+        """,
+    )
+
     equivalent_atoms = Quantity(
         type=np.int32,
-        shape=["*"],
+        shape=["n_atoms"],
         description="""
         List of equivalent atoms as defined in `atoms`. If no equivalent atoms are found,
         then the list is simply the index of each element, e.g.:
@@ -319,7 +333,7 @@ class AtomicCell(Cell):
     # ! improve description and clarify whether this belongs to `Symmetry` with @lauri-codes
     wyckoff_letters = Quantity(
         type=str,
-        shape=["*"],
+        shape=["n_atoms"],
         description="""
         Wyckoff letters associated with each atom.
         """,
@@ -869,7 +883,6 @@ class ModelSystem(System):
 
     branch_label = Quantity(
         type=str,
-        shape=[],
         description="""
         Label of the specific branch in the hierarchical `ModelSystem` tree.
         """,
@@ -895,9 +908,9 @@ class ModelSystem(System):
         """,
     )
 
+    # TODO improve description and add an example using the case in atom_indices
     bond_list = Quantity(
         type=np.int32,
-        # TODO improve description and add an example using the case in atom_indices
         description="""
         List of pairs of atom indices corresponding to bonds (e.g., as defined by a force field)
         within this atoms_group.

--- a/simulationdataschema/model_system.py
+++ b/simulationdataschema/model_system.py
@@ -742,36 +742,42 @@ class ChemicalFormula(ArchiveSection):
 class ModelSystem(System):
     # ! Work in this description with new `AtomState`
     """
-    Model system used as an input for the computation. It inherits from `System` where a set
-    of sub-sections for the `elemental_composition` is defined.
+    Model system used as an input for the computation.
 
-    We also defined:
+    We define:
         - `name` refers to all the verbose and user-dependent naming in ModelSystem,
         - `type` refers to the type of the ModelSystem (atom, bulk, surface, etc.),
-        - `dimensionality` refers to the dimensionality of the ModelSystem (0D, 1D, 2D, 3D),
+        - `dimensionality` refers to the dimensionality of the ModelSystem (0, 1, 2, 3),
 
-    If the ModelSystem `is_representative`, the normalization occurs. The time evolution of
-    the system is encoded on the fact that ModelSystem is a list under Simulation, and for
-    each element of that list, `time_step` can be defined.
+    If the ModelSystem `is_representative`, normalization occurs. The time evolution of the
+    ModelSystem is encoded on the fact that it is a list under `Simulation`, and for each element
+    of that list, `time_step` can be defined.
 
     It is composed of the sub-sections:
         - `AtomicCell` containing the information of the atomic structure,
-        - `Symmetry` containing the information of the (standarized) atomic cell symmetry
+        - `Symmetry` containing the information of the (conventional) atomic cell symmetry
         in bulk ModelSystem,
         - `ChemicalFormula` containing the information of the chemical formulas in different
         formats.
 
-    This class nest over itself (with the proxy in `model_system`) to define different
+    This class nest over itself (with the section proxy in `model_system`) to define different
     parent-child system trees. The quantities `branch_label`, `branch_depth`, `atom_indices`,
     and `bond_list` are used to define the parent-child tree.
 
     The normalization is ran in the following order:
-        1. `AtomicCell.normalize()` from `atomic_cell`,
-        2. `ModelSystem.normalize()` in this class,
-        3. `Symmetry.normalize()` is called within this class normalization,
-        4. `ChemicalFormula.normalize()` is called within this class normalization.
+        1. `OrbitalsState.normalize()` in atoms_state.py under `AtomsState`
+        2. `CoreHoleState.normalize()` in atoms_state.py under `AtomsState`
+        3. `HubbardInteractions.normalize()` in atoms_state.py under `AtomsState`
+        4. `AtomsState.normalize()` in atoms_state.py
+        5. `AtomicCell.normalize()` in atomic_cell.py
+        6. `Symmetry.normalize()` in this class
+        7. `ChemicalFormula.normalize()` in this class
+        8. `ModelSystem.normalize()` in this class
 
-    Examples:
+    Note: `normalize()` can be called at any time for each of the classes without being re-triggered
+    by the NOMAD normalization.
+
+    Examples for the parent-child hierarchical trees:
 
         - Example 1, a crystal Si has: 3 AtomicCell sections (named 'original', 'primitive',
         and 'conventional'), 1 Symmetry section, and 0 nested ModelSystem trees.

--- a/simulationdataschema/model_system.py
+++ b/simulationdataschema/model_system.py
@@ -60,7 +60,7 @@ from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel.metainfo.basesections import Entity, System
 from nomad.datamodel.metainfo.annotations import ELNAnnotation
 
-from .atom_state import AtomState
+from .atoms_state import AtomsState
 from .utils import get_sibling_section
 
 
@@ -296,7 +296,7 @@ class AtomicCell(Cell):
     A base section used to specify the atomic cell information of a system.
     """
 
-    atoms_state = SubSection(sub_section=AtomState.m_def, repeats=True)
+    atoms_state = SubSection(sub_section=AtomsState.m_def, repeats=True)
 
     equivalent_atoms = Quantity(
         type=np.int32,
@@ -513,7 +513,7 @@ class Symmetry(ArchiveSection):
         atomic_cell = AtomicCell(type=cell_type)
         atomic_cell.lattice_vectors = cell * ureg.angstrom
         for label, atomic_number in zip(labels, atomic_numbers):
-            atom_state = AtomState(chemical_symbol=label, atomic_number=atomic_number)
+            atom_state = AtomsState(chemical_symbol=label, atomic_number=atomic_number)
             atomic_cell.m_add_sub_section(AtomicCell.atoms_state, atom_state)
         atomic_cell.positions = (
             positions * ureg.angstrom

--- a/simulationdataschema/model_system.py
+++ b/simulationdataschema/model_system.py
@@ -37,7 +37,7 @@
 import re
 import numpy as np
 import ase
-from typing import Union, Tuple
+from typing import Tuple, Optional
 from structlog.stdlib import BoundLogger
 
 from matid import SymmetryAnalyzer, Classifier  # pylint: disable=import-error
@@ -55,404 +55,18 @@ from nomad import config
 from nomad.units import ureg
 from nomad.atomutils import Formula, get_normalized_wyckoff, search_aflow_prototype
 
-from nomad.datamodel.data import ArchiveSection
-
 from nomad.metainfo import Quantity, SubSection, SectionProxy, MEnum
+from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel.metainfo.basesections import Entity, System
 from nomad.datamodel.metainfo.annotations import ELNAnnotation
 
+from .atom_state import AtomState
 from .utils import get_sibling_section
-
-
-class OrbitalState(ArchiveSection):
-    """
-    A base section to define the orbital state of an atom.
-
-    It inherits from `ArchiveSection`.It contains the quantum numbers (n, l, ml, ms, j, mj),
-    the occupation, and the degeneracy of the state.
-    """
-
-    # TODO: add the relativistic kappa_quantum_number
-    n_quantum_number = Quantity(
-        type=np.int32,
-        description="""
-        Principal quantum number n of the orbital state.
-        """,
-    )
-
-    l_quantum_number = Quantity(
-        type=np.int32,
-        description="""
-        Azimuthal quantum number l of the orbital state.
-        """,
-    )
-
-    ml_quantum_number = Quantity(
-        type=np.int32,
-        description="""
-        Azimuthal projection of the l vector.
-        """,
-    )
-
-    j_quantum_number = Quantity(
-        type=np.float64,
-        shape=["1..2"],
-        description="""
-        Total angular momentum quantum number $j = |l-s| ... l+s$. Necessary with strong
-        L-S coupling or non-collinear spin systems.
-        """,
-    )
-
-    mj_quantum_number = Quantity(
-        type=np.float64,
-        shape=["*"],
-        description="""
-        Azimuthal projection of the $j$ vector. Necessary with strong L-S coupling or
-        non-collinear spin systems.
-        """,
-    )
-
-    ms_quantum_bool = Quantity(
-        type=bool,
-        description="""
-        True if the state is spin up, False if it is spin down. In non-collinear spin systems,
-        the projection axis $z$ should also be defined.
-        """,
-    )
-
-    degeneracy = Quantity(
-        type=np.int32,
-        description="""
-        The number of states under the filling constraints applied to the orbital set.
-        This implicitly assumes that all orbitals in the set are degenerate.
-        """,
-    )
-
-    occupation = Quantity(
-        type=np.int32,
-        description="""
-        The number of electrons in the orbital state. The state is fully occupied if
-        occupation = degeneracy.
-        """,
-    )
-
-    def normalize(self, archive, logger):
-        super().normalize(archive, logger)
-
-
-class Pseudopotential(ArchiveSection):
-    """
-    A base section to define the pseudopotential of an atom.
-
-    It inherits from `ArchiveSection`. It contains the name, type, norm_conserving, cutoff,
-    xc_functional_name, l_max, and lm_max of the pseudopotential.
-    """
-
-    name = Quantity(
-        type=str,
-        shape=[],
-        description="""
-        Native code name of the pseudopotential.
-        """,
-    )
-
-    type = Quantity(
-        type=MEnum("US V", "US MBK", "PAW"),
-        shape=[],
-        description="""
-        Pseudopotential classification.
-        | abbreviation | description | DOI |
-        | ------------ | ----------- | --------- |
-        | `'US'`       | Ultra-soft  | |
-        | `'PAW'`      | Projector augmented wave | |
-        | `'V'`        | Vanderbilt | https://doi.org/10.1103/PhysRevB.47.6728 |
-        | `'MBK'`      | Morrison-Bylander-Kleinman | https://doi.org/10.1103/PhysRevB.41.7892 |
-        """,
-    )
-
-    norm_conserving = Quantity(
-        type=bool,
-        shape=[],
-        description="""
-        Denotes whether the pseudopotential is norm-conserving.
-        """,
-    )
-
-    cutoff = Quantity(
-        type=np.float64,
-        shape=[],
-        unit="joule",
-        description="""
-        Minimum recommended spherical cutoff energy for any plane-wave basis set
-        using the pseudopotential.
-        """,
-    )
-
-    xc_functional_name = Quantity(
-        type=str,
-        shape=["*"],
-        description="""
-        Name of the exchange-correlation functional used to generate the pseudopotential.
-        Follows the libxc naming convention.
-        """,
-    )
-
-    l_max = Quantity(
-        type=np.int32,
-        shape=[],
-        description="""
-        Maximum angular momentum of the pseudopotential projectors.
-        """,
-    )
-
-    lm_max = Quantity(
-        type=np.int32,
-        shape=[],
-        description="""
-        Maximum magnetic momentum of the pseudopotential projectors.
-        """,
-    )
-
-    def normalize(self, archive, logger):
-        super().normalize(archive, logger)
-
-
-class CoreHole(ArchiveSection):
-    """
-    Describes the quantum state of a single hole in an open-shell core state. This is the physical interpretation.
-    For modelling purposes, the electron charge excited may lie between 0 and 1. This follows a so-called Janak state.
-    Sometimes, no electron is actually, excited, but just marked for excitation. This is denoted as an `initial` state.
-    Any missing quantum numbers indicate some level of arbitrariness in the choice of the core hole, represented in the degeneracy.
-    """
-
-    # quantities: list[str] = SingleElectronState.quantities + ["n_electrons_excited"]
-
-    n_electrons_excited = Quantity(
-        type=np.float64,
-        shape=[],
-        description="""
-        The electron charge excited for modelling purposes.
-        Choices that deviate from 0 or 1 typically leverage Janak composition.
-        Unless the `initial` state is chosen, the model corresponds to a single electron being excited in physical reality.
-        """,
-    )
-    occupation = Quantity(
-        type=np.float64,
-        description="""
-        The total number of electrons within the state (as defined by degeneracy)
-        after exciting the model charge.
-        """,
-    )
-    dscf_state = Quantity(
-        type=MEnum("initial", "final"),
-        shape=[],
-        description="""
-        The $\\Delta$-SCF state tag, used to identify the role in the workflow of the same name.
-        Allowed values are `initial` (not to be confused with the _initial-state approximation_) and `final`.
-        """,
-    )
-
-    def __setattr__(self, name, value):
-        if name == "n_electrons_excited":
-            if value < 0.0:
-                raise ValueError("Number of excited electrons must be positive.")
-            if value > 1.0:
-                raise ValueError("Number of excited electrons must be less than 1.")
-        elif name == "dscf_state":
-            if value == "initial":
-                self.n_electrons_excited = 0.0
-                self.degeneracy = 1
-        super().__setattr__(name, value)
-
-    def set_occupation(self) -> float:
-        """Set the occupation based on the number of excited electrons."""
-        if not self.occupation:
-            try:
-                self.occupation = self.set_degeneracy() - self.n_electrons_excited
-            except TypeError:
-                raise AttributeError(
-                    "Cannot set occupation without `n_electrons_excited`."
-                )
-        return self.occupation
-
-    def normalize(self, archive, logger):
-        super().normalize(archive, logger)
-        # self.set_occupation()
-
-
-class HubbardInteractions(ArchiveSection):
-    """
-    A base section to define the Hubbard interactions of the system.
-
-    It inherits from `ArchiveSection`. It contains the local Hubbard interaction matrix $umn$,
-    the intraorbital Hubbard interaction $u$, the interorbital Hund's coupling $jh$, the interorbital
-    Coulomb interaction $up$, the exchange interaction $j$, and the effective U parameter $u_{eff}$.
-    It might also contain the Slater integrals (F0, F2, F4) used to derive the local Hubbard interactions.
-    """
-
-    orbital_ref = Quantity(
-        type=OrbitalState,
-        shape=["*"],
-        description="""
-        Reference to the OrbitalState sections that are used as a basis to obtain the Hubbard
-        interaction matrices.
-        """,
-    )
-
-    umn = Quantity(
-        type=np.float64,
-        shape=["*", "*"],
-        unit="joule",
-        description="""
-        Value of the local Hubbard interaction matrix. The order of the rows and columns coincide
-        with the elements in `orbital_ref`.
-        """,
-    )
-
-    u = Quantity(
-        type=np.float64,
-        unit="joule",
-        description="""
-        Value of the (intraorbital) Hubbard interaction
-        """,
-    )
-
-    jh = Quantity(
-        type=np.float64,
-        unit="joule",
-        description="""
-        Value of the (interorbital) Hund's coupling.
-        """,
-    )
-
-    up = Quantity(
-        type=np.float64,
-        unit="joule",
-        description="""
-        Value of the (interorbital) Coulomb interaction. In rotational invariant systems, up = u - 2 * jh.
-        """,
-    )
-
-    j = Quantity(
-        type=np.float64,
-        unit="joule",
-        description="""
-        Value of the exchange interaction. In rotational invariant systems, j = jh.
-        """,
-    )
-
-    u_effective = Quantity(
-        type=np.float64,
-        unit="joule",
-        description="""
-        Value of the effective U parameter (u - j).
-        """,
-    )
-
-    slater_integrals = Quantity(
-        type=np.float64,
-        shape=[3],
-        unit="joule",
-        description="""
-        Value of the Slater integrals (F0, F2, F4) in spherical harmonics used to derive
-        the local Hubbard interactions:
-
-            u = ((2.0 / 7.0) ** 2) * (F0 + 5.0 * F2 + 9.0 * F4) / (4.0*np.pi)
-
-            up = ((2.0 / 7.0) ** 2) * (F0 - 5.0 * F2 + 3.0 * 0.5 * F4) / (4.0*np.pi)
-
-            jh = ((2.0 / 7.0) ** 2) * (5.0 * F2 + 15.0 * 0.25 * F4) / (4.0*np.pi)
-
-        See e.g., Elbio Dagotto, Nanoscale Phase Separation and Colossal Magnetoresistance,
-        Chapter 4, Springer Berlin (2003).
-        """,
-    )
-
-    double_counting_correction = Quantity(
-        type=str,
-        description="""
-        Name of the double counting correction algorithm applied.
-        """,
-    )
-
-    def normalize(self, archive, logger):
-        super().normalize(archive, logger)
-
-
-class AtomicState(ArchiveSection):
-    """
-    A base section to define the atomic state information.
-
-    It inherits from `ArchiveSection`. It contains the chemical symbol, atomic number, index,
-    orbital states, charge, pseudopotential, core hole, and Hubbard interactions of the atom.
-    """
-
-    chemical_symbol = Quantity(
-        type=MEnum(ase.data.chemical_symbols[1:]),
-        description="""
-        Symbol of the element, e.g. 'H', 'Pb'. This quantity is equivalent to `atomic_numbers`.
-        """,
-    )
-
-    atomic_number = Quantity(
-        type=np.int32,
-        description="""
-        Atomic number Z. This quantity is equivalent to `chemical_symbol`.
-        """,
-    )
-
-    orbitals = SubSection(sub_section=OrbitalState.m_def, repeats=True)
-
-    charge = Quantity(
-        type=np.int32,
-        description="""
-        Charge of the atom. It is defined as the number of extra electrons or holes in the
-        atom. If the atom is neutral, charge = 0 and the summation of all (if available) the`OrbitalState.occupation`
-        coincides with the `atomic_number`. Otherwise, charge can be any positive integer (+1, +2...)
-        for cations or any negative integer (-1, -2...) for anions.
-
-        Note: for `CoreHole` systems we do not consider the charge of the atom even if
-        we do not store the final `OrbitalState` where the electron was excited to.
-        """,
-    )
-
-    pseudopotential = SubSection(sub_section=Pseudopotential.m_def, repeats=False)
-
-    core_hole = SubSection(sub_section=CoreHole.m_def, repeats=False)
-
-    hubbard_interactions = SubSection(
-        sub_section=HubbardInteractions.m_def, repeats=False
-    )
-
-    def normalize(self, archive, logger):
-        super().normalize(archive, logger)
-
-        # Get chemical_symbol from atomic_number and viceversa
-        if self.chemical_symbol is None and self.atomic_number is not None:
-            try:
-                self.chemical_symbol = ase.data.chemical_symbols[self.atomic_number]
-            except IndexError:
-                logger.error(
-                    "The `AtomicState.atomic_number` is out of range of the periodic table."
-                )
-                return
-        elif self.chemical_symbol is not None and self.atomic_number is None:
-            try:
-                self.atomic_number = ase.data.atomic_numbers[self.chemical_symbol]
-            except IndexError:
-                logger.error(
-                    "The `AtomicState.chemical_symbol` is not recognized in the periodic table."
-                )
-                return
 
 
 class GeometricSpace(Entity):
     """
     A base section to define geometrical space-related entities.
-
-    It inherits from `Entity`. It contains the length of the basis vectors, the angles between
-    the basis vectors, the volume, the surface area, the area, the length, the coordinate system,
-    the origin shift, and the transformation matrix of the space.
     """
 
     length_vector_a = Quantity(
@@ -577,7 +191,7 @@ class GeometricSpace(Entity):
         """,
     )
 
-    def get_geometric_space_for_atomic_cell(self, logger):
+    def get_geometric_space_for_atomic_cell(self, logger: BoundLogger):
         """
         Get the real space parameters for the atomic cell using ASE.
         """
@@ -601,10 +215,6 @@ class GeometricSpace(Entity):
 class Cell(GeometricSpace):
     """
     A base section used to specify the cell quantities of a system at a given moment in time.
-
-    It inherits from `GeometricSpace`. It contains the type, positions and velocities of the entities,
-    the lattice vectors, the reciprocal lattice vectors, the periodic boundary conditions, the
-    supercell matrix.
     """
 
     type = Quantity(
@@ -684,12 +294,9 @@ class Cell(GeometricSpace):
 class AtomicCell(Cell):
     """
     A base section used to specify the atomic cell information of a system.
-
-    It inherits from `Cell`. It contains the atoms information, the equivalent atoms, and the
-    Wyckoff letters of the atoms
     """
 
-    atomic_state = SubSection(sub_section=AtomicState.m_def, repeats=True)
+    atoms_state = SubSection(sub_section=AtomState.m_def, repeats=True)
 
     equivalent_atoms = Quantity(
         type=np.int32,
@@ -711,7 +318,7 @@ class AtomicCell(Cell):
         """,
     )
 
-    def to_ase_atoms(self, logger: BoundLogger) -> Union[ase.Atoms, None]:
+    def to_ase_atoms(self, logger: BoundLogger) -> Optional[ase.Atoms]:
         """
         Generates an ASE Atoms object with the most basic information from the parsed `AtomicCell`
         section (labels, periodic_boundary_conditions, positions, and lattice_vectors).
@@ -720,10 +327,10 @@ class AtomicCell(Cell):
             logger (BoundLogger): The logger to log messages.
 
         Returns:
-            Union[ase.Atoms, None]: The ASE Atoms object with the basic information from the `AtomicCell`.
+            (Optional[ase.Atoms]): The ASE Atoms object with the basic information from the `AtomicCell`.
         """
         # Initialize ase.Atoms object with labels
-        atoms_labels = [atom.chemical_symbol for atom in self.atomic_state]
+        atoms_labels = [atom_state.chemical_symbol for atom_state in self.atoms_state]
         ase_atoms = ase.Atoms(symbols=atoms_labels)
 
         # PBC
@@ -736,9 +343,9 @@ class AtomicCell(Cell):
 
         # Positions (ensure they are parsed)
         if self.positions is not None:
-            if len(self.positions) != len(self.atomic_state):
+            if len(self.positions) != len(self.atoms_state):
                 logger.error(
-                    "Length of `AtomicCell.positions` does not coincide with the length of the `AtomicCell.atomic_state`."
+                    "Length of `AtomicCell.positions` does not coincide with the length of the `AtomicCell.atoms_state`."
                 )
                 return None
             ase_atoms.set_positions(self.positions.to("angstrom").magnitude)
@@ -765,8 +372,6 @@ class AtomicCell(Cell):
 class Symmetry(ArchiveSection):
     """
     A base section used to specify the symmetry of the `AtomicCell`.
-
-    It inherits from `ArchiveSection`.
 
     Note: this information can be extracted via normalization using the MatID package, if `AtomicCell`
     is specified.
@@ -875,7 +480,7 @@ class Symmetry(ArchiveSection):
 
     def resolve_analyzed_atomic_cell(
         self, symmetry_analyzer: SymmetryAnalyzer, cell_type: str, logger: BoundLogger
-    ) -> Union[AtomicCell, None]:
+    ) -> Optional[AtomicCell]:
         """
         Resolves the `AtomicCell` section from the `SymmetryAnalyzer` object and the cell_type
         (primitive or conventional).
@@ -886,7 +491,7 @@ class Symmetry(ArchiveSection):
             logger (BoundLogger): The logger to log messages.
 
         Returns:
-            Union[AtomicCell, None]: The resolved `AtomicCell` section or None if the cell_type
+            (Optional[AtomicCell]): The resolved `AtomicCell` section or None if the cell_type
             is not recognized.
         """
         if cell_type not in ["primitive", "conventional"]:
@@ -908,10 +513,8 @@ class Symmetry(ArchiveSection):
         atomic_cell = AtomicCell(type=cell_type)
         atomic_cell.lattice_vectors = cell * ureg.angstrom
         for label, atomic_number in zip(labels, atomic_numbers):
-            atomic_state = AtomicState(
-                chemical_symbol=label, atomic_number=atomic_number
-            )
-            atomic_cell.m_add_sub_section(AtomicCell.atomic_state, atomic_state)
+            atom_state = AtomState(chemical_symbol=label, atomic_number=atomic_number)
+            atomic_cell.m_add_sub_section(AtomicCell.atoms_state, atom_state)
         atomic_cell.positions = (
             positions * ureg.angstrom
         )  # ? why do we need to pass units
@@ -922,7 +525,7 @@ class Symmetry(ArchiveSection):
 
     def resolve_bulk_symmetry(
         self, original_atomic_cell: AtomicCell, logger: BoundLogger
-    ) -> Tuple[Union[AtomicCell, None], Union[AtomicCell, None]]:
+    ) -> Tuple[Optional[AtomicCell], Optional[AtomicCell]]:
         """
         Resolves the symmetry of the material being simulated using MatID and the
         originally parsed data under original_atomic_cell. It generates two other
@@ -934,8 +537,8 @@ class Symmetry(ArchiveSection):
             uses to in MatID.SymmetryAnalyzer().
             logger (BoundLogger): The logger to log messages.
         Returns:
-            primitive_atomic_cell (AtomicCell): The primitive `AtomicCell` section.
-            conventional_atomic_cell (AtomicCell): The standarized `AtomicCell` section.
+            primitive_atomic_cell (Optional[AtomicCell]): The primitive `AtomicCell` section.
+            conventional_atomic_cell (Optional[AtomicCell]): The standarized `AtomicCell` section.
         """
         symmetry = {}
         try:
@@ -971,12 +574,12 @@ class Symmetry(ArchiveSection):
         original_atomic_cell.wyckoff_letters = original_wyckoff
         original_atomic_cell.equivalent_atoms = original_equivalent_atoms
 
-        # Populating the primitive AtomicState information
+        # Populating the primitive AtomState information
         primitive_atomic_cell = self.resolve_analyzed_atomic_cell(
             symmetry_analyzer, "primitive", logger
         )
 
-        # Populating the conventional AtomicState information
+        # Populating the conventional AtomState information
         conventional_atomic_cell = self.resolve_analyzed_atomic_cell(
             symmetry_analyzer, "conventional", logger
         )
@@ -985,12 +588,12 @@ class Symmetry(ArchiveSection):
         # standarized Wyckoff numbers and the space group number
         if (
             symmetry.get("space_group_number")
-            and conventional_atomic_cell.atomic_state is not None
+            and conventional_atomic_cell.atoms_state is not None
         ):
             # Resolve atomic_numbers and wyckoff letters from the conventional cell
             conventional_num = [
                 atom_state.atomic_number
-                for atom_state in conventional_atomic_cell.atomic_state
+                for atom_state in conventional_atomic_cell.atoms_state
             ]
             conventional_wyckoff = conventional_atomic_cell.wyckoff_letters
             # Normalize wyckoff letters
@@ -1001,8 +604,11 @@ class Symmetry(ArchiveSection):
                 symmetry.get("space_group_number"), norm_wyckoff
             )
             strukturbericht = aflow_prototype.get("Strukturbericht Designation")
-            if strukturbericht != "None":
-                strukturbericht = re.sub("[$_{}]", "", strukturbericht)
+            strukturbericht = (
+                re.sub("[$_{}]", "", strukturbericht)
+                if strukturbericht != "None"
+                else None
+            )
             prototype_aflow_id = aflow_prototype.get("aflow_prototype_id")
             prototype_formula = aflow_prototype.get("Prototype")
             # Adding these to the symmetry dictionary for later assignement
@@ -1095,7 +701,7 @@ class ChemicalFormula(ArchiveSection):
         """,
     )
 
-    def resolve_chemical_formulas(self, formula: Formula):
+    def resolve_chemical_formulas(self, formula: Formula) -> None:
         """
         Resolves the chemical formulas of the `ModelSystem` in different formats.
 
@@ -1129,6 +735,7 @@ class ChemicalFormula(ArchiveSection):
 
 
 class ModelSystem(System):
+    # ! Work in this description with new `AtomState`
     """
     Model system used as an input for the computation. It inherits from `System` where a set
     of sub-sections for the `elemental_composition` is defined.

--- a/simulationdataschema/model_system.py
+++ b/simulationdataschema/model_system.py
@@ -989,7 +989,7 @@ class ModelSystem(System):
             (
                 self.type,
                 self.dimensionality,
-            ) = self.resolve_system_type_and_dimensionality(ase_atoms)
+            ) = self.resolve_system_type_and_dimensionality(ase_atoms, logger)
             # Creating and normalizing Symmetry section
             if self.type == "bulk" and self.symmetry is not None:
                 sec_symmetry = self.m_create(Symmetry)

--- a/simulationdataschema/model_system.py
+++ b/simulationdataschema/model_system.py
@@ -895,7 +895,6 @@ class ModelSystem(System):
         """,
     )
 
-    # TODO add method to resolve labels and positions from the parent AtomicCell
     atom_indices = Quantity(
         type=np.int32,
         shape=["*"],

--- a/simulationdataschema/outputs.py
+++ b/simulationdataschema/outputs.py
@@ -47,6 +47,6 @@ class Outputs(ArchiveSection):
 
     normalizer_level = 2
 
-    def normalize(self, archive, logger):
+    def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
         self.logger = logger

--- a/simulationdataschema/utils/__init__.py
+++ b/simulationdataschema/utils/__init__.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import get_sibling_section
+from .utils import get_sibling_section, RussellSaundersState

--- a/simulationdataschema/utils/utils.py
+++ b/simulationdataschema/utils/utils.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+from math import factorial
 from typing import Optional
 from structlog.stdlib import BoundLogger
 
@@ -64,3 +65,46 @@ def get_sibling_section(
             return None
         return sibling_section[index_sibling]
     return sibling_section
+
+
+class RussellSaundersState:
+    @classmethod
+    def generate_Js(cls, J1: float, J2: float, rising=True):
+        J_min, J_max = sorted([abs(J1), abs(J2)])
+        generator = range(
+            int(J_max - J_min) + 1
+        )  # works for both for fermions and bosons
+        if rising:
+            for jj in generator:
+                yield J_min + jj
+        else:
+            for jj in generator:
+                yield J_max - jj
+
+    @classmethod
+    def generate_MJs(cls, J, rising=True):
+        generator = range(int(2 * J + 1))
+        if rising:
+            for m in generator:
+                yield -J + m
+        else:
+            for m in generator:
+                yield J - m
+
+    def __init__(self, *args, **kwargs):
+        self.J = kwargs.get("J")
+        if self.J is None:
+            raise TypeError
+        self.occupation = kwargs.get("occ")
+        if self.occupation is None:
+            raise TypeError
+
+    @property
+    def multiplicity(self):
+        return 2 * self.J + 1
+
+    @property
+    def degeneracy(self):
+        return factorial(self.multiplicity) / (
+            factorial(self.multiplicity - self.occupation) * factorial(self.occupation)
+        )

--- a/simulationdataschema/utils/utils.py
+++ b/simulationdataschema/utils/utils.py
@@ -67,6 +67,7 @@ def get_sibling_section(
     return sibling_section
 
 
+# ? Check if this utils deserves its own file after extending it
 class RussellSaundersState:
     @classmethod
     def generate_Js(cls, J1: float, J2: float, rising=True):


### PR DESCRIPTION
@JFRudzinski @ndaelman-hu please, review when you can this merge request.

I worked out a bit further on the `labels`, `atomic_numbers` and `Method.AtomParameters` ideas and came with the following schema. Just a few points to consider:

1. Now there is further abstraction by having a class `Cell`. This can be used to inherit other system cells, e.g., `CoarseGrainedCell` or `LatticeModelCell`, without the need of pasing real chemical elements information and normalization.
2. The concepts of `labels` and `atomic_numbers` have been moved under a new base class named `AtomsState`. This base class is a combination of these concepts together with the old schema for `AtomParameters`. Everything in this context appears then under `ModelSystem` from now on.
3. This new base class also contains: information about the orbital state, information about the atom charge (as a positive or negative integer, tho I am happy to hear feedback here in case this might be a float), information about CoreHole and HubbardInteractions.
4. The design idea is that `OrbitalsState` has the information of the relevant orbitals for each atom. This means that not all orbitals for an atom (i.e., 1s, 2px, 2py, etc.) need to be necessarily parsed, but rather the ones relevant for the use-case being treated. The example of use-cases could be `CoreHole` and `HubbardInteractions`.
5. For `HubbardInteractions`, now there is a list of `orbitals_ref` which then points to the specific orbitals used for the interactions. This means that `HubbardInteractions.umn` shape is defined by the length of these refs.
6. For `CoreHole`, I also added `orbital_ref`. It is now then a game of adding `n_excited_electrons` and checking the `orbital_ref.degeneracy` to resolve the occupation. Prior to this, `CoreHole` inherited from the state, but I think this is much more clean, as now `CoreHole` only contains info relevant for when creating a hole in a core orbital state.
7. I added `RussellSaundersState` under utils.py. I am still trying to debug and wrap my head around what are these methods using, but it shouldn't be too complicated. I would be ok too to move it to its own module, like you prefer.
8. I will deprecate the old method `MoleculeParameters`, but we can think if there are some use-cases how to implement it. It shouldn't be too complicated.
9. I am considering the old method `Pseudopotentials` to probably live under a `ModelMethod.BasisSet` class. But we (@ndaelman-hu and I) can discuss this a bit later. I am happy to hear more feedback tho.

I hope you like this. With this, I think ModelSystem is fully flexible, normalizations are properly ran, and I will continue working on the #3 `ModelMethod` schema.

_Edit_:
The corresponding [branch in Gitlab](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/commits/1728-full-refactoring-of-run-into-data), [electronic-parsers](https://github.com/nomad-coe/electronic-parsers/tree/test_basesections), and some [La2CuO4_test_basesections_Wannier90.zip](https://github.com/nomad-coe/nomad-schema-plugin-simulation-data/files/14331372/La2CuO4_test_basesections_Wannier90.zip).