### PR TITLE
Moving `iri` and `rank` to m_def

### DIFF
--- a/src/nomad_simulations/physical_property.py
+++ b/src/nomad_simulations/physical_property.py
@@ -54,18 +54,12 @@ class PhysicalProperty(ArchiveSection):
     # TODO add `errors`
     # TODO add `smearing`
 
+    m_def = Section()  # modify `m_def` adding `iri` and `rank`
+
     name = Quantity(
         type=str,
         description="""
-        Name of the physical property. Example: `'ElectronicBandGap'`.
-        """,
-    )
-
-    iri = Quantity(
-        type=URL,
-        description="""
-        Internationalized Resource Identifier (IRI) of the physical property defined in the FAIRmat
-        taxonomy, https://fairmat-nfdi.github.io/fairmat-taxonomy/.
+        Name of the physical property.
         """,
     )
 
@@ -94,20 +88,6 @@ class PhysicalProperty(ArchiveSection):
         can be labeled as `'DFT'` or `'GW'` depending on the methodology used to calculate it.
         """,
         # ! add more examples in the description to improve the understanding of this quantity
-    )
-
-    rank = DirectQuantity(
-        type=Dimension,
-        shape=['0..*'],
-        default=[],
-        name='rank',
-        description="""
-        Rank of the tensor describing the physical property. This quantity is stored as a Dimension:
-            - scalars (tensor rank 0) have `rank=[]` (`len(rank) = 0`),
-            - vectors (tensor rank 1) have `rank=[a]` (`len(rank) = 1`),
-            - matrices (tensor rank 2), have `rank=[a, b]` (`len(rank) = 2`),
-            - etc.
-        """,
     )
 
     variables = SubSection(sub_section=Variables.m_def, repeats=True)
@@ -196,7 +176,7 @@ class PhysicalProperty(ArchiveSection):
         Returns:
             (list): The full shape of the physical property.
         """
-        return self.variables_shape + self.rank
+        return self.variables_shape + self.m_def.rank
 
     @property
     def _new_value(self) -> Quantity:
@@ -221,9 +201,10 @@ class PhysicalProperty(ArchiveSection):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
-        if self.iri is None:
+        if self.m_def.iri is None:
             logger.warning(
-                'The used property is not defined in the FAIRmat taxonomy (https://fairmat-nfdi.github.io/fairmat-taxonomy/). You can contribute there if you want to extend the list of available materials properties.'
+                'The used property is not defined in the FAIRmat taxonomy (http://fairmat-nfdi.eu/taxonomy/). '
+                'You can contribute there if you want to extend the list of available materials properties.'
             )
 
     def __setattr__(self, name: str, val: Any) -> None:

--- a/src/nomad_simulations/physical_property.py
+++ b/src/nomad_simulations/physical_property.py
@@ -105,12 +105,13 @@ class PhysicalProperty(ArchiveSection):
         """,
     )
 
-    physical_property_ref = Quantity(
-        type=Reference(SectionProxy('PhysicalProperty')),
+    physical_property_ref = SubSection(
+        section_def=SectionProxy('PhysicalProperty'),
         description="""
         Reference to the `PhysicalProperty` section from which the physical property was derived. If `physical_property_ref`
         is populated, the quantity `is_derived` is set to True via normalization.
         """,
+        repeats=False,
     )
 
     is_derived = Quantity(

--- a/src/nomad_simulations/properties/band_gap.py
+++ b/src/nomad_simulations/properties/band_gap.py
@@ -31,9 +31,7 @@ class ElectronicBandGap(PhysicalProperty):
     Energy difference between the highest occupied electronic state and the lowest unoccupied electronic state.
     """
 
