### PR TITLE
Extend equalities with comparison

### DIFF
--- a/src/nomad_simulations/schema_packages/__init__.py
+++ b/src/nomad_simulations/schema_packages/__init__.py
@@ -31,8 +31,8 @@ class NOMADSimulationsEntryPoint(SchemaPackageEntryPoint):
         description='Limite of the number of atoms in the unit cell to be treated for the system type classification from MatID to work. This is done to avoid overhead of the package.',
     )
     equal_cell_positions_tolerance: float = Field(
-        1e-12,
-        description='Tolerance (in meters) for the cell positions to be considered equal.',
+        12,
+        description='Decimal order or tolerance (in meters) for comparing cell positions.',
     )
 
     def load(self):

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -225,25 +225,25 @@ class GeometricSpace(Entity):
             return
 
 
+def _check_implemented(func: 'Callable'):
+    """
+    Decorator to restrict the comparison functions to the same class.
+    """
+
+    def wrapper(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return func(self, other)
+
+    return wrapper
+
+
 class PartialOrderElement:
     def __init__(self, representative_variable):
         self.representative_variable = representative_variable
 
     def __hash__(self):
         return self.representative_variable.__hash__()
-
-    @staticmethod
-    def _check_implemented(func: 'Callable'):
-        """
-        Decorator to restrict the comparison functions to the same class.
-        """
-
-        def wrapper(self, other):
-            if not isinstance(other, self.__class__):
-                return NotImplemented
-            return func(self, other)
-
-        return wrapper
 
     @_check_implemented
     def __eq__(self, other):
@@ -398,7 +398,7 @@ class Cell(GeometricSpace):
 
     def is_ne_cell(self, other) -> bool:
         # this does not hold in general, but here we use finite sets
-        return (not self.is_equal_cell(other))
+        return not self.is_equal_cell(other)
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
@@ -644,7 +644,10 @@ class Symmetry(ArchiveSection):
     )
 
     def resolve_analyzed_atomic_cell(
-        self, symmetry_analyzer: 'SymmetryAnalyzer', cell_type: str, logger: 'BoundLogger'
+        self,
+        symmetry_analyzer: 'SymmetryAnalyzer',
+        cell_type: str,
+        logger: 'BoundLogger',
     ) -> 'Optional[AtomicCell]':
         """
         Resolves the `AtomicCell` section from the `SymmetryAnalyzer` object and the cell_type

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -221,7 +221,7 @@ class GeometricSpace(Entity):
             return
 
 
-class PartialOrderBit:
+class PartialOrderElement:
     def __init__(self, representative_variable):
         self.representative_variable = representative_variable
 
@@ -257,7 +257,7 @@ class PartialOrderBit:
     # __ne__ assumes that usage in a finite set with its comparison definitions
 
 
-class HashedPositions(PartialOrderBit):
+class HashedPositions(PartialOrderElement):
     # `representative_variable` is a `pint.Quantity` object
 
     def __hash__(self):
@@ -274,6 +274,8 @@ class HashedPositions(PartialOrderBit):
 
     def __eq__(self, other):
         """Equality as defined between HashedPositions."""
+        if self.representative_variable is None or other.representative_variable is None:
+            return NotImplemented
         return np.allclose(self.representative_variable, other.representative_variable)
 
 
@@ -451,7 +453,7 @@ class AtomicCell(Cell):
     def _generate_comparer(positions: 'pint.Quantity', atoms_states: 'list[AtomsState]') -> tuple:
         # presumes `atoms_state` mapping 1-to-1 with `positions` and conserves the order
         return (
-            (HashedPositions(pos), PartialOrderBit(st.chemical_symbol))
+            (HashedPositions(pos), PartialOrderElement(st.chemical_symbol))
             for pos, st in zip(positions, atoms_states)
         )
 

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -43,7 +43,7 @@ from nomad.units import ureg
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from typing import Callable, Optional, Any
+    from typing import Any, Callable, Optional
 
     import pint
     from nomad.datamodel.datamodel import EntryArchive

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -233,7 +233,7 @@ class PartialOrderElement:
         return self.representative_variable.__hash__()
 
     @staticmethod
-    def _check_implemented(func: Callable):
+    def _check_implemented(func: 'Callable'):
         """
         Decorator to restrict the comparison functions to the same class.
         """
@@ -370,7 +370,7 @@ class Cell(GeometricSpace):
     )
 
     @staticmethod
-    def _generate_comparer(obj) -> Generator[Any, None, None]:
+    def _generate_comparer(obj: 'Cell') -> 'Generator[Any, None, None]':
         try:
             return ((HashedPositions(pos)) for pos in obj.positions)
         except AttributeError:
@@ -398,7 +398,7 @@ class Cell(GeometricSpace):
 
     def is_ne_cell(self, other) -> bool:
         # this does not hold in general, but here we use finite sets
-        return not self.is_equal_cell(other)
+        return (not self.is_equal_cell(other))
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
@@ -444,9 +444,7 @@ class AtomicCell(Cell):
         self.name = self.m_def.name
 
     @staticmethod
-    def _generate_comparer(
-        obj,
-    ) -> Generator[Any, None, None]:
+    def _generate_comparer(obj: 'AtomicCell') -> 'Generator[Any, None, None]':
         # presumes `atoms_state` mapping 1-to-1 with `positions` and conserves the order
         try:
             return (
@@ -456,7 +454,7 @@ class AtomicCell(Cell):
         except AttributeError:
             raise NotImplementedError
 
-    def to_ase_atoms(self, logger: 'BoundLogger') -> Optional[ase.Atoms]:
+    def to_ase_atoms(self, logger: 'BoundLogger') -> 'Optional[ase.Atoms]':
         """
         Generates an ASE Atoms object with the most basic information from the parsed `AtomicCell`
         section (labels, periodic_boundary_conditions, positions, and lattice_vectors).
