### PR TITLE
Add ElectronicDOS and XASSpectra properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.pyenv
 env/
 venv/
 ENV/

--- a/src/nomad_simulations/atoms_state.py
+++ b/src/nomad_simulations/atoms_state.py
@@ -25,12 +25,13 @@ from nomad.units import ureg
 
 from nomad.metainfo import Quantity, SubSection, MEnum, Section, Context
 from nomad.datamodel.data import ArchiveSection
+from nomad.datamodel.metainfo.basesections import Entity
 from nomad.datamodel.metainfo.annotations import ELNAnnotation
 
 from .utils import RussellSaundersState
 
 
-class OrbitalsState(ArchiveSection):
+class OrbitalsState(Entity):
     """
     A base section used to define the orbital state of an atom.
     """
@@ -537,7 +538,7 @@ class HubbardInteractions(ArchiveSection):
                 )
 
 
-class AtomsState(ArchiveSection):
+class AtomsState(Entity):
     """
     A base section to define each atom state information.
     """

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -42,7 +42,7 @@ def resolve_output(section, section_instance):
     return quantity
 
 
-class Outputs(PhysicalProperty):
+class Outputs(ArchiveSection):
     """
     Output properties of a simulation. This base class can be used for inheritance in any of the output properties
     defined in this schema.
@@ -116,7 +116,7 @@ class Outputs(PhysicalProperty):
         return None
 
     def normalize(self, archive, logger) -> None:
-        # super().normalize(archive, logger)
+        super().normalize(archive, logger)
 
         # Set ref to the last ModelSystem if this is not set in the output
         if self.model_system_ref is None:

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -57,14 +57,6 @@ class Outputs(ArchiveSection):
         a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
-    custom_physical_property = SubSection(
-        sub_section=PhysicalProperty.m_def,
-        repeats=True,
-        description="""
-        A custom physical property used to store properties not yet covered by the NOMAD schema.
-        """,
-    )
-
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # List of properties
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -31,6 +31,18 @@ from .properties import (
 )
 
 
+def resolve_output(section, section_instance):
+    quantity = None
+    if section.m_parent is None:
+        return quantity
+    for output in section.m_parent.outputs:
+        if isinstance(output, section_instance):
+            quantity = output.value
+            if quantity is not None:
+                break
+    return quantity
+
+
 class Outputs(ArchiveSection):
     """
     Output properties of a simulation. This base class can be used for inheritance in any of the output properties

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -28,6 +28,10 @@ from .physical_property import PhysicalProperty
 from .numerical_settings import SelfConsistency
 from .properties import (
     ElectronicBandGap,
+    FermiLevel,
+    ChemicalPotential,
+    ElectronicDensityOfStates,
+    XASSpectra,
 )
 
 
@@ -66,6 +70,16 @@ class Outputs(ArchiveSection):
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
     electronic_band_gap = SubSection(sub_section=ElectronicBandGap.m_def, repeats=True)
+
+    fermi_level = SubSection(sub_section=FermiLevel.m_def, repeats=True)
+
+    chemical_potential = SubSection(sub_section=ChemicalPotential.m_def, repeats=True)
+
+    electronic_dos = SubSection(
+        sub_section=ElectronicDensityOfStates.m_def, repeats=True
+    )
+
+    xas_spectra = SubSection(sub_section=XASSpectra.m_def, repeats=True)
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -69,11 +69,11 @@ class Outputs(ArchiveSection):
     # List of properties
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-    electronic_band_gap = SubSection(sub_section=ElectronicBandGap.m_def, repeats=True)
-
     fermi_level = SubSection(sub_section=FermiLevel.m_def, repeats=True)
 
     chemical_potential = SubSection(sub_section=ChemicalPotential.m_def, repeats=True)