-    # ! implement `iri` and `rank` as part of `m_def = Section()`
-
-    iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicBandGap'
+    m_def = Section(iri='http://fairmat-nfdi.eu/taxonomy/ElectronicBandGap', rank=[])
 
     type = Quantity(
         type=MEnum('direct', 'indirect'),
@@ -80,8 +78,6 @@ class ElectronicBandGap(PhysicalProperty):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
-        self.name = self.m_def.name
-        self.rank = []
 
     def _check_negative_values(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """

--- a/src/nomad_simulations/properties/energies.py
+++ b/src/nomad_simulations/properties/energies.py
@@ -28,9 +28,7 @@ class FermiLevel(PhysicalProperty):
     Energy required to add or extract a charge from a material at zero temperature. It can be also defined as the chemical potential at zero temperature.
     """
 
-    # ! implement `iri` and `rank` as part of `m_def = Section()`
-
-    iri = 'http://fairmat-nfdi.eu/taxonomy/FermiLevel'
+    m_def = Section(iri='http://fairmat-nfdi.eu/taxonomy/FermiLevel', rank=[])
 
     value = Quantity(
         type=np.float64,
@@ -44,8 +42,6 @@ class FermiLevel(PhysicalProperty):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
-        self.rank = []
-        self.name = self.m_def.name
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
@@ -56,9 +52,7 @@ class ChemicalPotential(PhysicalProperty):
     Free energy cost of adding or extracting a particle from a thermodynamic system.
     """
 
-    # ! implement `iri` and `rank` as part of `m_def = Section()`
-
-    iri = 'http://fairmat-nfdi.eu/taxonomy/ChemicalPotential'
+    m_def = Section(iri='http://fairmat-nfdi.eu/taxonomy/ChemicalPotential', rank=[])
 
     value = Quantity(
         type=np.float64,
@@ -72,8 +66,6 @@ class ChemicalPotential(PhysicalProperty):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
-        self.rank = []
-        self.name = self.m_def.name
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -36,6 +36,8 @@ class SpectralProfile(PhysicalProperty):
     A base section used to define the spectral profile.
     """
 
+    m_def = Section(rank=[])
+
     value = Quantity(
         type=np.float64,
         description="""
@@ -47,7 +49,6 @@ class SpectralProfile(PhysicalProperty):
         self, m_def: Section = None, m_context: Context = None, **kwargs
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
-        self.rank = []
 
     def _get_energy_points(self, logger: BoundLogger) -> Optional[pint.Quantity]:
         """
@@ -145,8 +146,9 @@ class ElectronicDensityOfStates(DOSProfile):
     Number of electronic states accessible for the charges per energy and per volume.
     """
 
-    # ! implement `iri` and `rank` as part of `m_def = Section()`
-    iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'
+    m_def = Section(
+        iri='http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates', rank=[]
+    )
 
     spin_channel = Quantity(
         type=np.int32,
@@ -533,7 +535,7 @@ class XASSpectra(SpectralProfile):
     X-ray Absorption Spectra (XAS).
     """
 
-    # ! implement `iri` and `rank` as part of `m_def = Section()`
+    m_def = Section(rank=[])  # TODO add XASSpectra to taxonomy
 
     xanes_spectra = SubSection(
         sub_section=SpectralProfile.m_def,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ from typing import List, Optional
 
 from nomad.units import ureg
 from nomad.datamodel import EntryArchive
+from nomad.datamodel.data import ArchiveSection
+from nomad.metainfo import Quantity, Section, Context, SubSection
 
 from . import logger
 
@@ -31,6 +33,7 @@ from nomad_simulations.atoms_state import AtomsState, OrbitalsState
 from nomad_simulations.model_method import ModelMethod
 from nomad_simulations.numerical_settings import SelfConsistency
 from nomad_simulations.outputs import Outputs, SCFOutputs
+from nomad_simulations.physical_property import PhysicalProperty
 from nomad_simulations.variables import Energy2 as Energy
 from nomad_simulations.properties import (
     ElectronicBandGap,

--- a/tests/test_band_gap.py
+++ b/tests/test_band_gap.py
@@ -41,11 +41,10 @@ class TestElectronicBandGap:
         """
         electronic_band_gap = ElectronicBandGap()
         assert (
-            electronic_band_gap.iri
+            electronic_band_gap.m_def.iri
             == 'http://fairmat-nfdi.eu/taxonomy/ElectronicBandGap'
         )
-        assert electronic_band_gap.name == 'ElectronicBandGap'
-        assert electronic_band_gap.rank == []
+        assert electronic_band_gap.m_def.rank == []
 
     @pytest.mark.parametrize(
         'value, result',

--- a/tests/test_energies.py
+++ b/tests/test_energies.py
@@ -30,9 +30,8 @@ class TestFermiLevel:
         Test the default quantities assigned when creating an instance of the `FermiLevel` class.
         """
         fermi_level = FermiLevel()
-        assert fermi_level.iri == 'http://fairmat-nfdi.eu/taxonomy/FermiLevel'
-        assert fermi_level.name == 'FermiLevel'
-        assert fermi_level.rank == []
+        assert fermi_level.m_def.iri == 'http://fairmat-nfdi.eu/taxonomy/FermiLevel'
+        assert fermi_level.m_def.rank == []
 
 
 class TestChemicalPotential:
@@ -47,8 +46,7 @@ class TestChemicalPotential:
         """
         chemical_potential = ChemicalPotential()
         assert (
-            chemical_potential.iri
+            chemical_potential.m_def.iri
             == 'http://fairmat-nfdi.eu/taxonomy/ChemicalPotential'
         )
-        assert chemical_potential.name == 'ChemicalPotential'
-        assert chemical_potential.rank == []
+        assert chemical_potential.m_def.rank == []

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -24,7 +24,8 @@ from nomad.datamodel import EntryArchive
 from . import logger
 from .conftest import generate_scf_electronic_band_gap_template
 
-from nomad_simulations.outputs import Outputs, ElectronicBandGap
+from nomad_simulations.outputs import Outputs
+from nomad_simulations.properties import ElectronicBandGap
 
 
 class TestOutputs:

--- a/tests/test_spectral_profile.py
+++ b/tests/test_spectral_profile.py
@@ -67,11 +67,10 @@ class TestElectronicDensityOfStates:
         """
         electronic_dos = ElectronicDensityOfStates()
         assert (
-            electronic_dos.iri
+            electronic_dos.m_def.iri
             == 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'
         )
-        assert electronic_dos.name == 'ElectronicDensityOfStates'
-        assert electronic_dos.rank == []
+        assert electronic_dos.m_def.rank == []
 
     def test_get_energy_points(self):
         """
@@ -262,9 +261,8 @@ class TestXASSpectra:
         Test the default quantities assigned when creating an instance of the `XASSpectra` class.
         """
         xas_spectra = XASSpectra()
-        assert xas_spectra.iri is None  # Add iri when available
-        assert xas_spectra.name == 'XASSpectra'
-        assert xas_spectra.rank == []
+        assert xas_spectra.m_def.iri is None  # TODO add iri when available
+        assert xas_spectra.m_def.rank == []
 
     @pytest.mark.parametrize(
         'xanes_energies, exafs_energies, xas_values',


### PR DESCRIPTION
I was wrongly mixing concepts for quantities and definitions. After talking with Area D, I decided to move `iri` and `rank` to `m_def` at the beginning of each property. This means that the `nomad/metainfo/metainfo.py` had to be modified to include these as part of the `class Section(Definition)` attributes.