### PR TITLE
Fix shape mismatch of bond_list in model_system

### DIFF
--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -1082,6 +1082,7 @@ class ModelSystem(System):
     # TODO improve description and add an example using the case in atom_indices
     bond_list = Quantity(
         type=np.int32,
+        shape=['*', 2],
         description="""
         List of pairs of atom indices corresponding to bonds (e.g., as defined by a force field)
         within this atoms_group.


### PR DESCRIPTION
The bond list is a list of lists or tuples with two elements each, containing atom indices. It was erroneously set to a scalar.