### PR TITLE
Add `subroutine_name_internal` quantity

### DIFF
--- a/src/nomad_simulations/schema_packages/general.py
+++ b/src/nomad_simulations/schema_packages/general.py
@@ -116,6 +116,18 @@ class Program(Entity):
         a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
+    subroutine_name_internal = Quantity(
+        type=str,
+        description="""
+        Specifies the name of the subroutine of the program at large.
+        This only applies when the routine produced (almost) all of the output,
+        so the naming is representative. This naming is mostly meant for users
+        who are familiar with the program's structure.
+        """,
+        a_eln=ELNAnnotation(component='StringEditQuantity'),
+    )
+
+
     compilation_host = Quantity(
         type=str,
         description="""


### PR DESCRIPTION
A participant of the spectra parser hackathon (Matyas Novak - SPR-KKR) asked about naming sub-programs / routines / executables in code. When a routine or executable is sufficiently standalone, it might be useful to identify it.

Still, `program.name` is not the place for that, as casual users would not be familiar with the subroutines. I therefore added it as a new quantity.