@@ -646,8 +644,8 @@ class Symmetry(ArchiveSection):
     )
 
     def resolve_analyzed_atomic_cell(
-        self, symmetry_analyzer: SymmetryAnalyzer, cell_type: str, logger: 'BoundLogger'
-    ) -> Optional[AtomicCell]:
+        self, symmetry_analyzer: 'SymmetryAnalyzer', cell_type: str, logger: 'BoundLogger'
+    ) -> 'Optional[AtomicCell]':
         """
         Resolves the `AtomicCell` section from the `SymmetryAnalyzer` object and the cell_type
         (primitive or conventional).
@@ -691,8 +689,8 @@ class Symmetry(ArchiveSection):
         return atomic_cell
 
     def resolve_bulk_symmetry(
-        self, original_atomic_cell: AtomicCell, logger: 'BoundLogger'
-    ) -> tuple[Optional[AtomicCell], Optional[AtomicCell]]:
+        self, original_atomic_cell: 'AtomicCell', logger: 'BoundLogger'
+    ) -> 'tuple[Optional[AtomicCell], Optional[AtomicCell]]':
         """
         Resolves the symmetry of the material being simulated using MatID and the
         originally parsed data under original_atomic_cell. It generates two other

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
+import re
 from functools import lru_cache
 from hashlib import sha1
-import re
 from typing import TYPE_CHECKING, Optional
 
 import ase
@@ -42,16 +42,16 @@ from nomad.metainfo import MEnum, Quantity, SectionProxy, SubSection
 from nomad.units import ureg
 
 if TYPE_CHECKING:
+    import pint
     from nomad.datamodel.datamodel import EntryArchive
     from nomad.metainfo import Context, Section
