### PR TITLE
 Move config tolerances to utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ requires-python = ">=3.9"
 dependencies = [
     "nomad-lab>=1.2.2dev578",
     "matid>=2.0.0.dev2",
+    'pydantic>=1.10.8,<2.0.0',
 ]
 
 [project.urls]

--- a/src/nomad_simulations/model_system.py
+++ b/src/nomad_simulations/model_system.py
@@ -33,7 +33,6 @@ from matid.classification.classifications import (
     Class3D,
 )  # pylint: disable=import-error
 
-from nomad import config
 from nomad.units import ureg
 from nomad.atomutils import Formula, get_normalized_wyckoff, search_aflow_prototype
 
@@ -43,7 +42,7 @@ from nomad.datamodel.metainfo.basesections import Entity, System
 from nomad.datamodel.metainfo.annotations import ELNAnnotation
 
 from .atoms_state import AtomsState
-from .utils import get_sibling_section, is_not_representative
+from .utils import get_sibling_section, is_not_representative, config
 
 
 class GeometricSpace(Entity):
@@ -547,7 +546,7 @@ class Symmetry(ArchiveSection):
         try:
             ase_atoms = original_atomic_cell.to_ase_atoms(logger)
             symmetry_analyzer = SymmetryAnalyzer(
-                ase_atoms, symmetry_tol=config.normalize.symmetry_tolerance
+                ase_atoms, symmetry_tol=config.symmetry_tolerance
             )
         except ValueError as e:
             logger.debug(
@@ -919,14 +918,11 @@ class ModelSystem(System):
         """
         classification = None
         system_type, dimensionality = self.type, self.dimensionality
-        if (
-            len(ase_atoms)
-            <= config.normalize.system_classification_with_clusters_threshold
-        ):
+        if len(ase_atoms) <= config.system_classification_with_clusters_threshold:
             try:
                 classifier = Classifier(
                     radii='covalent',
-                    cluster_threshold=config.normalize.cluster_threshold,
+                    cluster_threshold=config.cluster_threshold,
                 )
                 classification = classifier.classify(ase_atoms)
             except Exception as e:

--- a/src/nomad_simulations/properties/spectral_profile.py
+++ b/src/nomad_simulations/properties/spectral_profile.py
@@ -21,10 +21,9 @@ from structlog.stdlib import BoundLogger
 from typing import Optional, List, Dict
 import pint
 
-from nomad import config
 from nomad.metainfo import Quantity, SubSection, Section, Context
 
-from ..utils import get_sibling_section
+from ..utils import get_sibling_section, config
 from ..physical_property import PhysicalProperty
 from ..variables import Energy2 as Energy
 from ..atoms_state import AtomsState, OrbitalsState
@@ -251,8 +250,8 @@ class ElectronicDensityOfStates(DOSProfile):
             self.m_cache['lowest_occupied_energy'] = lowest_occupied_energy
 
         # Set thresholds for the energies and values
-        energy_threshold = config.normalize.band_structure_energy_tolerance
-        value_threshold = 1e-8  # The DOS value that is considered to be zero
+        energy_tolerance = config.dos_energy_tolerance
+        value_threshold = config.dos_value_threshold
 
         # Check that the closest `energies` to the energy reference is not too far away.
         # If it is very far away, normalization may be very inaccurate and we do not report it.
@@ -262,7 +261,7 @@ class ElectronicDensityOfStates(DOSProfile):
         fermi_energy_closest = energies[fermi_idx]
         distance = np.abs(fermi_energy_closest - eref)
         single_peak_fermi = False
-        if distance.magnitude <= energy_threshold:
+        if distance.magnitude <= energy_tolerance:
             # See if there are zero values close below the energy reference.
             idx = fermi_idx
             idx_descend = fermi_idx
@@ -272,7 +271,7 @@ class ElectronicDensityOfStates(DOSProfile):
                     energy_distance = np.abs(eref - energies[idx])
                 except IndexError:
                     break
-                if energy_distance.magnitude > energy_threshold:
+                if energy_distance.magnitude > energy_tolerance:
                     break
                 if value <= value_threshold:
                     idx_descend = idx
@@ -288,7 +287,7 @@ class ElectronicDensityOfStates(DOSProfile):
                     energy_distance = np.abs(eref - energies[idx])
                 except IndexError:
                     break
-                if energy_distance.magnitude > energy_threshold:
+                if energy_distance.magnitude > energy_tolerance:
                     break
                 if value <= value_threshold:
                     idx_ascend = idx

--- a/src/nomad_simulations/utils/__init__.py
+++ b/src/nomad_simulations/utils/__init__.py
@@ -17,3 +17,6 @@
 # limitations under the License.
 
 from .utils import get_sibling_section, RussellSaundersState, is_not_representative
+from .config_tolerances import ConfigTolerances
+
+config = ConfigTolerances()

--- a/src/nomad_simulations/utils/config_tolerances.py
+++ b/src/nomad_simulations/utils/config_tolerances.py
@@ -1,0 +1,55 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pydantic import BaseModel, Field
+
+
+class ConfigTolerances(BaseModel):
+    dos_value_threshold: float = Field(
+        1e-8,
+        description="""Threshold value at which the density of states (DOS) values are considered to be zero.""",
+    )
+
+    dos_energy_tolerance: float = Field(
+        8.01088e-21,
+        description="""Tolerance for the energies in the density of states (DOS) to compare with: $ (value - tolerance) <= value <= (value + tolerance) $""",
+    )
+
+    band_structure_energy_tolerance: float = Field(
+        8.01088e-21,
+        description="""Tolerance for the energies in the band structure to compare with: $ (value - tolerance) <= value <= (value + tolerance) $""",
+    )
+
+    k_space_precision: float = Field(
+        150000000.0,
+        description="""Precision be used when comparing the k-space values.""",
+    )
+
+    cluster_threshold: float = Field(
+        2.5, description="""Threshold used when clustering."""
+    )
+
+    system_classification_with_clusters_threshold: int = Field(
+        64,
+        description="""Threshold used when classifying the system with clusters.""",
+    )
+
+    symmetry_tolerance: float = Field(
+        0.1, description="""Tolerance used when comparing the symmetry."""
+    )


### PR DESCRIPTION
Hi @ladinesa 

I moved some of the config.normalize values to here, as the normalization will now be contained in the datamodel. For now, I only added the relevant config values found in default.yaml in NOMAD, but this has to be extended when needed in normalization.

What do you think?

Closes #65 