+
+    electronic_band_gap = SubSection(sub_section=ElectronicBandGap.m_def, repeats=True)
 
     electronic_dos = SubSection(
         sub_section=ElectronicDensityOfStates.m_def, repeats=True

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -22,7 +22,6 @@ from typing import Optional
 from nomad.datamodel.data import ArchiveSection
 from nomad.metainfo import Quantity, SubSection
 from nomad.datamodel.metainfo.annotations import ELNAnnotation
-
 from .model_system import ModelSystem
 from .physical_property import PhysicalProperty
 from .numerical_settings import SelfConsistency
@@ -43,7 +42,7 @@ def resolve_output(section, section_instance):
     return quantity
 
 
-class Outputs(ArchiveSection):
+class Outputs(PhysicalProperty):
     """
     Output properties of a simulation. This base class can be used for inheritance in any of the output properties
     defined in this schema.
@@ -117,7 +116,7 @@ class Outputs(ArchiveSection):
         return None
 
     def normalize(self, archive, logger) -> None:
-        super().normalize(archive, logger)
+        # super().normalize(archive, logger)
 
         # Set ref to the last ModelSystem if this is not set in the output
         if self.model_system_ref is None:

--- a/src/nomad_simulations/outputs.py
+++ b/src/nomad_simulations/outputs.py
@@ -22,24 +22,13 @@ from typing import Optional
 from nomad.datamodel.data import ArchiveSection
 from nomad.metainfo import Quantity, SubSection
 from nomad.datamodel.metainfo.annotations import ELNAnnotation
+
 from .model_system import ModelSystem
 from .physical_property import PhysicalProperty
 from .numerical_settings import SelfConsistency
 from .properties import (
     ElectronicBandGap,
 )
-
-
-def resolve_output(section, section_instance):
-    quantity = None
-    if section.m_parent is None:
-        return quantity
-    for output in section.m_parent.outputs:
-        if isinstance(output, section_instance):
-            quantity = output.value
-            if quantity is not None:
-                break
-    return quantity
 
 
 class Outputs(ArchiveSection):

--- a/src/nomad_simulations/physical_property.py
+++ b/src/nomad_simulations/physical_property.py
@@ -218,6 +218,7 @@ class PhysicalProperty(ArchiveSection):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
+        self.variables = []  # set default to empty list
         if self.iri is None:
             logger.warning(
                 'The used property is not defined in the FAIRmat taxonomy (https://fairmat-nfdi.github.io/fairmat-taxonomy/). You can contribute there if you want to extend the list of available materials properties.'

--- a/src/nomad_simulations/physical_property.py
+++ b/src/nomad_simulations/physical_property.py
@@ -51,6 +51,9 @@ class PhysicalProperty(ArchiveSection):
     string identifiers and quantities for referencing and establishing the character of a physical property.
     """
 
+    # TODO add `errors`
+    # TODO add `smearing`
+
     name = Quantity(
         type=str,
         description="""

--- a/src/nomad_simulations/physical_property.py
+++ b/src/nomad_simulations/physical_property.py
@@ -218,7 +218,6 @@ class PhysicalProperty(ArchiveSection):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
-        self.variables = []  # set default to empty list
         if self.iri is None:
             logger.warning(
                 'The used property is not defined in the FAIRmat taxonomy (https://fairmat-nfdi.github.io/fairmat-taxonomy/). You can contribute there if you want to extend the list of available materials properties.'

--- a/src/nomad_simulations/properties/__init__.py
+++ b/src/nomad_simulations/properties/__init__.py
@@ -17,3 +17,4 @@
 # limitations under the License.
 
 from .band_gap import ElectronicBandGap
+from .spectral_profile import SpectralProfile

--- a/src/nomad_simulations/properties/__init__.py
+++ b/src/nomad_simulations/properties/__init__.py
@@ -18,4 +18,9 @@
 
 from .energies import FermiLevel, ChemicalPotential
 from .band_gap import ElectronicBandGap
-from .spectral_profile import SpectralProfile, ElectronicDensityOfStates, XASSpectra
+from .spectral_profile import (
+    SpectralProfile,
+    DOSProfile,
+    ElectronicDensityOfStates,
+    XASSpectra,
+)

--- a/src/nomad_simulations/properties/__init__.py
+++ b/src/nomad_simulations/properties/__init__.py
@@ -16,5 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .energies import FermiLevel, ChemicalPotential
 from .band_gap import ElectronicBandGap
-from .spectral_profile import SpectralProfile
+from .spectral_profile import SpectralProfile, ElectronicDensityOfStates, XASSpectra

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -96,10 +96,7 @@ class ElectronicBandGap(PhysicalProperty):
 
         # Set the value to 0 when it is negative
         if (value < 0).any():
-            logger.warning('The electronic band gap cannot be defined negative.')
-            # return None
-            # value[value < 0] = None
-            # return value * self.value.u
+            logger.error('The electronic band gap cannot be defined negative.')
             return None
 
         if not isinstance(self.value.magnitude, np.ndarray):  # for scalars

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -67,7 +67,7 @@ class ElectronicBandGap(PhysicalProperty):
 
     value = Quantity(
         type=np.float64,
-        unit='joule',
+        unit='joule',  # ! this units need to be fixed when we have dynamical units
         description="""
         The value of the electronic band gap. This value has to be positive, otherwise it will
         prop an error and be set to None by the `normalize()` function.

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -31,6 +31,8 @@ class ElectronicBandGap(PhysicalProperty):
     Energy difference between the highest occupied electronic state and the lowest unoccupied electronic state.
     """
 
+    # ! implement `iri` and `rank` as part of `m_def = Section()`
+
     iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicBandGap'
 
     type = Quantity(

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -81,62 +81,6 @@ class ElectronicBandGap(PhysicalProperty):
         self.name = self.m_def.name
         self.rank = []
 
-    def check_negative_values(self, logger: BoundLogger) -> Optional[pint.Quantity]:
-        """
-        Checks if the electronic band gaps is negative and sets them to None if they are.
-
-        Args:
-            logger (BoundLogger): The logger to log messages.
-        """
-        value = self.value.magnitude
-        if not isinstance(self.value.magnitude, np.ndarray):  # for scalars
-            value = np.array(
-                [value]
-            )  # ! check this when talking with Lauri and Theodore
-
-        # Set the value to 0 when it is negative
-        if (value < 0).any():
-            logger.error('The electronic band gap cannot be defined negative.')
-            return None
-
-        if not isinstance(self.value.magnitude, np.ndarray):  # for scalars
-            value = value[0]
-        return value * self.value.u
-
-    def resolve_type(self, logger: BoundLogger) -> Optional[str]:
-        """
-        Resolves the `type` of the electronic band gap based on the stored `momentum_transfer` values.
-
-        Args:
-            logger (BoundLogger): The logger to log messages.
-
-        Returns:
-            (Optional[str]): The resolved `type` of the electronic band gap.
-        """
-        mtr = self.momentum_transfer if self.momentum_transfer is not None else []
-
-        # Check if the `momentum_transfer` is [], and return the type and a warning in the log for `indirect` band gaps
-        if len(mtr) == 0:
-            if self.type == 'indirect':
-                logger.warning(
-                    'The `momentum_transfer` is not stored for an `indirect` band gap.'
-                )
-            return self.type
-
-        # Check if the `momentum_transfer` has at least two elements, and return None if it does not
-        if len(mtr) == 1:
-            logger.warning(
-                'The `momentum_transfer` should have at least two elements so that the difference can be calculated and the type of electronic band gap can be resolved.'
-            )
-            return None
-
-        # Resolve `type` from the difference between the initial and final momentum transfer
-        momentum_difference = np.diff(mtr, axis=0)
-        if (np.isclose(momentum_difference, np.zeros(3))).all():
-            return 'direct'
-        else:
-            return 'indirect'
-
     def _check_negative_values(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """
         Checks if the electronic band gaps is negative and sets them to None if they are.

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -67,7 +67,7 @@ class ElectronicBandGap(PhysicalProperty):
 
     value = Quantity(
         type=np.float64,
-        unit='joule',  # ! this units need to be fixed when we have dynamical units
+        unit='joule',
         description="""
         The value of the electronic band gap. This value has to be positive, otherwise it will
         prop an error and be set to None by the `normalize()` function.

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -21,7 +21,6 @@ from structlog.stdlib import BoundLogger
 import pint
 from typing import Optional
 
-from nomad.units import ureg
 from nomad.metainfo import Quantity, MEnum, Section, Context
 
 from ..physical_property import PhysicalProperty
@@ -68,7 +67,7 @@ class ElectronicBandGap(PhysicalProperty):
 
     value = Quantity(
         type=np.float64,
-        unit='joule',
+        unit='joule',  # ! this units need to be fixed when we have dynamical units
         description="""
         The value of the electronic band gap. This value has to be positive, otherwise it will
         prop an error and be set to None by the `normalize()` function.
@@ -91,7 +90,9 @@ class ElectronicBandGap(PhysicalProperty):
         """
         value = self.value.magnitude
         if not isinstance(self.value.magnitude, np.ndarray):  # for scalars
-            value = np.array([value])
+            value = np.array(
+                [value]
+            )  # ! check this when talking with Lauri and Theodore
 
         # Set the value to 0 when it is negative
         if (value < 0).any():

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -67,7 +67,7 @@ class ElectronicBandGap(PhysicalProperty):
 
     value = Quantity(
         type=np.float64,
-        unit='joule',  # ! this units need to be fixed when we have dynamical units
+        unit='joule',
         description="""
         The value of the electronic band gap. This value has to be positive, otherwise it will
         prop an error and be set to None by the `normalize()` function.
@@ -81,9 +81,9 @@ class ElectronicBandGap(PhysicalProperty):
         self.name = self.m_def.name
         self.rank = []  # ? Is this here or in the attrs instantiation better?
 
-    def check_negative_values(self, logger: BoundLogger) -> pint.Quantity:
+    def check_negative_values(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """
-        Checks if the electronic band gaps is negative and sets them to 0 if they are.
+        Checks if the electronic band gaps is negative and sets them to None if they are.
 
         Args:
             logger (BoundLogger): The logger to log messages.
@@ -96,10 +96,11 @@ class ElectronicBandGap(PhysicalProperty):
 
         # Set the value to 0 when it is negative
         if (value < 0).any():
-            logger.warning(
-                'The electronic band gap cannot be defined negative. We set them up to 0.'
-            )
-        value[value < 0] = 0
+            logger.warning('The electronic band gap cannot be defined negative.')
+            # return None
+            # value[value < 0] = None
+            # return value * self.value.u
+            return None
 
         if not isinstance(self.value.magnitude, np.ndarray):  # for scalars
             value = value[0]

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -79,7 +79,7 @@ class ElectronicBandGap(PhysicalProperty):
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
-        self.rank = []  # ? Is this here or in the attrs instantiation better?
+        self.rank = []
 
     def check_negative_values(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -28,11 +28,11 @@ class FermiLevel(PhysicalProperty):
     Energy required to add or extract a charge from a material at zero temperature. It can be also defined as the chemical potential at zero temperature.
     """
 
-    iri = 'https://fairmat-nfdi.github.io/fairmat-taxonomy/FermiLevel'
+    iri = 'http://fairmat-nfdi.eu/taxonomy/FermiLevel'
 
     value = Quantity(
         type=np.float64,
-        unit='joule',  # ! this units need to be fixed when we have dynamical units
+        unit='joule',
         description="""
         Value of the Fermi level.
         """,
@@ -51,11 +51,11 @@ class ChemicalPotential(PhysicalProperty):
     Free energy cost of adding or extracting a particle from a thermodynamic system.
     """
 
-    iri = 'https://fairmat-nfdi.github.io/fairmat-taxonomy/ChemicalPotential'
+    iri = 'http://fairmat-nfdi.eu/taxonomy/ChemicalPotential'
 
     value = Quantity(
         type=np.float64,
-        unit='joule',  # ! this units need to be fixed when we have dynamical units
+        unit='joule',
         description="""
         Value of the chemical potential.
         """,

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -34,13 +34,13 @@ class FermiLevel(PhysicalProperty):
         type=np.float64,
         unit='joule',
         description="""
-        Value of the Fermi level.
+        The value of the Fermi level.
         """,
     )
 
     def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
         super().__init__(m_def, m_context, **kwargs)
-        self.rank = []  # ? Is this here or in the attrs instantiation better?
+        self.rank = []
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
@@ -57,13 +57,13 @@ class ChemicalPotential(PhysicalProperty):
         type=np.float64,
         unit='joule',
         description="""
-        Value of the chemical potential.
+        The value of the chemical potential.
         """,
     )
 
     def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
         super().__init__(m_def, m_context, **kwargs)
-        self.rank = []  # ? Is this here or in the attrs instantiation better?
+        self.rank = []
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -1,0 +1,69 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+from nomad.metainfo import Quantity, Section, Context
+
+from ..physical_property import PhysicalProperty
+
+
+class FermiLevel(PhysicalProperty):
+    """
+    Energy required to add or extract a charge from a material at zero temperature. It can be also defined as the chemical potential at zero temperature.
+    """
+
+    iri = 'https://fairmat-nfdi.github.io/fairmat-taxonomy/FermiLevel'
+
+    value = Quantity(
+        type=np.float64,
+        unit='joule',  # ! this units need to be fixed when we have dynamical units
+        description="""
+        Value of the Fermi level.
+        """,
+    )
+
+    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+        super().__init__(m_def, m_context, **kwargs)
+        self.rank = []  # ? Is this here or in the attrs instantiation better?
+
+    def normalize(self, archive, logger) -> None:
+        super().normalize(archive, logger)
+
+
+class ChemicalPotential(PhysicalProperty):
+    """
+    Free energy cost of adding or extracting a particle from a thermodynamic system.
+    """
+
+    iri = 'https://fairmat-nfdi.github.io/fairmat-taxonomy/ChemicalPotential'
+
+    value = Quantity(
+        type=np.float64,
+        unit='joule',  # ! this units need to be fixed when we have dynamical units
+        description="""
+        Value of the chemical potential.
+        """,
+    )
+
+    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+        super().__init__(m_def, m_context, **kwargs)
+        self.rank = []  # ? Is this here or in the attrs instantiation better?
+
+    def normalize(self, archive, logger) -> None:
+        super().normalize(archive, logger)

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -43,6 +43,7 @@ class FermiLevel(PhysicalProperty):
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.rank = []
+        self.name = self.m_def.name
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
@@ -68,6 +69,7 @@ class ChemicalPotential(PhysicalProperty):
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.rank = []
+        self.name = self.m_def.name
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -38,7 +38,9 @@ class FermiLevel(PhysicalProperty):
         """,
     )
 
-    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+    def __init__(
+        self, m_def: Section = None, m_context: Context = None, **kwargs
+    ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.rank = []
 
@@ -61,7 +63,9 @@ class ChemicalPotential(PhysicalProperty):
         """,
     )
 
-    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+    def __init__(
+        self, m_def: Section = None, m_context: Context = None, **kwargs
+    ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.rank = []
 

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -28,6 +28,8 @@ class FermiLevel(PhysicalProperty):
     Energy required to add or extract a charge from a material at zero temperature. It can be also defined as the chemical potential at zero temperature.
     """
 
+    # ! implement `iri` and `rank` as part of `m_def = Section()`
+
     iri = 'http://fairmat-nfdi.eu/taxonomy/FermiLevel'
 
     value = Quantity(
@@ -53,6 +55,8 @@ class ChemicalPotential(PhysicalProperty):
     """
     Free energy cost of adding or extracting a particle from a thermodynamic system.
     """
+
+    # ! implement `iri` and `rank` as part of `m_def = Section()`
 
     iri = 'http://fairmat-nfdi.eu/taxonomy/ChemicalPotential'
 

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -187,8 +187,12 @@ class ElectronicDensityOfStates(SpectralProfile):
             (bool): True if the simulation is spin-polarized, False otherwise.
         """
         # TODO use this in `ElectronicBandGap` too
+        outputs = self.m_parent
+        if outputs is None:
+            logger.warning('Could not resolve the parent `Outputs`.')
+            return False
         model_method = get_sibling_section(
-            section=self, sibling_section_name='model_method', logger=logger
+            section=outputs, sibling_section_name='model_method', logger=logger
         )
         return (
             True
@@ -411,6 +415,8 @@ class ElectronicDensityOfStates(SpectralProfile):
             else:
                 band_gap.value = homo - lumo
         return band_gap
+
+    # TODO add extraction from `projected_dos`
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -41,7 +41,7 @@ class SpectralProfile(PhysicalProperty):
         description="""
         The value of the intensities of a spectral profile in arbitrary units.
         """,
-    )
+    )  # TODO check units and normalization_factor of DOS and Spectras and see whether they can be merged
 
     def __init__(
         self, m_def: Section = None, m_context: Context = None, **kwargs
@@ -174,7 +174,7 @@ class ElectronicDensityOfStates(DOSProfile):
         """,
     )
 
-    # ? Do we want to store the integrated value here os as part of an nomad-analysis tool?
+    # ? Do we want to store the integrated value here os as part of an nomad-analysis tool? Check `dos_integrator.py` module in dos normalizer repository
     # value_integrated = Quantity(
     #     type=np.float64,
     #     description="""

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -137,12 +137,13 @@ class ElectronicDensityOfStates(SpectralProfile):
         """,
     )
 
-    value_integrated = Quantity(
-        type=np.float64,
-        description="""
-        The cumulative intensities integrated from from the lowest (most negative) energy to the `fermi_level`.
-        """,
-    )
+    # ? Do we want to store the integrated value here os as part of an nomad-analysis tool?
+    # value_integrated = Quantity(
+    #     type=np.float64,
+    #     description="""
+    #     The cumulative intensities integrated from from the lowest (most negative) energy to the `fermi_level`.
+    #     """,
+    # )
 
     projected_dos = SubSection(
         sub_section=SpectralProfile.m_def,

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -34,7 +34,7 @@ from nomad.metainfo import (
 
 from ..utils import get_sibling_section
 from ..physical_property import PhysicalProperty
-from ..variables import Energy
+from ..variables import Energy2 as Energy
 from .band_gap import ElectronicBandGap
 
 

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -55,7 +55,9 @@ class SpectralProfile(PhysicalProperty):
     #     """,
     # )
 
-    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+    def __init__(
+        self, m_def: Section = None, m_context: Context = None, **kwargs
+    ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.rank = []  # ? Is this here or in the attrs instantiation better?
 
@@ -138,7 +140,9 @@ class ElectronicDensityOfStates(SpectralProfile):
         """,
     )
 
-    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+    def __init__(
+        self, m_def: Section = None, m_context: Context = None, **kwargs
+    ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
@@ -152,7 +156,7 @@ class ElectronicDensityOfStates(SpectralProfile):
         fermi_level = self.fermi_level
         # if fermi_level is None:
         #     fermi_level = resolve_output_value(self, FermiLevel)
-        # return fermi_level
+        return fermi_level
 
     def check_spin_polarized(self) -> bool:
         """
@@ -224,7 +228,9 @@ class XASSpectra(SpectralProfile):
         repeats=False,
     )
 
-    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+    def __init__(
+        self, m_def: Section = None, m_context: Context = None, **kwargs
+    ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         # Set the name of the section
         self.name = self.m_def.name

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -21,6 +21,7 @@ from structlog.stdlib import BoundLogger
 from typing import Optional
 import pint
 
+from nomad import config
 from nomad.units import ureg
 from nomad.metainfo import (
     Quantity,
@@ -31,7 +32,10 @@ from nomad.metainfo import (
     JSON,
 )
 
+from ..utils import get_sibling_section
 from ..physical_property import PhysicalProperty
+from ..variables import Energy
+from .band_gap import ElectronicBandGap
 
 
 class SpectralProfile(PhysicalProperty):
@@ -42,11 +46,11 @@ class SpectralProfile(PhysicalProperty):
     value = Quantity(
         type=np.float64,
         description="""
-        Value of the intensities of a spectral profile in arbitrary units.
+        The value of the intensities of a spectral profile in arbitrary units.
         """,
     )
 
-    # TODO implement this in PhysicalProperty (similar to shape)
+    # TODO implement this in PhysicalProperty (similar to `value.shape`)
     # value_units = Quantity(
     #     type=str,
     #     description="""
@@ -92,8 +96,7 @@ class ElectronicDensityOfStates(SpectralProfile):
     spin_channel = Quantity(
         type=np.int32,
         description="""
-        Spin channel of the corresponding DOS. It can take values of 0 or 1. This quantity is set only if
-        `ModelMethod.is_spin_polarized` is `True`.
+        Spin channel of the corresponding electronic DOS. It can take values of 0 or 1.
         """,
     )
 
@@ -103,10 +106,17 @@ class ElectronicDensityOfStates(SpectralProfile):
         description="""
         The Fermi level is the highest occupied energy level at zero temperature. For insulators and semiconductors,
         some codes have some difficulty in determining the Fermi level, and it is often set to the middle of the band gap,
-        at the top of the valence band, or even in the bottom of the conduction band.
+        at the top of the valence band, or even in the bottom of the conduction band. This quantity is extracted
+        from `FermiLevel.value` property.
+        """,
+    )
 
-        We set the `energies_origin` to the top of the valence band, thus, `energies_origin` and `fermi_level` might
-        not coincide.
+    energies_origin = Quantity(
+        type=np.float64,
+        unit='joule',
+        description="""
+        Energy level denoting the origin along the energy axis, used for comparison and visualization. It is
+        defined as the `ElectronicEigenvalues.highest_occupied` and does not necessarily coincide with `fermi_level`.
         """,
     )
 
@@ -116,6 +126,14 @@ class ElectronicDensityOfStates(SpectralProfile):
         Normalization factor for electronic DOS to get a cell-independent intensive DOS. The cell-independent
         intensive DOS is as the integral from the lowest (most negative) energy to the `fermi_level` for a neutrally
         charged system (i.e., the sum of `AtomsState.charge` is zero).
+        """,
+    )
+
+    value = Quantity(
+        type=np.float64,
+        unit='1/joule',
+        description="""
+        The value of the electronic DOS.
         """,
     )
 
@@ -146,65 +164,243 @@ class ElectronicDensityOfStates(SpectralProfile):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def resolve_fermi_level(self) -> Optional[np.float64]:
+    def _check_energy_variables(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """
-        Resolve the Fermi level from the output `FermiLevel` section, if present.
+        Check if the required `Energy` variable is present in the `variables`. If so, it returns
+        the grid points of the `Energy` variable.
+
+        Args:
+            logger (BoundLogger): The logger to log messages.
 
         Returns:
-            (Optional[np.float64]): The resolved Fermi level.
+            (Optional[pint.Quantity]): The grid points of the `Energy` variable.
         """
-        fermi_level = self.fermi_level
-        # if fermi_level is None:
-        #     fermi_level = resolve_output_value(self, FermiLevel)
-        return fermi_level
+        for var in self.variables:
+            if isinstance(var, Energy):
+                return var.grid_points
+        logger.error(
+            'The required `Energy` variable is not present in the `variables`.'
+        )
+        return None
 
-    def check_spin_polarized(self) -> bool:
+    def _check_spin_polarized(self, logger: BoundLogger) -> bool:
         """
         Check if the simulation `is_spin_polarized`.
+
+        Args:
+            logger (BoundLogger): The logger to log messages.
 
         Returns:
             (bool): True if the simulation is spin-polarized, False otherwise.
         """
-        if self.m_parent is not None:
-            for method in self.m_parent.model_method:
-                if method.is_spin_polarized:
-                    return True
-        return False
+        # TODO use this in `ElectronicBandGap` too
+        model_method = get_sibling_section(
+            section=self, sibling_section_name='model_method', logger=logger
+        )
+        return (
+            True
+            if model_method is not None and model_method.is_spin_polarized
+            else False
+        )
 
-    def resolve_energies_origin(self) -> Optional[pint.Quantity]:
+    def resolve_fermi_level(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """
-        Resolve the origin of reference for the energies from the `Eigenvalues` output property, or if this does not exist,
-        from the `FermiLevel` output property.
+        Resolve the Fermi level from a sibling `FermiLevel` section, if present.
+
+        Args:
+            logger (BoundLogger): The logger to log messages.
+
+        Returns:
+            (Optional[pint.Quantity]): The resolved Fermi level.
+        """
+        fermi_level_value = None
+        if self.fermi_level is None:
+            fermi_level = get_sibling_section(
+                section=self, sibling_section_name='fermi_level', logger=logger
+            )  # we consider `index_sibling` to be 0
+            if fermi_level is not None:
+                fermi_level_value = fermi_level.value
+        return fermi_level_value
+
+    def resolve_energies_origin(
+        self,
+        energies: pint.Quantity,
+        fermi_level: Optional[pint.Quantity],
+        logger: BoundLogger,
+    ) -> Optional[pint.Quantity]:
+        """
+        Resolve the origin of reference for the energies from the sibling `ElectronicEigenvalues` section and its
+        `highest_occupied` level, or if this does not exist, from the `fermi_level` value as extracted from `resolve_fermi_level()`.
+
+        Args:
+            fermi_level (Optional[pint.Quantity]): The resolved Fermi level.
+            energies (pint.Quantity): The grid points of the `Energy` variable.
+            logger (BoundLogger): The logger to log messages.
 
         Returns:
             (Optional[pint.Quantity]): The resolved origin of reference for the energies.
         """
-        energies_origin = self.energies_origin
-        # ! We need schema for `Eigenvalues` to store `highest_occupied` and `lowest_occupied` to use in `ElectronicBandGap` and `ElectronicDOS`
-        # if energies_origin is None:
-        #     fermi_level = self.resolve_fermi_level()
-        #     if fermi_level is not None:
-        #         energies_origin = fermi_level
-        #     else:
-        #         eigenvalues = resolve_output_value(self, Eigenvalues)
-        #         if eigenvalues is not None:
-        #             energies_origin = eigenvalues.highest_occupied
+        # ! We need schema for `ElectronicEigenvalues` to store `highest_occupied` and `lowest_occupied`
+
+        # Check if the variables contain more than one variable (different than Energy)
+        # ? Is this correct or should be use the index of energies to extract the proper shape element in `self.value` being used for `dos_values`?
+        if len(self.variables) > 1:
+            logger.warning(
+                'The ElectronicDensityOfStates section contains more than one variable. We cannot extract the energy reference.'
+            )
+            return None
+
+        # Extract the `ElectronicEigenvalues` section to get the `highest_occupied` and `lowest_occupied` energies
+        # TODO implement once `ElectronicEigenvalues` is in the schema
+        eigenvalues = get_sibling_section(
+            section=self, sibling_section_name='electronic_eigenvalues', logger=logger
+        )  # we consider `index_sibling` to be 0
+        highest_occupied_energy = (
+            eigenvalues.highest_occupied if eigenvalues is not None else None
+        )
+        lowest_occupied_energy = (
+            eigenvalues.lowest_occupied if eigenvalues is not None else None
+        )
+        # and set defaults for `highest_occupied_energy` and `lowest_occupied_energy` in `m_cache`
+        if highest_occupied_energy is not None:
+            self.m_cache['highest_occupied_energy'] = highest_occupied_energy
+        if lowest_occupied_energy is not None:
+            self.m_cache['lowest_occupied_energy'] = lowest_occupied_energy
+
+        # Set thresholds for the energies and values
+        energy_threshold = config.normalize.band_structure_energy_tolerance
+        value_threshold = 1e-8  # The DOS value that is considered to be zero
+
+        # Check that the closest `energies` to the energy reference is not too far away.
+        # If it is very far away, normalization may be very inaccurate and we do not report it.
+        dos_values = self.value.magnitude
+        eref = highest_occupied_energy if fermi_level is None else fermi_level
+        fermi_idx = (np.abs(energies - eref)).argmin()
+        fermi_energy_closest = energies[fermi_idx]
+        distance = np.abs(fermi_energy_closest - eref)
+        single_peak_fermi = False
+        if distance.magnitude <= energy_threshold:
+            # See if there are zero values close below the energy reference.
+            idx = fermi_idx
+            idx_descend = fermi_idx
+            while True:
+                try:
+                    value = dos_values[idx]
+                    energy_distance = np.abs(eref - energies[idx])
+                except IndexError:
+                    break
+                if energy_distance.magnitude > energy_threshold:
+                    break
+                if value <= value_threshold:
+                    idx_descend = idx
+                    break
+                idx -= 1
+
+            # See if there are zero values close above the fermi energy.
+            idx = fermi_idx
+            idx_ascend = fermi_idx
+            while True:
+                try:
+                    value = dos_values[idx]
+                    energy_distance = np.abs(eref - energies[idx])
+                except IndexError:
+                    break
+                if energy_distance.magnitude > energy_threshold:
+                    break
+                if value <= value_threshold:
+                    idx_ascend = idx
+                    break
+                idx += 1
+
+            # If there is a single peak at fermi energy, no
+            # search needs to be performed.
+            if idx_ascend != fermi_idx and idx_descend != fermi_idx:
+                self.m_cache['highest_occupied_energy'] = fermi_energy_closest
+                self.m_cache['lowest_occupied_energy'] = fermi_energy_closest
+                single_peak_fermi = True
+
+            if not single_peak_fermi:
+                # Look for highest occupied energy below the descend index
+                idx = idx_descend
+                while True:
+                    try:
+                        value = dos_values[idx]
+                    except IndexError:
+                        break
+                    if value > value_threshold:
+                        idx = idx if idx == idx_descend else idx + 1
+                        self.m_cache['highest_occupied_energy'] = energies[idx]
+                        break
+                    idx -= 1
+                # Look for lowest unoccupied energy above idx_ascend
+                idx = idx_ascend
+                while True:
+                    try:
+                        value = dos_values[idx]
+                    except IndexError:
+                        break
+                    if value > value_threshold:
+                        idx = idx if idx == idx_ascend else idx - 1
+                        self.m_cache['highest_occupied_energy'] = energies[idx]
+                        break
+                    idx += 1
+
+        # Return the `highest_occupied_energy` as the `energies_origin`, or the `fermi_level` if it is not None
+        energies_origin = self.m_cache.get('highest_occupied_energy')
+        if energies_origin is None:
+            energies_origin = fermi_level
         return energies_origin
+
+    def extract_band_gap(self) -> Optional[ElectronicBandGap]:
+        """
+        Extract the electronic band gap from the `highest_occupied_energy` and `lowest_occupied_energy` stored
+        in `m_cache` from `resolve_energies_origin()`. If the difference of `highest_occupied_energy` and
+        `lowest_occupied_energy` is negative, the band gap `value` is set to 0.0.
+
+        Returns:
+            (Optional[ElectronicBandGap]): The extracted electronic band gap section to be stored in `Outputs`.
+        """
+        band_gap = None
+        homo = self.m_cache.get('highest_occupied_energy')
+        lumo = self.m_cache.get('lowest_occupied_energy')
+        if homo and lumo:
+            band_gap = ElectronicBandGap()
+            band_gap.is_derived = True
+            band_gap.physical_property_ref = self
+
+            if (homo - lumo).magnitude < 0:
+                band_gap.value = 0.0
+            else:
+                band_gap.value = homo - lumo
+        return band_gap
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 
-        # Resolve `fermi_level`
-        self.fermi_level = self.resolve_fermi_level()
+        # Initial check to see if `variables` contains the required `Energy` variable
+        energies = self._check_energy_variables(logger)
+        if energies is None:
+            return
 
         # Check if `is_spin_polarized` but `spin_channel` is not set
-        if self.check_spin_polarized() and self.spin_channel is None:
+        if self._check_spin_polarized(logger) and self.spin_channel is None:
             logger.warning(
                 'Spin-polarized calculation detected but the `spin_channel` is not set.'
             )
 
-        # Resolve `energies_origin`
-        self.energies_origin = self.resolve_energies_origin()
+        # Resolve `fermi_level` from a sibling section with respect to `ElectronicDensityOfStates`
+        self.fermi_level = self.resolve_fermi_level(logger)
+        # and the `energies_origin` from the sibling `ElectronicEigenvalues` section
+        self.energies_origin = self.resolve_energies_origin(
+            energies, self.fermi_level, logger
+        )
+        if self.energies_origin is None:
+            logger.info('Could not resolve the `energies_origin` for the DOS')
+
+        # `ElectronicBandGap` extraction
+        band_gap = self.extract_band_gap()
+        if band_gap is not None:
+            self.m_parent.electronic_band_gap.append(band_gap)
 
 
 class XASSpectra(SpectralProfile):

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -177,16 +177,15 @@ class ElectronicDensityOfStates(DOSProfile):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def _check_energy_variables(self, logger: BoundLogger) -> Optional[pint.Quantity]:
+    def _get_energy_points(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """
-        Check if the required `Energy` variable is present in the `variables`. If so, it returns
-        the grid points of the `Energy` variable.
+        Gets the `grid_points` of the `Energy` variable if the required `Energy` variable is present in the `variables`.
 
         Args:
             logger (BoundLogger): The logger to log messages.
 
         Returns:
-            (Optional[pint.Quantity]): The grid points of the `Energy` variable.
+            (Optional[pint.Quantity]): The `grid_points` of the `Energy` variable.
         """
         for var in self.variables:
             if isinstance(var, Energy):
@@ -501,7 +500,7 @@ class ElectronicDensityOfStates(DOSProfile):
         super().normalize(archive, logger)
 
         # Initial check to see if `variables` contains the required `Energy` variable
-        energies = self._check_energy_variables(logger)
+        energies = self._get_energy_points(logger)
         if energies is None:
             return
 
@@ -559,7 +558,6 @@ class XASSpectra(SpectralProfile):
         # Set the name of the section
         self.name = self.m_def.name
 
-    # ? Maybe this method (and the one for ElectronicDensityOfStates.generate_from_projected_dos) should be moved to `PhysicalProperty`?
     def generate_from_contributions(self, logger: BoundLogger) -> None:
         """
         Generate the `value` of the XAS spectra by concatenating the XANES and EXAFS contributions. It also concatenates
@@ -568,6 +566,7 @@ class XASSpectra(SpectralProfile):
         Args:
             logger (BoundLogger): The logger to log messages.
         """
+        # TODO check if this method is general enough
         if self.xanes_spectra is not None or self.exafs_spectra is not None:
             # Concatenate XANE and EXAFS `Energy` grid points
             for var in self.xanes_spectra.variables:

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -110,6 +110,7 @@ class ElectronicDensityOfStates(DOSProfile):
     Number of electronic states accessible for the charges per energy and per volume.
     """
 
+    # ! implement `iri` and `rank` as part of `m_def = Section()`
     iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'
 
     spin_channel = Quantity(
@@ -119,23 +120,13 @@ class ElectronicDensityOfStates(DOSProfile):
         """,
     )
 
-    fermi_level = Quantity(
-        type=np.float64,
-        unit='joule',
-        description="""
-        The Fermi level is the highest occupied energy level at zero temperature. For insulators and semiconductors,
-        some codes have some difficulty in determining the Fermi level, and it is often set to the middle of the band gap,
-        at the top of the valence band, or even in the bottom of the conduction band. This quantity is extracted
-        from `FermiLevel.value` property.
-        """,
-    )
-
+    # TODO clarify the role of `energies_origin` once `ElectronicEigenvalues` is implemented
     energies_origin = Quantity(
         type=np.float64,
         unit='joule',
         description="""
         Energy level denoting the origin along the energy axis, used for comparison and visualization. It is
-        defined as the `ElectronicEigenvalues.highest_occupied_energy` and does not necessarily coincide with `fermi_level`.
+        defined as the `ElectronicEigenvalues.highest_occupied_energy`.
         """,
     )
 
@@ -143,7 +134,7 @@ class ElectronicDensityOfStates(DOSProfile):
         type=np.float64,
         description="""
         Normalization factor for electronic DOS to get a cell-independent intensive DOS. The cell-independent
-        intensive DOS is as the integral from the lowest (most negative) energy to the `fermi_level` for a neutrally
+        intensive DOS is as the integral from the lowest (most negative) energy to the Fermi level for a neutrally
         charged system (i.e., the sum of `AtomsState.charge` is zero).
         """,
     )
@@ -152,7 +143,7 @@ class ElectronicDensityOfStates(DOSProfile):
     # value_integrated = Quantity(
     #     type=np.float64,
     #     description="""
-    #     The cumulative intensities integrated from from the lowest (most negative) energy to the `fermi_level`.
+    #     The cumulative intensities integrated from from the lowest (most negative) energy to the Fermi level.
     #     """,
     # )
 
@@ -161,8 +152,9 @@ class ElectronicDensityOfStates(DOSProfile):
         repeats=True,
         description="""
         Projected DOS. It can be atom- (different elements in the unit cell) or orbital-projected. These can be calculated in a cascade as:
-            - If the total DOS is not present, we can sum all atom-projected DOS to obtain it.
-            - If the atom-projected DOS is not present, we can sum all orbital-projected DOS to obtain it.
+            - If the total DOS is not present, we sum all atom-projected DOS to obtain it.
+            - If the atom-projected DOS is not present, we sum all orbital-projected DOS to obtain it.
+        Note: the cover given by summing up contributions is not perfect, and will depend on the projection functions used.
 
         In `projected_dos`, `name` and `entity_ref` must be set in order for normalization to work:
             - The `entity_ref` is the `OrbitalsState` or `AtomsState` sections.
@@ -196,25 +188,6 @@ class ElectronicDensityOfStates(DOSProfile):
         )
         return None
 
-    def resolve_fermi_level(self, logger: BoundLogger) -> Optional[pint.Quantity]:
-        """
-        Resolve the Fermi level from a sibling `FermiLevel` section, if present.
-
-        Args:
-            logger (BoundLogger): The logger to log messages.
-
-        Returns:
-            (Optional[pint.Quantity]): The resolved Fermi level.
-        """
-        fermi_level_value = self.fermi_level
-        if fermi_level_value is None:
-            fermi_level = get_sibling_section(
-                section=self, sibling_section_name='fermi_level', logger=logger
-            )  # we consider `index_sibling` to be 0
-            if fermi_level is not None:
-                fermi_level_value = fermi_level.value
-        return fermi_level_value
-
     def resolve_energies_origin(
         self,
         energies: pint.Quantity,
@@ -223,7 +196,7 @@ class ElectronicDensityOfStates(DOSProfile):
     ) -> Optional[pint.Quantity]:
         """
         Resolve the origin of reference for the energies from the sibling `ElectronicEigenvalues` section and its
-        `highest_occupied` level, or if this does not exist, from the `fermi_level` value as extracted from `resolve_fermi_level()`.
+        `highest_occupied` level, or if this does not exist, from the `fermi_level` value as extracted from the sibling property, `FermiLevel`.
 
         Args:
             fermi_level (Optional[pint.Quantity]): The resolved Fermi level.
@@ -234,6 +207,7 @@ class ElectronicDensityOfStates(DOSProfile):
             (Optional[pint.Quantity]): The resolved origin of reference for the energies.
         """
         # ! We need schema for `ElectronicEigenvalues` to store `highest_occupied` and `lowest_occupied`
+        # TODO improve and check this normalization after implementing `ElectronicEigenvalues`
 
         # Check if the variables contain more than one variable (different than Energy)
         # ? Is this correct or should be use the index of energies to extract the proper shape element in `self.value` being used for `dos_values`?
@@ -441,7 +415,6 @@ class ElectronicDensityOfStates(DOSProfile):
                 extracted_pdos.append(pdos)
         return extracted_pdos
 
-    # ? Maybe this method (and the one for XASSpectra.generate_from_contributions) should be moved to `PhysicalProperty`?
     def generate_from_projected_dos(
         self, logger: BoundLogger
     ) -> Optional[pint.Quantity]:
@@ -506,10 +479,14 @@ class ElectronicDensityOfStates(DOSProfile):
             return
 
         # Resolve `fermi_level` from a sibling section with respect to `ElectronicDensityOfStates`
-        self.fermi_level = self.resolve_fermi_level(logger)
+        fermi_level = get_sibling_section(
+            section=self, sibling_section_name='fermi_level', logger=logger
+        )  # * we consider `index_sibling` to be 0
+        if fermi_level is not None:
+            fermi_level = fermi_level.value
         # and the `energies_origin` from the sibling `ElectronicEigenvalues` section
         self.energies_origin = self.resolve_energies_origin(
-            energies, self.fermi_level, logger
+            energies, fermi_level, logger
         )
         if self.energies_origin is None:
             logger.info('Could not resolve the `energies_origin` for the DOS')
@@ -524,17 +501,20 @@ class ElectronicDensityOfStates(DOSProfile):
             self.m_parent.electronic_band_gap.append(band_gap)
 
         # Total `value` extraction from `projected_dos`
-        if self.value is None:
+        value_from_pdos = self.generate_from_projected_dos(logger)
+        if self.value is None and value_from_pdos is not None:
             logger.info(
                 'The `ElectronicDensityOfStates.value` is not stored. We will attempt to obtain it by summing up projected DOS contributions, if these are present.'
             )
-        self.value = self.generate_from_projected_dos(logger)
+            self.value = value_from_pdos
 
 
 class XASSpectra(SpectralProfile):
     """
     X-ray Absorption Spectra (XAS).
     """
+
+    # ! implement `iri` and `rank` as part of `m_def = Section()`
 
     xanes_spectra = SubSection(
         sub_section=SpectralProfile.m_def,
@@ -559,7 +539,6 @@ class XASSpectra(SpectralProfile):
         # Set the name of the section
         self.name = self.m_def.name
 
-    # ? Maybe this method (and the one for ElectronicDensityOfStates.generate_from_projected_dos) should be moved to `PhysicalProperty`?
     def generate_from_contributions(self, logger: BoundLogger) -> None:
         """
         Generate the `value` of the XAS spectra by concatenating the XANES and EXAFS contributions. It also concatenates

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -32,7 +32,7 @@ from nomad.metainfo import (
     JSON,
 )
 
-from .outputs import resolve_output_value, Outputs, PhysicalProperty, FermiLevel
+from ..outputs import resolve_output_value, Outputs, PhysicalProperty, FermiLevel
 
 
 class SpectralProfile(Outputs):

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -135,7 +135,7 @@ class ElectronicDensityOfStates(DOSProfile):
         unit='joule',
         description="""
         Energy level denoting the origin along the energy axis, used for comparison and visualization. It is
-        defined as the `ElectronicEigenvalues.highest_occupied` and does not necessarily coincide with `fermi_level`.
+        defined as the `ElectronicEigenvalues.highest_occupied_energy` and does not necessarily coincide with `fermi_level`.
         """,
     )
 
@@ -164,7 +164,7 @@ class ElectronicDensityOfStates(DOSProfile):
             - If the total DOS is not present, we can sum all atom-projected DOS to obtain it.
             - If the atom-projected DOS is not present, we can sum all orbital-projected DOS to obtain it.
 
-        In `projected_dos`, `name` and `entity_ref` must be set in order to normalization to work:
+        In `projected_dos`, `name` and `entity_ref` must be set in order for normalization to work:
             - The `entity_ref` is the `OrbitalsState` or `AtomsState` sections.
             - The `name` of the projected DOS should be `'atom X'` or `'orbital Y X'`, with 'X' being the chemical symbol and 'Y' the orbital label.
             These can be extracted from `entity_ref`.

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -441,7 +441,7 @@ class ElectronicDensityOfStates(DOSProfile):
                 extracted_pdos.append(pdos)
         return extracted_pdos
 
-    def extract_dos_from_projected(
+    def generate_from_projected_dos(
         self, logger: BoundLogger
     ) -> Optional[pint.Quantity]:
         if self.projected_dos is None or len(self.projected_dos) == 0:
@@ -505,8 +505,7 @@ class ElectronicDensityOfStates(DOSProfile):
             self.m_parent.electronic_band_gap.append(band_gap)
 
         # Total `value` extraction from `projected_dos`:
-        if self.value is None:
-            self.value = self.extract_dos_from_projected(logger)
+        self.value = self.generate_from_projected_dos(logger)
 
 
 class XASSpectra(SpectralProfile):

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -82,7 +82,7 @@ class SpectralProfile(PhysicalProperty):
 
 class ElectronicDensityOfStates(SpectralProfile):
     """
-    Electronic Density of States (DOS).
+    Number of electronic states accessible for the charges per energy and per volume.
     """
 
     iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'

--- a/src/nomad_simulations/spectral_profile.py
+++ b/src/nomad_simulations/spectral_profile.py
@@ -1,0 +1,131 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+from nomad.units import ureg
+from nomad.datamodel.data import ArchiveSection
+from nomad.metainfo import (
+    Quantity,
+    SubSection,
+    MEnum,
+    Section,
+    Context,
+    JSON,
+)
+
+from .outputs import Outputs, PhysicalProperty
+
+
+class SpectralProfile(Outputs, PhysicalProperty):
+    """
+    A base section used to define the spectral profile.
+    """
+
+    intensities = Quantity(
+        type=np.float64,
+        shape=['*'],
+        description="""
+        Intensities in arbitrary units.
+        """,
+    )
+
+    intensities_units = Quantity(
+        type=str,
+        description="""
+        Unit using the pint UnitRegistry() notation for the `intensities`. Example, if the spectra `is_derived`
+        from the imaginary part of the dielectric function, `intensities_units` are `'F/m'`.
+        """,
+    )
+
+    def __init__(self, m_def: Section = None, m_context: Context = None, **kwargs):
+        super(Outputs).__init__(m_def, m_context, **kwargs)
+        super(PhysicalProperty).__init__(m_def, m_context, **kwargs)
+        # Set the name of the section
+        self.name = self.m_def.name
+
+    def normalize(self, archive, logger) -> None:
+        super(Outputs).normalize(archive, logger)
+
+
+class ElectronicSpectralProfile(SpectralProfile):
+    """
+    A base section used to define the electronic spectral profile variables. These are defined as the excitation energies.
+    """
+
+    n_energies = Quantity(
+        type=np.int32,
+        shape=[],
+        description="""
+        Number of energies.
+        """,
+    )
+
+    energies = Quantity(
+        type=np.float64,
+        shape=['n_energies'],
+        unit='joule',
+        description="""
+        Energies.
+        """,
+    )
+
+    energies_origin = Quantity(
+        type=np.float64,
+        unit='joule',
+        description="""
+        Origin of reference for the energies. This quantity is used to set the `energies` to zero at the origin.
+        """,
+    )
+
+
+class ElectronicDensityOfStates(ElectronicSpectralProfile):
+    """
+    Electronic Density of States (DOS).
+    """
+
+    energy_fermi = Quantity(
+        type=np.float64,
+        unit='joule',
+        description="""
+        Fermi energy.
+        """,
+    )
+
+    spin_channel = Quantity(
+        type=np.int32,
+        description="""
+        Spin channel of the corresponding DOS. It can take values of 0 or 1.
+        """,
+    )
+
+    normalization_factor = Quantity(
+        type=np.float64,
+        description="""
+        Normalization factor for DOS values to get a cell-independent intensive DOS,
+        defined as the DOS integral from the lowest energy state to the Fermi level for a neutrally charged system.
+        """,
+    )
+
+    intensities_integrated = Quantity(
+        type=np.float64,
+        shape=['n_energies'],
+        description="""
+        A cumulative DOS starting from the mimunum energy available up to the energy level specified in `energies`.
+        """,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,11 @@ if os.getenv('_PYTEST_RAISE', '0') != '0':
         raise excinfo.value
 
 
-def get_model_system(
+def generate_model_system(
     type: str = 'original',
     positions: List[List[float]] = [[0, 0, 0], [0.5, 0.5, 0.5]],
     chemical_symbols: List[str] = ['Ga', 'As'],
-    orbital_symbols: List[List[str]] = [['s'], ['px', 'py']],
+    orbitals_symbols: List[List[str]] = [['s'], ['px', 'py']],
 ) -> ModelSystem:
     """
     Create a `ModelSystem` object with the given parameters.
@@ -62,16 +62,16 @@ def get_model_system(
 
     # Add atoms_state to the model_system
     atoms_state = []
-    for index, atom in enumerate(chemical_symbols):
-        orbitals = orbital_symbols[index]
+    for index, element in enumerate(chemical_symbols):
+        orbitals = orbitals_symbols[index]
         orbitals_state = []
         for orbital in orbitals:
             orbitals_state.append(
                 OrbitalsState(
                     l_quantum_symbol=orbital[0], ml_quantum_symbol=orbital[1:]
                 )
-            )
-        atom_state = AtomsState(chemical_symbol=atom, orbitals_state=orbitals_state)
+            )  # TODO add this split setter as part of the `OrbitalsState` methods
+        atom_state = AtomsState(chemical_symbol=element, orbitals_state=orbitals_state)
         # and obtain the atomic number for each AtomsState
         atom_state.resolve_chemical_symbol_and_number(logger)
         atoms_state.append(atom_state)
@@ -79,7 +79,9 @@ def get_model_system(
     return model_system
 
 
-def get_scf_electronic_band_gap_template(threshold_change: float = 1e-3) -> SCFOutputs:
+def generate_scf_electronic_band_gap_template(
+    threshold_change: float = 1e-3,
+) -> SCFOutputs:
     """
     Create a `SCFOutputs` object with a template for the electronic_band_gap property.
     """
@@ -103,15 +105,15 @@ def get_scf_electronic_band_gap_template(threshold_change: float = 1e-3) -> SCFO
     return scf_outputs
 
 
-def get_electronic_dos(
+def generate_electronic_dos(
     energy_points: List[int] = [-3, -2, -1, 0, 1, 2, 3],
     total_dos: List[float] = [1.5, 1.2, 0, 0, 0, 0.8, 1.3],
 ) -> ElectronicDensityOfStates:
     """
     Create an `ElectronicDensityOfStates` object with a template for the electronic_dos property. It uses
-    the template of the model_system created with the `get_model_system` function.
+    the template of the model_system created with the `generate_model_system` function.
     """
-    model_system = get_model_system()
+    model_system = generate_model_system()
     variables_energy = [Energy(grid_points=energy_points * ureg.joule)]
     electronic_dos = ElectronicDensityOfStates(variables=variables_energy)
     electronic_dos.value = total_dos * ureg('1/joule')
@@ -143,14 +145,14 @@ def get_electronic_dos(
 
 @pytest.fixture(scope='session')
 def model_system() -> ModelSystem:
-    return get_model_system()
+    return generate_model_system()
 
 
 @pytest.fixture(scope='session')
 def scf_electronic_band_gap() -> SCFOutputs:
-    return get_scf_electronic_band_gap_template()
+    return generate_scf_electronic_band_gap_template()
 
 
 @pytest.fixture(scope='session')
 def electronic_dos() -> ElectronicDensityOfStates:
-    return get_electronic_dos()
+    return generate_electronic_dos()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def generate_simulation(
 ) -> Simulation:
     """
     Generate a `Simulation` section with the main sub-sections, `ModelSystem`, `ModelMethod`, and `Outputs`. If `ModelSystem`
-    and `Outputs` is not None, then it adds `ModelSystem` as a reference in `Outputs`.
+    and `Outputs` are set, then it adds `ModelSystem` as a reference in `Outputs`.
     """
     simulation = Simulation()
     if model_method is not None:
@@ -64,8 +64,7 @@ def generate_simulation(
         simulation.model_system.append(model_system)
     if outputs is not None:
         simulation.outputs.append(outputs)
-        if model_system is not None:
-            outputs.model_system_ref = model_system
+        outputs.model_system_ref = model_system
     return simulation
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,18 +74,20 @@ def generate_model_system(
     positions: List[List[float]] = [[0, 0, 0], [0.5, 0.5, 0.5]],
     chemical_symbols: List[str] = ['Ga', 'As'],
     orbitals_symbols: List[List[str]] = [['s'], ['px', 'py']],
-) -> ModelSystem:
+) -> Optional[ModelSystem]:
     """
     Generate a `ModelSystem` section with the given parameters.
     """
+    if len(chemical_symbols) != len(orbitals_symbols):
+        return None
+
     model_system = ModelSystem()
     atomic_cell = AtomicCell(type=type, positions=positions * ureg.meter)
     model_system.cell.append(atomic_cell)
 
     # Add atoms_state to the model_system
     atoms_state = []
-    for index, element in enumerate(chemical_symbols):
-        orbitals = orbitals_symbols[index]
+    for element, orbitals in zip(chemical_symbols, orbitals_symbols):
         orbitals_state = []
         for orbital in orbitals:
             orbitals_state.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,17 +145,14 @@ def generate_simulation_electronic_dos(
     outputs.electronic_dos.append(electronic_dos)
     # electronic_dos.value = total_dos * ureg('1/joule')
     orbital_s_Ga_pdos = DOSProfile(
-        name='orbital s Ga',
         variables=variables_energy,
         entity_ref=model_system.cell[0].atoms_state[0].orbitals_state[0],
     )
     orbital_px_As_pdos = DOSProfile(
-        name='orbital px As',
         variables=variables_energy,
         entity_ref=model_system.cell[0].atoms_state[1].orbitals_state[0],
     )
     orbital_py_As_pdos = DOSProfile(
-        name='orbital py As',
         variables=variables_energy,
         entity_ref=model_system.cell[0].atoms_state[1].orbitals_state[1],
     )

--- a/tests/test_energies.py
+++ b/tests/test_energies.py
@@ -1,0 +1,60 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import numpy as np
+from typing import Optional, List, Union
+
+from . import logger
+
+from nomad_simulations.properties import FermiLevel, ChemicalPotential
+
+
+class TestFermiLevel:
+    """
+    Test the `FermiLevel` class defined in `properties/energies.py`.
+    """
+
+    # ! Include this initial `test_default_quantities` method when testing your PhysicalProperty classes
+    def test_default_quantities(self):
+        """
+        Test the default quantities assigned when creating an instance of the `FermiLevel` class.
+        """
+        fermi_level = FermiLevel()
+        assert fermi_level.iri == 'http://fairmat-nfdi.eu/taxonomy/FermiLevel'
+        assert fermi_level.name == 'FermiLevel'
+        assert fermi_level.rank == []
+
+
+class TestChemicalPotential:
+    """
+    Test the `ChemicalPotential` class defined in `properties/energies.py`.
+    """
+
+    # ! Include this initial `test_default_quantities` method when testing your PhysicalProperty classes
+    def test_default_quantities(self):
+        """
+        Test the default quantities assigned when creating an instance of the `ChemicalPotential` class.
+        """
+        chemical_potential = ChemicalPotential()
+        assert (
+            chemical_potential.iri
+            == 'http://fairmat-nfdi.eu/taxonomy/ChemicalPotential'
+        )
+        assert chemical_potential.name == 'ChemicalPotential'
+        assert chemical_potential.rank == []

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -28,20 +28,6 @@ from nomad_simulations.physical_property import PhysicalProperty
 from nomad_simulations.outputs import Outputs, ElectronicBandGap
 
 
-class TotalEnergy(PhysicalProperty):
-    """Physical property class defined for testing purposes."""
-
-    rank = []
-    variables = []
-    value = Quantity(
-        type=np.float64,
-        unit='joule',
-        description="""
-        The total energy of the system.
-        """,
-    )
-
-
 class TestOutputs:
     """
     Test the `Outputs` class defined in `outputs.py`.
@@ -102,11 +88,6 @@ class TestOutputs:
         scf_outputs = get_scf_electronic_band_gap_template(
             threshold_change=threshold_change
         )
-        # Add a non-SCF calculated PhysicalProperty
-        scf_outputs.custom_physical_property = [
-            TotalEnergy(name='TotalEnergy', value=1 * ureg.joule)
-        ]
 
         scf_outputs.normalize(None, logger)
         assert scf_outputs.electronic_band_gap[0].is_scf_converged == result
-        assert scf_outputs.custom_physical_property[0].is_scf_converged is None

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -17,14 +17,11 @@
 #
 
 import pytest
-import numpy as np
 
 from . import logger
-from .conftest import get_scf_electronic_band_gap_template
+from .conftest import generate_scf_electronic_band_gap_template
 
 from nomad.units import ureg
-from nomad.metainfo import Quantity
-from nomad_simulations.physical_property import PhysicalProperty
 from nomad_simulations.outputs import Outputs, ElectronicBandGap
 
 
@@ -41,7 +38,7 @@ class TestOutputs:
         """
         Test the  `resolve_is_scf_converged` method.
         """
-        scf_outputs = get_scf_electronic_band_gap_template(
+        scf_outputs = generate_scf_electronic_band_gap_template(
             threshold_change=threshold_change
         )
         is_scf_converged = scf_outputs.resolve_is_scf_converged(
@@ -85,7 +82,7 @@ class TestOutputs:
         """
         Test the `normalize` method.
         """
-        scf_outputs = get_scf_electronic_band_gap_template(
+        scf_outputs = generate_scf_electronic_band_gap_template(
             threshold_change=threshold_change
         )
 

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -74,7 +74,7 @@ class TestElectronicDensityOfStates:
 
     def test_get_energy_points(self):
         """
-        Test the `_get_energy_points` method.
+        Test the `_get_energy_points` private method. We test here that the function indeed returns the points from a `Energy` variable.
         """
         electronic_dos = ElectronicDensityOfStates()
         electronic_dos.variables = [
@@ -203,7 +203,6 @@ class TestElectronicDensityOfStates:
         'value, result',
         [
             (None, [1.5, 1.2, 0, 0, 0, 0.8, 1.3]),
-            ([1.5, 1.2, 0, 0, 0, 0.8, 1.3], [1.5, 1.2, 0, 0, 0, 0.8, 1.3]),
             ([30.5, 1.2, 0, 0, 0, 0.8, 1.3], [30.5, 1.2, 0, 0, 0, 0.8, 1.3]),
         ],
     )
@@ -273,6 +272,8 @@ class TestXASSpectra:
             ([0, 1, 2], None, None),
             (None, [3, 4, 5], None),
             ([0, 1, 2], [3, 4, 5], [0.5, 0.1, 0.3, 0.2, 0.4, 0.6]),
+            ([0, 1, 4], [3, 4, 5], None),
+            ([0, 1, 2], [0, 4, 5], None),
         ],
     )
     def test_generate_from_contributions(
@@ -284,7 +285,6 @@ class TestXASSpectra:
         """
         Test the `generate_from_contributions` method.
         """
-        # ! extend this test
         xas_spectra = XASSpectra()
         if xanes_energies is not None:
             xanes_spectra = SpectralProfile()

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -26,7 +26,7 @@ from nomad.units import ureg
 
 from nomad_simulations import Simulation
 from nomad_simulations.model_system import ModelSystem, AtomicCell
-from nomad_simulations.atoms_state import AtomsState, OrbitalsState
+from nomad_simulations.atoms_state import AtomsState
 from nomad_simulations.outputs import Outputs
 from nomad_simulations.properties import (
     SpectralProfile,
@@ -35,6 +35,7 @@ from nomad_simulations.properties import (
     FermiLevel,
 )
 from nomad_simulations.variables import Temperature, Energy2 as Energy
+from nomad_simulations.utils import get_sibling_section
 
 
 class TestSpectralProfile:
@@ -89,38 +90,6 @@ class TestElectronicDensityOfStates:
         )
         energies = electronic_dos._check_energy_variables(logger)
         assert (energies.magnitude == np.array([-3, -2, -1, 0, 1, 2, 3])).all()
-
-    @pytest.mark.parametrize(
-        'fermi_level, sibling_section_value, result',
-        [
-            (None, None, None),
-            (None, 0.5, 0.5),
-            (0.5, None, 0.5),
-            (0.5, 1.0, 0.5),
-        ],
-    )
-    def test_resolve_fermi_level(
-        self,
-        fermi_level: Optional[float],
-        sibling_section_value: Optional[float],
-        result: Optional[float],
-        electronic_dos: ElectronicDensityOfStates,
-    ):
-        """
-        Test the `_resolve_fermi_level` method.
-        """
-        outputs = Outputs()
-        sec_fermi_level = FermiLevel(variables=[])
-        if sibling_section_value is not None:
-            sec_fermi_level.value = sibling_section_value * ureg.joule
-        outputs.fermi_level.append(sec_fermi_level)
-        if fermi_level is not None:
-            electronic_dos.fermi_level = fermi_level * ureg.joule
-        outputs.electronic_dos.append(electronic_dos)
-        resolved_fermi_level = electronic_dos.resolve_fermi_level(logger)
-        if resolved_fermi_level is not None:
-            resolved_fermi_level = resolved_fermi_level.magnitude
-        assert resolved_fermi_level == result
 
     def test_resolve_energies_origin(self):
         """

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -47,14 +47,12 @@ class TestSpectralProfile:
         Test the `is_valid_spectral_profile` method.
         """
         spectral_profile = SpectralProfile(
-            variables=[Energy(grid_points=[-3, -2, -1, 0, 1, 2, 3] * ureg.joule)]
+            variables=[Energy(grid_points=[-1, 0, 1] * ureg.joule)]
         )
-        spectral_profile.value = [1.5, 1.2, 0, 0, 0, 0.8, 1.3]
+        spectral_profile.value = [1.5, 0, 0.8]
         assert spectral_profile.is_valid_spectral_profile()
-        spectral_profile.value = [3, 2, 0, 0, 0, -4, 1]
+        spectral_profile.value = [2, 0, -4]
         assert not spectral_profile.is_valid_spectral_profile()
-        # default value inherited in other SpectralProfile classes
-        assert spectral_profile.rank == []
 
 
 class TestElectronicDensityOfStates:
@@ -75,19 +73,19 @@ class TestElectronicDensityOfStates:
         assert electronic_dos.name == 'ElectronicDensityOfStates'
         assert electronic_dos.rank == []
 
-    def test_check_energy_variables(self):
+    def test_get_energy_points(self):
         """
-        Test the `_check_energy_variables` method.
+        Test the `_get_energy_points` method.
         """
         electronic_dos = ElectronicDensityOfStates()
         electronic_dos.variables = [
-            Temperature(grid_points=[-3, -2, -1, 0, 1, 2, 3] * ureg.kelvin)
+            Temperature(grid_points=list(range(-3, 4)) * ureg.kelvin)
         ]
-        assert electronic_dos._check_energy_variables(logger) is None
+        assert electronic_dos._get_energy_points(logger) is None
         electronic_dos.variables.append(
-            Energy(grid_points=[-3, -2, -1, 0, 1, 2, 3] * ureg.joule)
+            Energy(grid_points=list(range(-3, 4)) * ureg.joule)
         )
-        energies = electronic_dos._check_energy_variables(logger)
+        energies = electronic_dos._get_energy_points(logger)
         assert (energies.magnitude == np.array([-3, -2, -1, 0, 1, 2, 3])).all()
 
     @pytest.mark.parametrize(
@@ -127,7 +125,7 @@ class TestElectronicDensityOfStates:
         Test the `resolve_energies_origin` method.
         """
         # ! add test when `ElectronicEigenvalues` is implemented
-        assert True
+        pass
 
     def test_resolve_normalization_factor(
         self, electronic_dos: ElectronicDensityOfStates
@@ -171,15 +169,19 @@ class TestElectronicDensityOfStates:
         assert np.isclose(normalization_factor, 0.015625)
         # Spin-polarized
         electronic_dos.spin_channel = 0
-        normalization_factor = electronic_dos.resolve_normalization_factor(logger)
-        assert np.isclose(normalization_factor, 0.0078125)
+        normalization_factor_spin_polarized = (
+            electronic_dos.resolve_normalization_factor(logger)
+        )
+        assert np.isclose(
+            normalization_factor_spin_polarized, 0.5 * normalization_factor
+        )
 
     def test_extract_band_gap(self):
         """
         Test the `extract_band_gap` method.
         """
         # ! add test when `ElectronicEigenvalues` is implemented
-        assert True
+        pass
 
     def test_generate_from_projected_dos(
         self, model_system: ModelSystem, electronic_dos: ElectronicDensityOfStates
@@ -241,7 +243,7 @@ class TestElectronicDensityOfStates:
         Test the `normalize` method.
         """
         # ! add test when `ElectronicEigenvalues` is implemented
-        assert True
+        pass
 
 
 class TestXASSpectra:

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -149,6 +149,20 @@ class TestElectronicDensityOfStates:
         # ! add test when `ElectronicEigenvalues` is implemented
         pass
 
+    def test_resolve_pdos_name(self, simulation_electronic_dos: Simulation):
+        """
+        Test the `resolve_pdos_name` method.
+        """
+        # Get projected DOSProfile from the simulation fixture
+        projected_dos = (
+            simulation_electronic_dos.outputs[0].electronic_dos[0].projected_dos
+        )
+        assert len(projected_dos) == 3
+        pdos_names = ['orbital s Ga', 'orbital px As', 'orbital py As']
+        for i, pdos in enumerate(projected_dos):
+            name = pdos.resolve_pdos_name(logger)
+            assert name == pdos_names[i]
+
     def test_extract_projected_dos(self, simulation_electronic_dos: Simulation):
         """
         Test the `extract_projected_dos` method.

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -219,7 +219,7 @@ class TestElectronicDensityOfStates:
 
         # Note: `val` is reported from `self.value`, not from the extraction
         val = electronic_dos.generate_from_projected_dos(logger)
-        assert (val == electronic_dos.value).all()
+        assert (val.magnitude == electronic_dos.value.magnitude).all()
         assert len(electronic_dos.projected_dos) == 5  # including atom projected DOS
         orbital_projected = electronic_dos.extract_projected_dos('orbital', logger)
         atom_projected = electronic_dos.extract_projected_dos('atom', logger)

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -236,7 +236,7 @@ class TestElectronicDensityOfStates:
         #     == outputs.model_system_ref.cell[0].atoms_state[1]
         # )  # `As` atom
 
-    def test_extract_band_gap(self):
+    def test_normalize(self):
         """
         Test the `normalize` method.
         """

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -181,11 +181,11 @@ class TestElectronicDensityOfStates:
         # ! add test when `ElectronicEigenvalues` is implemented
         assert True
 
-    def test_extract_dos_from_projected(
+    def test_generate_from_projected_dos(
         self, model_system: ModelSystem, electronic_dos: ElectronicDensityOfStates
     ):
         """
-        Test the `extract_dos_from_projected` and `extract_projected_dos` methods.
+        Test the `generate_from_projected_dos` and `extract_projected_dos` methods.
         """
         simulation = Simulation()
         simulation.model_system.append(model_system)
@@ -218,7 +218,7 @@ class TestElectronicDensityOfStates:
         # )  # orbital `py` in `As` atom
 
         # Note: `val` is reported from `self.value`, not from the extraction
-        val = electronic_dos.extract_dos_from_projected(logger)
+        val = electronic_dos.generate_from_projected_dos(logger)
         assert (val == electronic_dos.value).all()
         assert len(electronic_dos.projected_dos) == 5  # including atom projected DOS
         orbital_projected = electronic_dos.extract_projected_dos('orbital', logger)

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -28,7 +28,7 @@ from nomad_simulations.properties import (
     ElectronicDensityOfStates,
     XASSpectra,
 )
-from nomad_simulations.variables import Temperature
+from nomad_simulations.variables import Temperature, Energy2 as Energy
 
 
 class TestSpectralProfile:
@@ -36,8 +36,17 @@ class TestSpectralProfile:
     Test the `SpectralProfile` class defined in `properties/spectral_profile.py`.
     """
 
-    def test_negative_value(self):
-        spectral_profile = SpectralProfile()
+    def test_is_valid_spectral_profile(self):
+        """
+        Test the `is_valid_spectral_profile` method.
+        """
+        spectral_profile = SpectralProfile(
+            variables=[Energy(grid_points=[-3, -2, -1, 0, 1, 2, 3] * ureg.joule)]
+        )
+        spectral_profile.value = [1.5, 1.2, 0, 0, 0, 0.8, 1.3]
+        assert spectral_profile.is_valid_spectral_profile()
+        spectral_profile.value = [3, 2, 0, 0, 0, -4, 1]
+        assert not spectral_profile.is_valid_spectral_profile()
         # default value inherited in other SpectralProfile classes
         assert spectral_profile.rank == []
 
@@ -52,13 +61,28 @@ class TestElectronicDensityOfStates:
         """
         Test the default quantities assigned when creating an instance of the `ElectronicDensityOfStates` class.
         """
-        electronic_band_gap = ElectronicDensityOfStates()
+        electronic_dos = ElectronicDensityOfStates()
         assert (
-            electronic_band_gap.iri
+            electronic_dos.iri
             == 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'
         )
-        assert electronic_band_gap.name == 'ElectronicDensityOfStates'
-        assert electronic_band_gap.rank == []
+        assert electronic_dos.name == 'ElectronicDensityOfStates'
+        assert electronic_dos.rank == []
+
+    def test_check_energy_variables(self):
+        """
+        Test the `_check_energy_variables` method.
+        """
+        electronic_dos = ElectronicDensityOfStates()
+        electronic_dos.variables = [
+            Temperature(grid_points=[-3, -2, -1, 0, 1, 2, 3] * ureg.kelvin)
+        ]
+        assert electronic_dos._check_energy_variables(logger) is None
+        electronic_dos.variables.append(
+            Energy(grid_points=[-3, -2, -1, 0, 1, 2, 3] * ureg.joule)
+        )
+        energies = electronic_dos._check_energy_variables(logger)
+        assert (energies.magnitude == np.array([-3, -2, -1, 0, 1, 2, 3])).all()
 
 
 class TestXASSpectra:
@@ -71,7 +95,7 @@ class TestXASSpectra:
         """
         Test the default quantities assigned when creating an instance of the `XASSpectra` class.
         """
-        electronic_band_gap = XASSpectra()
-        assert electronic_band_gap.iri is None  # Add iri when available
-        assert electronic_band_gap.name == 'XASSpectra'
-        assert electronic_band_gap.rank == []
+        xas_spectra = XASSpectra()
+        assert xas_spectra.iri is None  # Add iri when available
+        assert xas_spectra.name == 'XASSpectra'
+        assert xas_spectra.rank == []

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -1,0 +1,77 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import numpy as np
+from typing import Optional, List, Union
+
+from . import logger
+
+from nomad.units import ureg
+from nomad_simulations.properties import (
+    SpectralProfile,
+    ElectronicDensityOfStates,
+    XASSpectra,
+)
+from nomad_simulations.variables import Temperature
+
+
+class TestSpectralProfile:
+    """
+    Test the `SpectralProfile` class defined in `properties/spectral_profile.py`.
+    """
+
+    def test_negative_value(self):
+        spectral_profile = SpectralProfile()
+        # default value inherited in other SpectralProfile classes
+        assert spectral_profile.rank == []
+
+
+class TestElectronicDensityOfStates:
+    """
+    Test the `ElectronicDensityOfStates` class defined in `properties/spectral_profile.py`.
+    """
+
+    # ! Include this initial `test_default_quantities` method when testing your PhysicalProperty classes
+    def test_default_quantities(self):
+        """
+        Test the default quantities assigned when creating an instance of the `ElectronicDensityOfStates` class.
+        """
+        electronic_band_gap = ElectronicDensityOfStates()
+        assert (
+            electronic_band_gap.iri
+            == 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'
+        )
+        assert electronic_band_gap.name == 'ElectronicDensityOfStates'
+        assert electronic_band_gap.rank == []
+
+
+class TestXASSpectra:
+    """
+    Test the `XASSpectra` class defined in `properties/spectral_profile.py`.
+    """
+
+    # ! Include this initial `test_default_quantities` method when testing your PhysicalProperty classes
+    def test_default_quantities(self):
+        """
+        Test the default quantities assigned when creating an instance of the `XASSpectra` class.
+        """
+        electronic_band_gap = XASSpectra()
+        assert electronic_band_gap.iri is None  # Add iri when available
+        assert electronic_band_gap.name == 'XASSpectra'
+        assert electronic_band_gap.rank == []

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -258,3 +258,30 @@ class TestXASSpectra:
         assert xas_spectra.iri is None  # Add iri when available
         assert xas_spectra.name == 'XASSpectra'
         assert xas_spectra.rank == []
+
+    def test_generate_from_contributions(self):
+        """
+        Test the `generate_from_contributions` method.
+        """
+        xas_spectra = XASSpectra()
+        xanes_spectra = SpectralProfile(
+            variables=[Energy(grid_points=[0, 1, 2] * ureg.joule)]
+        )
+        xanes_spectra.value = [0.5, 0.1, 0.3]
+        xas_spectra.xanes_spectra = xanes_spectra
+        exafs_spectra = SpectralProfile(
+            variables=[Energy(grid_points=[3, 4, 5] * ureg.joule)]
+        )
+        exafs_spectra.value = [0.2, 0.4, 0.6]
+        xas_spectra.exafs_spectra = exafs_spectra
+        xas_spectra.generate_from_contributions(logger)
+        assert len(xas_spectra.variables) == 1
+        assert len(xas_spectra.variables[0].grid_points) == 6
+        assert len(xas_spectra.variables[0].grid_points) == (
+            len(xanes_spectra.variables[0].grid_points)
+            + len(exafs_spectra.variables[0].grid_points)
+        )
+        assert (
+            xas_spectra.variables[0].grid_points.magnitude == [0, 1, 2, 3, 4, 5]
+        ).all()
+        assert (xas_spectra.value == [0.5, 0.1, 0.3, 0.2, 0.4, 0.6]).all()


### PR DESCRIPTION
@ndaelman-hu 

@JFRudzinski @Bernadette-Mohr only for you: I added `properties/energies.py` and a couple of properties, `FermiLevel` and `ChemicalPotential`. You can disregard the rest of the message.

I just finished this initial version. Mainly, you have to check `properties/spectral_profile.py` and `properties/energies.py`. I added some tests, but I have the issue that I would need some other sections in order to properly test the functionalities in `ElectronicDensityOfStates`, namely, I need `ElectronicEigenvalues` containing the info of the `highest_occupied_energy` and `lowest_occupied_energy`.

Besides these, I changed `OrbitalsState` and `AtomsState` to inherit from `Entity`. Do you mind giving your thoughts in here? I wanted to give an `entity_ref` that can be used to reference if a property is atomic or orbitally resolved, e.g., the projected DOS (but there might be others).