-    import pint
     from structlog.stdlib import BoundLogger
 
 from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.utils import (
+    catch_not_implemented,
     get_sibling_section,
     is_not_representative,
-    catch_not_implemented,
 )
 
 configuration = config.get_plugin_entry_point(

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -274,7 +274,10 @@ class HashedPositions(PartialOrderElement):
 
     def __eq__(self, other):
         """Equality as defined between HashedPositions."""
-        if self.representative_variable is None or other.representative_variable is None:
+        if (
+            self.representative_variable is None
+            or other.representative_variable is None
+        ):
             return NotImplemented
         return np.allclose(self.representative_variable, other.representative_variable)
 
@@ -450,7 +453,9 @@ class AtomicCell(Cell):
         self.name = self.m_def.name
 
     @staticmethod
-    def _generate_comparer(positions: 'pint.Quantity', atoms_states: 'list[AtomsState]') -> tuple:
+    def _generate_comparer(
+        positions: 'pint.Quantity', atoms_states: 'list[AtomsState]'
+    ) -> tuple:
         # presumes `atoms_state` mapping 1-to-1 with `positions` and conserves the order
         return (
             (HashedPositions(pos), PartialOrderElement(st.chemical_symbol))

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -19,7 +19,7 @@
 import re
 from functools import lru_cache
 from hashlib import sha1
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import ase
 import numpy as np
@@ -42,6 +42,9 @@ from nomad.metainfo import MEnum, Quantity, SectionProxy, SubSection
 from nomad.units import ureg
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import Callable, Optional
+
     import pint
     from nomad.datamodel.datamodel import EntryArchive
     from nomad.metainfo import Context, Section
@@ -229,7 +232,7 @@ class PartialOrderElement:
     def __hash__(self):
         return self.representative_variable.__hash__()
 
-    def _check_implemented(func: callable):
+    def _check_implemented(func: Callable):
         """
         Decorator to restrict the comparison functions to the same class.
         """
@@ -304,7 +307,7 @@ class Cell(GeometricSpace):
         type=MEnum('original', 'primitive', 'conventional'),
         description="""
         Representation type of the cell structure. It might be:
-            - 'original' as in origanally parsed,
+            - 'original' as in originally parsed,
             - 'primitive' as the primitive unit cell,
             - 'conventional' as the conventional cell used for referencing.
         """,
@@ -366,7 +369,7 @@ class Cell(GeometricSpace):
     )
 
     @staticmethod
-    def _generate_comparer(obj) -> tuple:
+    def _generate_comparer(obj) -> Generator[HashedPositions, None, None]:
         try:
             return (HashedPositions(pos) for pos in obj.positions)
         except AttributeError:
@@ -440,7 +443,9 @@ class AtomicCell(Cell):
         self.name = self.m_def.name
 
     @staticmethod
-    def _generate_comparer(obj) -> tuple:
+    def _generate_comparer(
+        obj,
+    ) -> Generator[HashedPositions, PartialOrderElement, None, None]:
         # presumes `atoms_state` mapping 1-to-1 with `positions` and conserves the order
         try:
             return (

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -43,7 +43,7 @@ from nomad.units import ureg
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from typing import Callable, Optional
+    from typing import Callable, Optional, Any
 
     import pint
     from nomad.datamodel.datamodel import EntryArchive
@@ -232,6 +232,7 @@ class PartialOrderElement:
     def __hash__(self):
         return self.representative_variable.__hash__()
 
+    @staticmethod
     def _check_implemented(func: Callable):
         """
         Decorator to restrict the comparison functions to the same class.
@@ -369,9 +370,9 @@ class Cell(GeometricSpace):
     )
 
     @staticmethod
-    def _generate_comparer(obj) -> Generator[HashedPositions, None, None]:
+    def _generate_comparer(obj) -> Generator[Any, None, None]:
         try:
-            return (HashedPositions(pos) for pos in obj.positions)
+            return ((HashedPositions(pos)) for pos in obj.positions)
         except AttributeError:
             raise NotImplementedError
 
@@ -445,7 +446,7 @@ class AtomicCell(Cell):
     @staticmethod
     def _generate_comparer(
         obj,
-    ) -> Generator[HashedPositions, PartialOrderElement, None, None]:
+    ) -> Generator[Any, None, None]:
         # presumes `atoms_state` mapping 1-to-1 with `positions` and conserves the order
         try:
             return (

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -51,6 +51,7 @@ from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.utils import (
     get_sibling_section,
     is_not_representative,
+    catch_not_implemented,
 )
 
 configuration = config.get_plugin_entry_point(
@@ -367,45 +368,31 @@ class Cell(GeometricSpace):
     def _generate_comparer(positions: 'pint.Quantity') -> tuple:
         return (HashedPositions(pos) for pos in positions)
 
-    def _check_implemented(func: callable):
-        """
-        Decorator to default comparison functions outside the same class to `False`.
-        """
-        def wrapper(self, other):
-            if not isinstance(other, self.__class__):
-                return False  # ? should this throw an error instead?
-            try:
-                return func(self, other)
-            except (TypeError, NotImplementedError):
-                return False
-
-        return wrapper
-
-    @_check_implemented
+    @catch_not_implemented
     def is_lt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) < set(
             self._generate_comparer(other.positions)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_gt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) > set(
             self._generate_comparer(other.positions)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_le_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) <= set(
             self._generate_comparer(other.positions)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_ge_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) >= set(
             self._generate_comparer(other.positions)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_equal_cell(self, other) -> bool:  # TODO: improve naming
         return set(self._generate_comparer(self.positions)) == set(
             self._generate_comparer(other.positions)
@@ -468,7 +455,7 @@ class AtomicCell(Cell):
             for pos, st in zip(positions, atoms_states)
         )
 
-    def _check_implemented(func: callable):
+    def catch_not_implemented(func: callable):
         """
         Decorator to default comparison functions outside the same class to `False`.
         """
@@ -482,31 +469,31 @@ class AtomicCell(Cell):
 
         return wrapper
 
-    @_check_implemented
+    @catch_not_implemented
     def is_lt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) < set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_gt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) > set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_le_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) <= set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_ge_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) >= set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
-    @_check_implemented
+    @catch_not_implemented
     def is_equal_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) == set(
             self._generate_comparer(other.positions, other.atoms_state)

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -376,38 +376,38 @@ class Cell(GeometricSpace):
         return wrapper
 
     @_check_implemented
-    def __lt__(self, other) -> bool:
+    def is_lt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) < set(
             self._generate_comparer(other.positions)
         )
 
     @_check_implemented
-    def __gt__(self, other) -> bool:
+    def is_gt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) > set(
             self._generate_comparer(other.positions)
         )
 
     @_check_implemented
-    def __le__(self, other) -> bool:
+    def is_le_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) <= set(
             self._generate_comparer(other.positions)
         )
 
     @_check_implemented
-    def __ge__(self, other) -> bool:
+    def is_ge_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions)) >= set(
             self._generate_comparer(other.positions)
         )
 
     @_check_implemented
-    def __eq__(self, other) -> bool:
+    def is_equal_cell(self, other) -> bool:  # TODO: improve naming
         return set(self._generate_comparer(self.positions)) == set(
             self._generate_comparer(other.positions)
         )
 
     def __ne__(self, other) -> bool:
         # this does not hold in general, but here we use finite sets
-        return not self.__eq__(other)
+        return not self.is_equal_cell(other)
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
@@ -474,31 +474,31 @@ class AtomicCell(Cell):
         return wrapper
 
     @_check_implemented
-    def __lt__(self, other) -> bool:
+    def is_lt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) < set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
     @_check_implemented
-    def __gt__(self, other) -> bool:
+    def is_gt_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) > set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
     @_check_implemented
-    def __le__(self, other) -> bool:
+    def is_le_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) <= set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
     @_check_implemented
-    def __ge__(self, other) -> bool:
+    def is_ge_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) >= set(
             self._generate_comparer(other.positions, other.atoms_state)
         )
 
     @_check_implemented
-    def __eq__(self, other) -> bool:
+    def is_equal_cell(self, other) -> bool:
         return set(self._generate_comparer(self.positions, self.atoms_state)) == set(
             self._generate_comparer(other.positions, other.atoms_state)
         )

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -229,6 +229,9 @@ class PartialOrderElement:
         return self.representative_variable.__hash__()
 
     def _check_implemented(func: callable):
+        """
+        Decorator to restrict the comparison functions to the same class.
+        """
         def wrapper(self, other):
             if not isinstance(other, self.__class__):
                 return NotImplemented
@@ -365,6 +368,9 @@ class Cell(GeometricSpace):
         return (HashedPositions(pos) for pos in positions)
 
     def _check_implemented(func: callable):
+        """
+        Decorator to default comparison functions outside the same class to `False`.
+        """
         def wrapper(self, other):
             if not isinstance(other, self.__class__):
                 return False  # ? should this throw an error instead?
@@ -405,7 +411,7 @@ class Cell(GeometricSpace):
             self._generate_comparer(other.positions)
         )
 
-    def __ne__(self, other) -> bool:
+    def is_ne_cell(self, other) -> bool:
         # this does not hold in general, but here we use finite sets
         return not self.is_equal_cell(other)
 
@@ -463,6 +469,9 @@ class AtomicCell(Cell):
         )
 
     def _check_implemented(func: callable):
+        """
+        Decorator to default comparison functions outside the same class to `False`.
+        """
         def wrapper(self, other):
             if not isinstance(other, self.__class__):
                 return False  # ? should this throw an error instead?

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -454,6 +454,26 @@ class AtomicCell(Cell):
         except AttributeError:
             raise NotImplementedError
 
+    def get_chemical_symbols(self, logger: 'BoundLogger') -> list[str]:
+        """
+        Get the chemical symbols of the atoms in the atomic cell. These are defined on `atoms_state[*].chemical_symbol`.
+        Args:
+            logger (BoundLogger): The logger to log messages.
+
+        Returns:
+            list: The list of chemical symbols of the atoms in the atomic cell.
+        """
+        if not self.atoms_state:
+            return []
+
+        chemical_symbols = []
+        for atom_state in self.atoms_state:
+            if not atom_state.chemical_symbol:
+                logger.warning('Could not find `AtomsState[*].chemical_symbol`.')
+                return []
+            chemical_symbols.append(atom_state.chemical_symbol)
+        return chemical_symbols
+
     def to_ase_atoms(self, logger: 'BoundLogger') -> 'Optional[ase.Atoms]':
         """
         Generates an ASE Atoms object with the most basic information from the parsed `AtomicCell`

--- a/src/nomad_simulations/schema_packages/utils/__init__.py
+++ b/src/nomad_simulations/schema_packages/utils/__init__.py
@@ -1,8 +1,8 @@
 from .utils import (
     RussellSaundersState,
+    catch_not_implemented,
     get_composition,
     get_sibling_section,
     get_variables,
     is_not_representative,
-    catch_not_implemented,
 )

--- a/src/nomad_simulations/schema_packages/utils/__init__.py
+++ b/src/nomad_simulations/schema_packages/utils/__init__.py
@@ -4,4 +4,5 @@ from .utils import (
     get_sibling_section,
     get_variables,
     is_not_representative,
+    catch_not_implemented,
 )

--- a/src/nomad_simulations/schema_packages/utils/utils.py
+++ b/src/nomad_simulations/schema_packages/utils/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from nomad.config import config
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Callable, Optional
 
     from nomad.datamodel.data import ArchiveSection
     from structlog.stdlib import BoundLogger
@@ -156,7 +156,7 @@ def get_composition(children_names: 'list[str]') -> str:
     return formula if formula else None
 
 
-def catch_not_implemented(func: callable):
+def catch_not_implemented(func: Callable):
     """
     Decorator to default comparison functions outside the same class to `False`.
     """

--- a/src/nomad_simulations/schema_packages/utils/utils.py
+++ b/src/nomad_simulations/schema_packages/utils/utils.py
@@ -160,6 +160,7 @@ def catch_not_implemented(func: callable):
     """
     Decorator to default comparison functions outside the same class to `False`.
     """
+
     def wrapper(self, other):
         if not isinstance(other, self.__class__):
             return False  # ? should this throw an error instead?

--- a/src/nomad_simulations/schema_packages/utils/utils.py
+++ b/src/nomad_simulations/schema_packages/utils/utils.py
@@ -156,12 +156,12 @@ def get_composition(children_names: 'list[str]') -> str:
     return formula if formula else None
 
 
-def catch_not_implemented(func: Callable):
+def catch_not_implemented(func: 'Callable') -> 'Callable':
     """
     Decorator to default comparison functions outside the same class to `False`.
     """
 
-    def wrapper(self, other):
+    def wrapper(self, other) -> bool:
         if not isinstance(other, self.__class__):
             return False  # ? should this throw an error instead?
         try:

--- a/src/nomad_simulations/schema_packages/utils/utils.py
+++ b/src/nomad_simulations/schema_packages/utils/utils.py
@@ -154,3 +154,18 @@ def get_composition(children_names: 'list[str]') -> str:
     children_count_tup = np.unique(children_names, return_counts=True)
     formula = ''.join([f'{name}({count})' for name, count in zip(*children_count_tup)])
     return formula if formula else None
+
+
+def catch_not_implemented(func: callable):
+    """
+    Decorator to default comparison functions outside the same class to `False`.
+    """
+    def wrapper(self, other):
+        if not isinstance(other, self.__class__):
+            return False  # ? should this throw an error instead?
+        try:
+            return func(self, other)
+        except (TypeError, NotImplementedError):
+            return False
+
+    return wrapper

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -102,11 +102,13 @@ class TestAtomicCell:
                 Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
                 False,
             ),  # one atomic cell and another cell (missing chemical symbols)
-            (
-                AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                False,
-            ),  # missing chemical symbols
+            #(
+            #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            #    False,
+            #),  # missing chemical symbols
+            # ND: the comparison will now return an error here
+            #     handling a case that should be resolved by the normalizer falls outside its scope
             (
                 AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -59,7 +59,8 @@ class TestCell:
         """
         Test the `is_equal_cell` methods of `Cell`.
         """
-        assert cell_1.is_equal_cell(other=cell_2) == result
+        assert cell_1.is_equal_cell(cell_2) == result
+        assert cell_1.is_ne_cell(cell_2) != result
 
 
 class TestAtomicCell:
@@ -252,12 +253,12 @@ class TestAtomicCell:
         """
         Test the `is_equal_cell` methods of `AtomicCell`.
         """
-        assert (cell_1 < cell_2) == result['lt']
-        assert (cell_1 > cell_2) == result['gt']
-        assert (cell_1 <= cell_2) == (result['lt'] or result['eq'])
-        assert (cell_1 >= cell_2) == (result['gt'] or result['eq'])
-        assert (cell_1 == cell_2) == result['eq']
-        assert (cell_1 != cell_2) != (result[0] and result[1])
+        assert cell_1.is_lt_cell(cell_2) == result['lt']
+        assert cell_1.is_gt_cell(cell_2) == result['gt']
+        assert cell_1.is_le_cell(cell_2) == (result['lt'] or result['eq'])
+        assert cell_1.is_ge_cell(cell_2) == (result['gt'] or result['eq'])
+        assert cell_1.is_equal_cell(cell_2) == result['eq']
+        assert cell_1.is_ne_cell(cell_2) != (result[0] and result[1])
 
     @pytest.mark.parametrize(
         'chemical_symbols, atomic_numbers, formula, lattice_vectors, positions, periodic_boundary_conditions',

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -17,52 +17,6 @@ from nomad_simulations.schema_packages.model_system import (
 from . import logger
 from .conftest import generate_atomic_cell
 
-
-class TestCell:
-    """
-    Test the `Cell` section defined in model_system.py
-    """
-
-    @pytest.mark.parametrize(
-        'cell_1, cell_2, result',
-        [
-            (Cell(), None, False),  # one cell is None
-            (Cell(), Cell(), False),  # both cells are empty
-            (
-                Cell(positions=[[1, 0, 0]]),
-                Cell(),
-                False,
-            ),  # one cell has positions, the other is empty
-            (
-                Cell(positions=[[1, 0, 0], [0, 1, 0]]),
-                Cell(positions=[[1, 0, 0]]),
-                False,
-            ),  # length mismatch
-            (
-                Cell(positions=[[1, 0, 0], [0, 1, 0]]),
-                Cell(positions=[[1, 0, 0], [0, -1, 0]]),
-                False,
-            ),  # different positions
-            (
-                Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                True,
-            ),  # same ordered positions
-            (
-                Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                Cell(positions=[[1, 0, 0], [0, 0, 1], [0, 1, 0]]),
-                True,
-            ),  # different ordered positions but same cell
-        ],
-    )
-    def test_is_equal_cell(self, cell_1: Cell, cell_2: Cell, result: bool):
-        """
-        Test the `is_equal_cell` methods of `Cell`.
-        """
-        assert cell_1.is_equal_cell(cell_2) == result
-        assert cell_1.is_ne_cell(cell_2) != result
-
-
 class TestAtomicCell:
     """
     Test the `AtomicCell`, `Cell` and `GeometricSpace` classes defined in model_system.py
@@ -251,14 +205,14 @@ class TestAtomicCell:
     )
     def test_partial_order(self, cell_1: Cell, cell_2: Cell, result: bool):
         """
-        Test the `is_equal_cell` methods of `AtomicCell`.
+        Test the comparison operators of `Cell` and `AtomicCell`.
         """
         assert cell_1.is_lt_cell(cell_2) == result['lt']
         assert cell_1.is_gt_cell(cell_2) == result['gt']
         assert cell_1.is_le_cell(cell_2) == (result['lt'] or result['eq'])
         assert cell_1.is_ge_cell(cell_2) == (result['gt'] or result['eq'])
         assert cell_1.is_equal_cell(cell_2) == result['eq']
-        assert cell_1.is_ne_cell(cell_2) != (result[0] and result[1])
+        assert cell_1.is_ne_cell(cell_2) == (not result['eq'])
 
     @pytest.mark.parametrize(
         'chemical_symbols, atomic_numbers, formula, lattice_vectors, positions, periodic_boundary_conditions',

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -107,16 +107,16 @@ class TestAtomicCell:
                 Cell(positions=[[1, 0, 0], [0, 0, 1], [0, 1, 0]]),
                 {'lt': False, 'gt': False, 'eq': True},
             ),  # different ordered positions but same cell
-            #(
+            # (
             #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
             #    Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
             #    False,
-            #),  # one atomic cell and another cell (missing chemical symbols)
-            #(
+            # ),  # one atomic cell and another cell (missing chemical symbols)
+            # (
             #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
             #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
             #    False,
-            #),  # missing chemical symbols
+            # ),  # missing chemical symbols
             # ND: the comparison will now return an error here
             #     handling a case that should be resolved by the normalizer falls outside its scope
             (
@@ -133,7 +133,7 @@ class TestAtomicCell:
                     ],
                 ),
                 {'lt': False, 'gt': False, 'eq': False},
-            ), # chemical symbols are treated as the fundamental set elements
+            ),  # chemical symbols are treated as the fundamental set elements
             (
                 AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
@@ -151,7 +151,7 @@ class TestAtomicCell:
                     ],
                 ),
                 {'lt': False, 'gt': True, 'eq': False},
-            ), # one is a subset of the other
+            ),  # one is a subset of the other
             (
                 AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0]],
@@ -159,7 +159,8 @@ class TestAtomicCell:
                         AtomsState(chemical_symbol='H'),
                         AtomsState(chemical_symbol='H'),
                     ],
-                ),AtomicCell(
+                ),
+                AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
                     atoms_state=[
                         AtomsState(chemical_symbol='H'),
@@ -168,7 +169,7 @@ class TestAtomicCell:
                     ],
                 ),
                 {'lt': True, 'gt': False, 'eq': False},
-            ), # one is a subset of the other
+            ),  # one is a subset of the other
             (
                 AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -17,6 +17,7 @@ from nomad_simulations.schema_packages.model_system import (
 from . import logger
 from .conftest import generate_atomic_cell
 
+
 class TestAtomicCell:
     """
     Test the `AtomicCell`, `Cell` and `GeometricSpace` classes defined in model_system.py
@@ -125,6 +126,24 @@ class TestAtomicCell:
                 ),
                 {'lt': True, 'gt': False, 'eq': False},
             ),  # one is a subset of the other
+            (
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                {'lt': False, 'gt': False, 'eq': False},
+            ),
             (
                 AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -70,38 +70,48 @@ class TestAtomicCell:
     @pytest.mark.parametrize(
         'cell_1, cell_2, result',
         [
-            (Cell(), None, False),  # one cell is None
-            (Cell(), Cell(), False),  # both cells are empty
+            (Cell(), None, {'lt': False, 'gt': False, 'eq': False}),  # one cell is None
+            # (Cell(), Cell(), False),  # both cells are empty
+            # (
+            #    Cell(positions=[[1, 0, 0]]),
+            #    Cell(),
+            #    False,
+            # ),  # one cell has positions, the other is empty
             (
                 Cell(positions=[[1, 0, 0]]),
-                Cell(),
-                False,
-            ),  # one cell has positions, the other is empty
+                Cell(positions=[[2, 0, 0]]),
+                {'lt': False, 'gt': False, 'eq': False},
+            ),  # position vectors are treated as the fundamental set elements
             (
                 Cell(positions=[[1, 0, 0], [0, 1, 0]]),
                 Cell(positions=[[1, 0, 0]]),
-                False,
-            ),  # length mismatch
+                {'lt': False, 'gt': True, 'eq': False},
+            ),  # one is a subset of the other
+            (
+                Cell(positions=[[1, 0, 0]]),
+                Cell(positions=[[1, 0, 0], [0, 1, 0]]),
+                {'lt': True, 'gt': False, 'eq': False},
+            ),  # one is a subset of the other
             (
                 Cell(positions=[[1, 0, 0], [0, 1, 0]]),
                 Cell(positions=[[1, 0, 0], [0, -1, 0]]),
-                False,
+                {'lt': False, 'gt': False, 'eq': False},
             ),  # different positions
             (
                 Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
                 Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                True,
+                {'lt': False, 'gt': False, 'eq': True},
             ),  # same ordered positions
             (
                 Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
                 Cell(positions=[[1, 0, 0], [0, 0, 1], [0, 1, 0]]),
-                True,
+                {'lt': False, 'gt': False, 'eq': True},
             ),  # different ordered positions but same cell
-            (
-                AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                False,
-            ),  # one atomic cell and another cell (missing chemical symbols)
+            #(
+            #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            #    Cell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            #    False,
+            #),  # one atomic cell and another cell (missing chemical symbols)
             #(
             #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
             #    AtomicCell(positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
@@ -111,6 +121,56 @@ class TestAtomicCell:
             #     handling a case that should be resolved by the normalizer falls outside its scope
             (
                 AtomicCell(
+                    positions=[[1, 0, 0]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                AtomicCell(
+                    positions=[[1, 0, 0]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                    ],
+                ),
+                {'lt': False, 'gt': False, 'eq': False},
+            ), # chemical symbols are treated as the fundamental set elements
+            (
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                    ],
+                ),
+                {'lt': False, 'gt': True, 'eq': False},
+            ), # one is a subset of the other
+            (
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                    ],
+                ),AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                {'lt': True, 'gt': False, 'eq': False},
+            ), # one is a subset of the other
+            (
+                AtomicCell(
                     positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
                     atoms_state=[
                         AtomsState(chemical_symbol='H'),
@@ -126,7 +186,7 @@ class TestAtomicCell:
                         AtomsState(chemical_symbol='O'),
                     ],
                 ),
-                True,
+                {'lt': False, 'gt': False, 'eq': True},
             ),  # same ordered positions and chemical symbols
             (
                 AtomicCell(
@@ -145,7 +205,7 @@ class TestAtomicCell:
                         AtomsState(chemical_symbol='O'),
                     ],
                 ),
-                False,
+                {'lt': False, 'gt': False, 'eq': False},
             ),  # same ordered positions but different chemical symbols
             (
                 AtomicCell(
@@ -164,38 +224,39 @@ class TestAtomicCell:
                         AtomsState(chemical_symbol='H'),
                     ],
                 ),
-                True,
-            ),  # different ordered positions but same chemical symbols
+                {'lt': False, 'gt': False, 'eq': True},
+            ),  # same position-symbol map, different overall order
+            (
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                AtomicCell(
+                    positions=[[1, 0, 0], [0, 0, 1], [0, 1, 0]],
+                    atoms_state=[
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='O'),
+                    ],
+                ),
+                {'lt': False, 'gt': False, 'eq': False},
+            ),  # different position-symbol map
         ],
     )
-    def test_is_equal_cell(self, cell_1: Cell, cell_2: Cell, result: bool):
+    def test_partial_order(self, cell_1: Cell, cell_2: Cell, result: bool):
         """
         Test the `is_equal_cell` methods of `AtomicCell`.
         """
-        assert cell_1.is_equal_cell(other=cell_2) == result
-
-    @pytest.mark.parametrize(
-        'atomic_cell, result',
-        [
-            (AtomicCell(), []),
-            (AtomicCell(atoms_state=[AtomsState(chemical_symbol='H')]), ['H']),
-            (
-                AtomicCell(
-                    atoms_state=[
-                        AtomsState(chemical_symbol='H'),
-                        AtomsState(chemical_symbol='Fe'),
-                        AtomsState(chemical_symbol='O'),
-                    ]
-                ),
-                ['H', 'Fe', 'O'],
-            ),
-        ],
-    )
-    def test_get_chemical_symbols(self, atomic_cell: AtomicCell, result: list[str]):
-        """
-        Test the `get_chemical_symbols` method of `AtomicCell`.
-        """
-        assert atomic_cell.get_chemical_symbols(logger=logger) == result
+        assert (cell_1 < cell_2) == result['lt']
+        assert (cell_1 > cell_2) == result['gt']
+        assert (cell_1 <= cell_2) == (result['lt'] or result['eq'])
+        assert (cell_1 >= cell_2) == (result['gt'] or result['eq'])
+        assert (cell_1 == cell_2) == result['eq']
+        assert (cell_1 != cell_2) != (result[0] and result[1])
 
     @pytest.mark.parametrize(
         'chemical_symbols, atomic_numbers, formula, lattice_vectors, positions, periodic_boundary_conditions',

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -222,7 +222,9 @@ class TestAtomicCell:
             ),  # different position-symbol map
         ],
     )
-    def test_partial_order(self, cell_1: Cell, cell_2: Cell, result: dict[str, bool]):
+    def test_partial_order(
+        self, cell_1: 'Cell', cell_2: 'Cell', result: dict[str, bool]
+    ):
         """
         Test the comparison operators of `Cell` and `AtomicCell`.
         """

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -222,7 +222,7 @@ class TestAtomicCell:
             ),  # different position-symbol map
         ],
     )
-    def test_partial_order(self, cell_1: Cell, cell_2: Cell, result: bool):
+    def test_partial_order(self, cell_1: Cell, cell_2: Cell, result: dict[str, bool]):
         """
         Test the comparison operators of `Cell` and `AtomicCell`.
         """


### PR DESCRIPTION
### Changes

This is an extension to commit 96f4a91, defining also `<`, `>`, `<=`, `<=` for `Cell` and `AtomicCell`.
It builds the definition up functor-wise, and introduces `PartialOrderElement` as the foundational comparison type, to power partial orders. Note that incomparable elements of the same class return `False` instead of `NotImplemented`.

### Background and motivation
 
@JFRudzinski knows this, but early on this year I've been working on sorting hierarchies like `ModelSystem`. This work wasn't merged due to incompleteness and changing priorities. The comparison metrics matched those applied in commit 96f4a91. The other operators are necessary for sorting, though.