### PR TITLE
Remove editable annotations

### DIFF
--- a/docs/normalize.md
+++ b/docs/normalize.md
@@ -25,7 +25,7 @@ class Section1(ArchiveSection):
 class Section2(ArchiveSection):
     normalizer_level = 0
 
-    def normalize(self, achive, logger):
+    def normalize(self, archive, logger):
         super().normalize(archive, logger)
         # Some operations here or before `super().normalize(archive, logger)`
 
@@ -36,7 +36,7 @@ class ParentSection(ArchiveSection):
 
     sub_section_2 = SubSection(Section2.m_def, repeats=True)
 
-    def normalize(self, achive, logger):
+    def normalize(self, archive, logger):
         super().normalize(archive, logger)
         # Some operations here or before `super().normalize(archive, logger)`
 ```

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -308,7 +308,7 @@ class CoreHole(ArchiveSection):
         description="""
         Reference to the OrbitalsState section that is used as a basis to obtain the `CoreHole` section.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     n_excited_electrons = Quantity(
@@ -411,7 +411,7 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Value of the (intraorbital) Hubbard interaction
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     j_hunds_coupling = Quantity(
@@ -420,7 +420,7 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Value of the (interorbital) Hund's coupling.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     u_interorbital_interaction = Quantity(
@@ -430,7 +430,7 @@ class HubbardInteractions(ArchiveSection):
         Value of the (interorbital) Coulomb interaction. In rotational invariant systems,
         u_interorbital_interaction = u_interaction - 2 * j_hunds_coupling.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     j_local_exchange_interaction = Quantity(
@@ -439,7 +439,7 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Value of the exchange interaction. In rotational invariant systems, j_local_exchange_interaction = j_hunds_coupling.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     u_effective = Quantity(
@@ -474,7 +474,7 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Name of the double counting correction algorithm applied.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     def resolve_u_interactions(self, logger: 'BoundLogger') -> Optional[tuple]:
@@ -586,7 +586,7 @@ class AtomsState(Entity):
         Note: for `CoreHole` systems we do not consider the charge of the atom even if
         we do not store the final `OrbitalsState` where the electron was excited to.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     core_hole = SubSection(sub_section=CoreHole.m_def, repeats=False)

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -4,7 +4,6 @@ import ase
 import numpy as np
 import pint
 from nomad.datamodel.data import ArchiveSection
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.datamodel.metainfo.basesections import Entity
 from nomad.metainfo import MEnum, Quantity, SubSection
 from nomad.units import ureg

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -308,7 +308,6 @@ class CoreHole(ArchiveSection):
         description="""
         Reference to the OrbitalsState section that is used as a basis to obtain the `CoreHole` section.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     n_excited_electrons = Quantity(
@@ -411,7 +410,6 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Value of the (intraorbital) Hubbard interaction
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     j_hunds_coupling = Quantity(
@@ -420,7 +418,6 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Value of the (interorbital) Hund's coupling.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     u_interorbital_interaction = Quantity(
@@ -430,7 +427,6 @@ class HubbardInteractions(ArchiveSection):
         Value of the (interorbital) Coulomb interaction. In rotational invariant systems,
         u_interorbital_interaction = u_interaction - 2 * j_hunds_coupling.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     j_local_exchange_interaction = Quantity(
@@ -439,7 +435,6 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Value of the exchange interaction. In rotational invariant systems, j_local_exchange_interaction = j_hunds_coupling.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     u_effective = Quantity(
@@ -474,7 +469,6 @@ class HubbardInteractions(ArchiveSection):
         description="""
         Name of the double counting correction algorithm applied.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     def resolve_u_interactions(self, logger: 'BoundLogger') -> Optional[tuple]:
@@ -586,7 +580,6 @@ class AtomsState(Entity):
         Note: for `CoreHole` systems we do not consider the charge of the atom even if
         we do not store the final `OrbitalsState` where the electron was excited to.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     core_hole = SubSection(sub_section=CoreHole.m_def, repeats=False)

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -12,7 +12,6 @@ import numpy as np
 import pint
 from nomad import utils
 from nomad.datamodel.data import ArchiveSection
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.metainfo import MEnum, Quantity, SubSection
 from nomad.units import ureg
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -204,13 +204,6 @@ class AtomCenteredBasisSet(BasisSetComponent):
         sub_section=AtomCenteredFunction.m_def, repeats=True
     )  # TODO change name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-        # self.name = self.m_def.name
-        # TODO: set name based on basis functions
-        # ? use basis set names from Basis Set Exchange
-
-
 class APWBaseOrbital(ArchiveSection):
     """
     Abstract base section for (S)(L)APW and local orbital component wavefunctions.

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -57,7 +57,6 @@ class BasisSetComponent(ArchiveSection):
         description="""
         Reference to the section `AtomsState` specifying the localization of the basis set.
         """,
-        # a_eln=ELNAnnotation(components='ReferenceEditQuantity'),
     )
 
     # TODO: add atom index-based instantiator for species if not present
@@ -69,7 +68,6 @@ class BasisSetComponent(ArchiveSection):
         Reference to the section `BaseModelMethod` containing the information
         of the Hamiltonian term to which the basis set applies.
         """,
-        # a_eln=ELNAnnotation(components='ReferenceEditQuantity'),
     )
 
     # ? band_scope or orbital_scope: valence vs core

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -204,6 +204,7 @@ class AtomCenteredBasisSet(BasisSetComponent):
         sub_section=AtomCenteredFunction.m_def, repeats=True
     )  # TODO change name
 
+
 class APWBaseOrbital(ArchiveSection):
     """
     Abstract base section for (S)(L)APW and local orbital component wavefunctions.

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -57,7 +57,7 @@ class BasisSetComponent(ArchiveSection):
         description="""
         Reference to the section `AtomsState` specifying the localization of the basis set.
         """,
-        a_eln=ELNAnnotation(components='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(components='ReferenceEditQuantity'),
     )
 
     # TODO: add atom index-based instantiator for species if not present
@@ -69,7 +69,7 @@ class BasisSetComponent(ArchiveSection):
         Reference to the section `BaseModelMethod` containing the information
         of the Hamiltonian term to which the basis set applies.
         """,
-        a_eln=ELNAnnotation(components='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(components='ReferenceEditQuantity'),
     )
 
     # ? band_scope or orbital_scope: valence vs core

--- a/src/nomad_simulations/schema_packages/general.py
+++ b/src/nomad_simulations/schema_packages/general.py
@@ -70,7 +70,6 @@ class Program(Entity):
         description="""
         The name of the program.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     version = Quantity(
@@ -78,7 +77,6 @@ class Program(Entity):
         description="""
         The version label of the program.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     link = Quantity(
@@ -86,7 +84,6 @@ class Program(Entity):
         description="""
         Website link to the program in published information.
         """,
-        # a_eln=ELNAnnotation(component='URLEditQuantity'),
     )
 
     version_internal = Quantity(
@@ -95,7 +92,6 @@ class Program(Entity):
         Specifies a program version tag used internally for development purposes.
         Any kind of tagging system is supported, including git commit hashes.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     subroutine_name_internal = Quantity(
@@ -106,7 +102,6 @@ class Program(Entity):
         so the naming is representative. This naming is mostly meant for users
         who are familiar with the program's structure.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     compilation_host = Quantity(
@@ -114,7 +109,6 @@ class Program(Entity):
         description="""
         Specifies the host on which the program was compiled.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
 
@@ -137,7 +131,6 @@ class BaseSimulation(Activity):
         description="""
         The date and time when this computation ended.
         """,
-        # a_eln=ELNAnnotation(component='DateTimeEditQuantity'),
     )
 
     cpu1_start = Quantity(
@@ -146,7 +139,6 @@ class BaseSimulation(Activity):
         description="""
         The starting time of the computation on the (first) CPU 1.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     cpu1_end = Quantity(
@@ -155,7 +147,6 @@ class BaseSimulation(Activity):
         description="""
         The end time of the computation on the (first) CPU 1.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     wall_start = Quantity(
@@ -164,7 +155,6 @@ class BaseSimulation(Activity):
         description="""
         The internal wall-clock time from the starting of the computation.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     wall_end = Quantity(
@@ -173,7 +163,6 @@ class BaseSimulation(Activity):
         description="""
         The internal wall-clock time from the end of the computation.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     program = SubSection(sub_section=Program.m_def, repeats=False)

--- a/src/nomad_simulations/schema_packages/general.py
+++ b/src/nomad_simulations/schema_packages/general.py
@@ -70,7 +70,7 @@ class Program(Entity):
         description="""
         The name of the program.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     version = Quantity(
@@ -78,7 +78,7 @@ class Program(Entity):
         description="""
         The version label of the program.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     link = Quantity(
@@ -86,7 +86,7 @@ class Program(Entity):
         description="""
         Website link to the program in published information.
         """,
-        a_eln=ELNAnnotation(component='URLEditQuantity'),
+        # a_eln=ELNAnnotation(component='URLEditQuantity'),
     )
 
     version_internal = Quantity(
@@ -95,7 +95,7 @@ class Program(Entity):
         Specifies a program version tag used internally for development purposes.
         Any kind of tagging system is supported, including git commit hashes.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     subroutine_name_internal = Quantity(
@@ -106,7 +106,7 @@ class Program(Entity):
         so the naming is representative. This naming is mostly meant for users
         who are familiar with the program's structure.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     compilation_host = Quantity(
@@ -114,11 +114,8 @@ class Program(Entity):
         description="""
         Specifies the host on which the program was compiled.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        pass
 
 
 class BaseSimulation(Activity):
@@ -140,7 +137,7 @@ class BaseSimulation(Activity):
         description="""
         The date and time when this computation ended.
         """,
-        a_eln=ELNAnnotation(component='DateTimeEditQuantity'),
+        # a_eln=ELNAnnotation(component='DateTimeEditQuantity'),
     )
 
     cpu1_start = Quantity(
@@ -149,7 +146,7 @@ class BaseSimulation(Activity):
         description="""
         The starting time of the computation on the (first) CPU 1.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     cpu1_end = Quantity(
@@ -158,7 +155,7 @@ class BaseSimulation(Activity):
         description="""
         The end time of the computation on the (first) CPU 1.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     wall_start = Quantity(
@@ -167,7 +164,7 @@ class BaseSimulation(Activity):
         description="""
         The internal wall-clock time from the starting of the computation.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     wall_end = Quantity(
@@ -176,13 +173,10 @@ class BaseSimulation(Activity):
         description="""
         The internal wall-clock time from the end of the computation.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     program = SubSection(sub_section=Program.m_def, repeats=False)
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        pass
 
 
 class Simulation(BaseSimulation, Schema):

--- a/src/nomad_simulations/schema_packages/general.py
+++ b/src/nomad_simulations/schema_packages/general.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 import numpy as np
 from nomad.config import config
 from nomad.datamodel.data import Schema
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.datamodel.metainfo.basesections import Activity, Entity
 from nomad.metainfo import Datetime, Quantity, SchemaPackage, Section, SubSection
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -46,7 +46,7 @@ class BaseModelMethod(ArchiveSection):
         Name of the mathematical model. This is typically used to identify the model Hamiltonian used in the
         simulation. Typical standard names: 'DFT', 'TB', 'GW', 'BSE', 'DMFT', 'NMR', 'kMC'.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     type = Quantity(
@@ -56,7 +56,7 @@ class BaseModelMethod(ArchiveSection):
         model can be 'Wannier', 'DFTB', 'xTB' or 'Slater-Koster'. This quantity should be
         rewritten to a MEnum when inheriting from this class.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     external_reference = Quantity(
@@ -64,13 +64,10 @@ class BaseModelMethod(ArchiveSection):
         description="""
         External reference to the model e.g. DOI, URL.
         """,
-        a_eln=ELNAnnotation(component='URLEditQuantity'),
+        # a_eln=ELNAnnotation(component='URLEditQuantity'),
     )
 
     numerical_settings = SubSection(sub_section=NumericalSettings.m_def, repeats=True)
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class ModelMethod(BaseModelMethod):
@@ -87,9 +84,6 @@ class ModelMethod(BaseModelMethod):
         Contribution or sub-term of the total model Hamiltonian.
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class ModelMethodElectronic(ModelMethod):
@@ -118,11 +112,8 @@ class ModelMethodElectronic(ModelMethod):
         Describes the relativistic treatment used for the calculation of the final energy
         and related quantities. If `None`, no relativistic treatment is applied.
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class XCFunctional(ArchiveSection):
@@ -136,7 +127,7 @@ class XCFunctional(ArchiveSection):
         Provides the name of one of the exchange or correlation (XC) functional following the libxc
         convention. For the code base containing the conventions, see https://gitlab.com/libxc/libxc.
         """,  # TODO: step away from the libxc naming convention
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     name = Quantity(
@@ -153,7 +144,7 @@ class XCFunctional(ArchiveSection):
         Weight of the functional. This quantity is relevant when defining linear combinations of the
         different functionals. If not specified, its value is 1.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     # ? add method to extract `name` from `libxc_name`
@@ -220,7 +211,7 @@ class DFT(ModelMethodElectronic):
         description="""
         Amount of exact exchange mixed in with the XC functional (value range = [0, 1]).
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     # ! MEnum this
@@ -252,7 +243,7 @@ class DFT(ModelMethodElectronic):
         | `"SIC_MAURI_US"`          | A (scaled) correction proposed by Mauri and co-
         workers on the spin density / doublet unpaired orbital |
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     van_der_waals_correction = Quantity(
@@ -269,7 +260,7 @@ class DFT(ModelMethodElectronic):
         | `"MDB"` | http://dx.doi.org/10.1103/PhysRevLett.108.236402 and http://dx.doi.org/10.1063/1.4865104 |
         | `"XC"` | The method to calculate the VdW energy uses a non-local functional |
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     def __init__(self, m_def: 'Section' = None, m_context: 'Context' = None, **kwargs):
@@ -426,7 +417,7 @@ class TB(ModelMethodElectronic):
         | `'SlaterKoster'` | https://journals.aps.org/pr/abstract/10.1103/PhysRev.94.1498 |
         | `'unavailable'` | - |
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     # ? these 4 quantities will change when `BasisSet` is defined
@@ -854,7 +845,7 @@ class ExcitedStateMethodology(ModelMethodElectronic):
         description="""
         Number of states used to calculate the excitations.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     n_empty_states = Quantity(
@@ -862,7 +853,7 @@ class ExcitedStateMethodology(ModelMethodElectronic):
         description="""
         Number of empty states used to calculate the excitations. This quantity is complementary to `n_states`.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     broadening = Quantity(
@@ -871,11 +862,8 @@ class ExcitedStateMethodology(ModelMethodElectronic):
         description="""
         Lifetime broadening applied to the spectra in full-width at half maximum for excited-state calculations.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class Screening(ExcitedStateMethodology):
@@ -890,11 +878,8 @@ class Screening(ExcitedStateMethodology):
         Value of the static dielectric constant at infinite q. For metals, this is infinite
         (or a very large value), while for insulators is finite.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class GW(ExcitedStateMethodology):
@@ -927,7 +912,7 @@ class GW(ExcitedStateMethodology):
         | `'qp-scGW0'`  | quasiparticle self-consistent G with fixed W0 | https://journals.aps.org/prb/abstract/10.1103/PhysRevB.76.115109 |
         | `'qp-scGW'`  | quasiparticle self-consistent G and W | https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.96.226402 |
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     analytical_continuation = Quantity(
@@ -953,7 +938,7 @@ class GW(ExcitedStateMethodology):
         | `'ppm_FaridEngel'` | Farid and Engel plasmon-pole model  | https://journals.aps.org/prb/abstract/10.1103/PhysRevB.47.15931 |
         | `'multi_pole'` | Multi-pole fitting  | https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.74.1827 |
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     # TODO improve description
@@ -970,11 +955,8 @@ class GW(ExcitedStateMethodology):
         description="""
         Reference to the `Screening` section that the GW calculation used to obtain the screened Coulomb interactions.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class BSE(ExcitedStateMethodology):
@@ -1003,7 +985,7 @@ class BSE(ExcitedStateMethodology):
         | `'IP'` | Independent-particle approach |
         | `'RPA'` | Random Phase Approximation |
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     solver = Quantity(
@@ -1019,7 +1001,7 @@ class BSE(ExcitedStateMethodology):
         | `'SLEPc'` | Scalable Library for Eigenvalue Problem Computations | https://slepc.upv.es/ |
         | `'TDA'` | Tamm-Dancoff approximation | https://doi.org/10.1016/S0009-2614(99)01149-5 |
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     screening_ref = Quantity(
@@ -1027,11 +1009,8 @@ class BSE(ExcitedStateMethodology):
         description="""
         Reference to the `Screening` section that the BSE calculation used to obtain the screened Coulomb interactions.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 # ? Is this class really necessary or should go in outputs.py?
@@ -1057,7 +1036,7 @@ class CoreHoleSpectra(ModelMethodElectronic):
         description="""
         Type of the CoreHole excitation spectra calculated, either "absorption" or "emission".
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     edge = Quantity(
@@ -1092,7 +1071,7 @@ class CoreHoleSpectra(ModelMethodElectronic):
         description="""
         Reference to the `CoreHole` section that contains the information of the edge of the excited core-hole.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     excited_state_method_ref = Quantity(
@@ -1100,13 +1079,10 @@ class CoreHoleSpectra(ModelMethodElectronic):
         description="""
         Reference to the `ModelMethodElectronic` section (e.g., `DFT` or `BSE`) that was used to obtain the core-hole spectra.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     # TODO add normalization to obtain `edge`
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class DMFT(ModelMethodElectronic):
@@ -1218,6 +1194,3 @@ class DMFT(ModelMethodElectronic):
         `orbitals_ref` and their spin state.
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -46,7 +46,6 @@ class BaseModelMethod(ArchiveSection):
         Name of the mathematical model. This is typically used to identify the model Hamiltonian used in the
         simulation. Typical standard names: 'DFT', 'TB', 'GW', 'BSE', 'DMFT', 'NMR', 'kMC'.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     type = Quantity(
@@ -56,7 +55,6 @@ class BaseModelMethod(ArchiveSection):
         model can be 'Wannier', 'DFTB', 'xTB' or 'Slater-Koster'. This quantity should be
         rewritten to a MEnum when inheriting from this class.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     external_reference = Quantity(
@@ -64,7 +62,6 @@ class BaseModelMethod(ArchiveSection):
         description="""
         External reference to the model e.g. DOI, URL.
         """,
-        # a_eln=ELNAnnotation(component='URLEditQuantity'),
     )
 
     numerical_settings = SubSection(sub_section=NumericalSettings.m_def, repeats=True)
@@ -112,7 +109,6 @@ class ModelMethodElectronic(ModelMethod):
         Describes the relativistic treatment used for the calculation of the final energy
         and related quantities. If `None`, no relativistic treatment is applied.
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
 
@@ -127,7 +123,6 @@ class XCFunctional(ArchiveSection):
         Provides the name of one of the exchange or correlation (XC) functional following the libxc
         convention. For the code base containing the conventions, see https://gitlab.com/libxc/libxc.
         """,  # TODO: step away from the libxc naming convention
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     name = Quantity(
@@ -144,7 +139,6 @@ class XCFunctional(ArchiveSection):
         Weight of the functional. This quantity is relevant when defining linear combinations of the
         different functionals. If not specified, its value is 1.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     # ? add method to extract `name` from `libxc_name`
@@ -211,7 +205,6 @@ class DFT(ModelMethodElectronic):
         description="""
         Amount of exact exchange mixed in with the XC functional (value range = [0, 1]).
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     # ! MEnum this
@@ -243,7 +236,6 @@ class DFT(ModelMethodElectronic):
         | `"SIC_MAURI_US"`          | A (scaled) correction proposed by Mauri and co-
         workers on the spin density / doublet unpaired orbital |
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     van_der_waals_correction = Quantity(
@@ -260,7 +252,6 @@ class DFT(ModelMethodElectronic):
         | `"MDB"` | http://dx.doi.org/10.1103/PhysRevLett.108.236402 and http://dx.doi.org/10.1063/1.4865104 |
         | `"XC"` | The method to calculate the VdW energy uses a non-local functional |
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     def __init__(self, m_def: 'Section' = None, m_context: 'Context' = None, **kwargs):
@@ -417,7 +408,6 @@ class TB(ModelMethodElectronic):
         | `'SlaterKoster'` | https://journals.aps.org/pr/abstract/10.1103/PhysRev.94.1498 |
         | `'unavailable'` | - |
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     # ? these 4 quantities will change when `BasisSet` is defined
@@ -845,7 +835,6 @@ class ExcitedStateMethodology(ModelMethodElectronic):
         description="""
         Number of states used to calculate the excitations.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     n_empty_states = Quantity(
@@ -853,7 +842,6 @@ class ExcitedStateMethodology(ModelMethodElectronic):
         description="""
         Number of empty states used to calculate the excitations. This quantity is complementary to `n_states`.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     broadening = Quantity(
@@ -862,7 +850,6 @@ class ExcitedStateMethodology(ModelMethodElectronic):
         description="""
         Lifetime broadening applied to the spectra in full-width at half maximum for excited-state calculations.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
 
@@ -878,7 +865,6 @@ class Screening(ExcitedStateMethodology):
         Value of the static dielectric constant at infinite q. For metals, this is infinite
         (or a very large value), while for insulators is finite.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
 
@@ -912,7 +898,6 @@ class GW(ExcitedStateMethodology):
         | `'qp-scGW0'`  | quasiparticle self-consistent G with fixed W0 | https://journals.aps.org/prb/abstract/10.1103/PhysRevB.76.115109 |
         | `'qp-scGW'`  | quasiparticle self-consistent G and W | https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.96.226402 |
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     analytical_continuation = Quantity(
@@ -938,7 +923,6 @@ class GW(ExcitedStateMethodology):
         | `'ppm_FaridEngel'` | Farid and Engel plasmon-pole model  | https://journals.aps.org/prb/abstract/10.1103/PhysRevB.47.15931 |
         | `'multi_pole'` | Multi-pole fitting  | https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.74.1827 |
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     # TODO improve description
@@ -955,7 +939,6 @@ class GW(ExcitedStateMethodology):
         description="""
         Reference to the `Screening` section that the GW calculation used to obtain the screened Coulomb interactions.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
 
@@ -985,7 +968,6 @@ class BSE(ExcitedStateMethodology):
         | `'IP'` | Independent-particle approach |
         | `'RPA'` | Random Phase Approximation |
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     solver = Quantity(
@@ -1001,7 +983,6 @@ class BSE(ExcitedStateMethodology):
         | `'SLEPc'` | Scalable Library for Eigenvalue Problem Computations | https://slepc.upv.es/ |
         | `'TDA'` | Tamm-Dancoff approximation | https://doi.org/10.1016/S0009-2614(99)01149-5 |
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     screening_ref = Quantity(
@@ -1009,7 +990,6 @@ class BSE(ExcitedStateMethodology):
         description="""
         Reference to the `Screening` section that the BSE calculation used to obtain the screened Coulomb interactions.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
 
@@ -1036,7 +1016,6 @@ class CoreHoleSpectra(ModelMethodElectronic):
         description="""
         Type of the CoreHole excitation spectra calculated, either "absorption" or "emission".
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     edge = Quantity(
@@ -1071,7 +1050,6 @@ class CoreHoleSpectra(ModelMethodElectronic):
         description="""
         Reference to the `CoreHole` section that contains the information of the edge of the excited core-hole.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     excited_state_method_ref = Quantity(
@@ -1079,7 +1057,6 @@ class CoreHoleSpectra(ModelMethodElectronic):
         description="""
         Reference to the `ModelMethodElectronic` section (e.g., `DFT` or `BSE`) that was used to obtain the core-hole spectra.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     # TODO add normalization to obtain `edge`

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from nomad.datamodel.data import ArchiveSection
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.metainfo import URL, MEnum, Quantity, Section, SubSection
 
 if TYPE_CHECKING:
@@ -1008,7 +1007,6 @@ class CoreHoleSpectra(ModelMethodElectronic):
     #     description="""
     #     Solver algorithm used for the core-hole spectra.
     #     """,
-    #     a_eln=ELNAnnotation(component="StringEditQuantity"),
     # )
 
     type = Quantity(

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -400,9 +400,6 @@ class Cell(GeometricSpace):
         # this does not hold in general, but here we use finite sets
         return not self.is_equal_cell(other)
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class AtomicCell(Cell):
     """

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -73,7 +73,7 @@ class GeometricSpace(Entity):
         description="""
         Length of the first basis vector.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     length_vector_b = Quantity(
@@ -82,7 +82,7 @@ class GeometricSpace(Entity):
         description="""
         Length of the second basis vector.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     length_vector_c = Quantity(
@@ -91,7 +91,7 @@ class GeometricSpace(Entity):
         description="""
         Length of the third basis vector.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     angle_vectors_b_c = Quantity(
@@ -100,7 +100,7 @@ class GeometricSpace(Entity):
         description="""
         Angle between second and third basis vector.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     angle_vectors_a_c = Quantity(
@@ -109,7 +109,7 @@ class GeometricSpace(Entity):
         description="""
         Angle between first and third basis vector.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     angle_vectors_a_b = Quantity(
@@ -118,7 +118,7 @@ class GeometricSpace(Entity):
         description="""
         Angle between first and second basis vector.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     volume = Quantity(
@@ -127,7 +127,7 @@ class GeometricSpace(Entity):
         description="""
         Volume of a 3D real space entity.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     surface_area = Quantity(
@@ -136,7 +136,7 @@ class GeometricSpace(Entity):
         description="""
         Surface area of a 3D real space entity.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     area = Quantity(
@@ -145,7 +145,7 @@ class GeometricSpace(Entity):
         description="""
         Area of a 2D real space entity.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     length = Quantity(
@@ -154,7 +154,7 @@ class GeometricSpace(Entity):
         description="""
         Total length of a 1D real space entity.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     coordinates_system = Quantity(
@@ -657,7 +657,7 @@ class Symmetry(ArchiveSection):
         description="""
         Reference to the AtomicCell section that the symmetry refers to.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     def resolve_analyzed_atomic_cell(
@@ -991,7 +991,7 @@ class ModelSystem(System):
         crystal or it can be filled up. For example, an heterostructure of graphene (G) sandwiched
         in between hexagonal boron nitrides (hBN) slabs could be named 'hBN/G/hBN'.
         """,
-        a_eln=ELNAnnotation(component='StringEditQuantity'),
+        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     # TODO work on improving and extending this quantity and the description
@@ -1009,7 +1009,7 @@ class ModelSystem(System):
         description="""
         Type of the system (atom, bulk, surface, etc.) which is determined by the normalizer.
         """,
-        a_eln=ELNAnnotation(component='EnumEditQuantity'),
+        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     dimensionality = Quantity(
@@ -1020,7 +1020,7 @@ class ModelSystem(System):
 
             https://doi.org/10.1103/PhysRevLett.118.106101.
         """,
-        a_eln=ELNAnnotation(component='NumberEditQuantity'),
+        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     # TODO improve on the definition and usage

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -36,7 +36,6 @@ from matid.classification.classifications import (
 from nomad.atomutils import Formula, get_normalized_wyckoff, search_aflow_prototype
 from nomad.config import config
 from nomad.datamodel.data import ArchiveSection
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.datamodel.metainfo.basesections import Entity, System
 from nomad.metainfo import MEnum, Quantity, SectionProxy, SubSection
 from nomad.units import ureg

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -73,7 +73,6 @@ class GeometricSpace(Entity):
         description="""
         Length of the first basis vector.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     length_vector_b = Quantity(
@@ -82,7 +81,6 @@ class GeometricSpace(Entity):
         description="""
         Length of the second basis vector.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     length_vector_c = Quantity(
@@ -91,7 +89,6 @@ class GeometricSpace(Entity):
         description="""
         Length of the third basis vector.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     angle_vectors_b_c = Quantity(
@@ -100,7 +97,6 @@ class GeometricSpace(Entity):
         description="""
         Angle between second and third basis vector.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     angle_vectors_a_c = Quantity(
@@ -109,7 +105,6 @@ class GeometricSpace(Entity):
         description="""
         Angle between first and third basis vector.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     angle_vectors_a_b = Quantity(
@@ -118,7 +113,6 @@ class GeometricSpace(Entity):
         description="""
         Angle between first and second basis vector.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     volume = Quantity(
@@ -127,7 +121,6 @@ class GeometricSpace(Entity):
         description="""
         Volume of a 3D real space entity.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     surface_area = Quantity(
@@ -136,7 +129,6 @@ class GeometricSpace(Entity):
         description="""
         Surface area of a 3D real space entity.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     area = Quantity(
@@ -145,7 +137,6 @@ class GeometricSpace(Entity):
         description="""
         Area of a 2D real space entity.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     length = Quantity(
@@ -154,7 +145,6 @@ class GeometricSpace(Entity):
         description="""
         Total length of a 1D real space entity.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     coordinates_system = Quantity(
@@ -657,7 +647,6 @@ class Symmetry(ArchiveSection):
         description="""
         Reference to the AtomicCell section that the symmetry refers to.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     def resolve_analyzed_atomic_cell(
@@ -991,7 +980,6 @@ class ModelSystem(System):
         crystal or it can be filled up. For example, an heterostructure of graphene (G) sandwiched
         in between hexagonal boron nitrides (hBN) slabs could be named 'hBN/G/hBN'.
         """,
-        # a_eln=ELNAnnotation(component='StringEditQuantity'),
     )
 
     # TODO work on improving and extending this quantity and the description
@@ -1009,7 +997,6 @@ class ModelSystem(System):
         description="""
         Type of the system (atom, bulk, surface, etc.) which is determined by the normalizer.
         """,
-        # a_eln=ELNAnnotation(component='EnumEditQuantity'),
     )
 
     dimensionality = Quantity(
@@ -1020,7 +1007,6 @@ class ModelSystem(System):
 
             https://doi.org/10.1103/PhysRevLett.118.106101.
         """,
-        # a_eln=ELNAnnotation(component='NumberEditQuantity'),
     )
 
     # TODO improve on the definition and usage

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -32,9 +32,6 @@ class NumericalSettings(ArchiveSection):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Smearing(NumericalSettings):
     """
@@ -884,6 +881,3 @@ class SelfConsistency(NumericalSettings):
         super().__init__(m_def, m_context, **kwargs)
         # Set the name of the section
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from nomad.datamodel.data import ArchiveSection
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.metainfo import Quantity, SubSection
 
 if TYPE_CHECKING:
@@ -57,7 +56,6 @@ class Outputs(ArchiveSection):
         description="""
         Reference to the `ModelSystem` section in which the output physical properties were calculated.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     model_method_ref = Quantity(
@@ -66,7 +64,6 @@ class Outputs(ArchiveSection):
         Reference to the `ModelMethod` section containing the details of the mathematical
         model with which the output physical properties were calculated.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -358,9 +358,6 @@ class WorkflowOutputs(Outputs):
     #     """,
     # )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class TrajectoryOutputs(WorkflowOutputs):
     """

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -324,7 +324,6 @@ class PropertyContribution(PhysicalProperty):
         description="""
         Reference to the `ModelMethod` section to which the property is linked to.
         """,
-        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     def normalize(self, archive, logger) -> None:

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -324,7 +324,7 @@ class PropertyContribution(PhysicalProperty):
         description="""
         Reference to the `ModelMethod` section to which the property is linked to.
         """,
-        a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
+        # a_eln=ELNAnnotation(component='ReferenceEditQuantity'),
     )
 
     def normalize(self, archive, logger) -> None:

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 from nomad import utils
 from nomad.datamodel.data import ArchiveSection
-from nomad.datamodel.metainfo.annotations import ELNAnnotation
 from nomad.datamodel.metainfo.basesections import Entity
 from nomad.metainfo import (
     URL,

--- a/src/nomad_simulations/schema_packages/properties/band_structure.py
+++ b/src/nomad_simulations/schema_packages/properties/band_structure.py
@@ -54,9 +54,6 @@ class BaseElectronicEigenvalues(PhysicalProperty):
         # ! `n_bands` need to be set up during initialization of the class
         self.rank = [int(kwargs.get('n_bands'))]
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class ElectronicEigenvalues(BaseElectronicEigenvalues):
     """ """
@@ -321,9 +318,6 @@ class ElectronicBandStructure(ElectronicEigenvalues):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Occupancy(PhysicalProperty):
     """
@@ -373,6 +367,3 @@ class Occupancy(PhysicalProperty):
         self.name = self.m_def.name
 
     # TODO add extraction from `ElectronicEigenvalues.occupation`
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/properties/energies.py
+++ b/src/nomad_simulations/schema_packages/properties/energies.py
@@ -32,9 +32,6 @@ class BaseEnergy(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class EnergyContribution(BaseEnergy, PropertyContribution):
     """
@@ -51,10 +48,6 @@ class EnergyContribution(BaseEnergy, PropertyContribution):
     quantity will contain the energy contribution from this component evaluated over all
     relevant atoms or electrons or as a function of them.
     """
-
-    # TODO address the dual parent normalization explicity
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 ####################################
@@ -78,9 +71,6 @@ class FermiLevel(BaseEnergy):
         self.rank = []
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 #! The only issue with this structure is that total energy will never be a sum of its contributions,
 #! since kinetic energy lives separately, but I think maybe this is ok?
@@ -99,9 +89,6 @@ class TotalEnergy(BaseEnergy):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 # ? Separate quantities for nuclear and electronic KEs?
 class KineticEnergy(BaseEnergy):
@@ -115,9 +102,6 @@ class KineticEnergy(BaseEnergy):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class PotentialEnergy(BaseEnergy):
     """
@@ -129,6 +113,3 @@ class PotentialEnergy(BaseEnergy):
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/properties/forces.py
+++ b/src/nomad_simulations/schema_packages/properties/forces.py
@@ -32,9 +32,6 @@ class BaseForce(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class ForceContribution(BaseForce, PropertyContribution):
     """
@@ -51,9 +48,6 @@ class ForceContribution(BaseForce, PropertyContribution):
     quantity will contain the force contribution from this component evaluated over all
     relevant atoms or electrons or as a function of them.
     """
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 ###################################
@@ -74,6 +68,3 @@ class TotalForce(BaseForce):
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/properties/greens_function.py
+++ b/src/nomad_simulations/schema_packages/properties/greens_function.py
@@ -210,9 +210,6 @@ class ElectronicGreensFunction(BaseGreensFunction):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class ElectronicSelfEnergy(BaseGreensFunction):
     """
@@ -235,9 +232,6 @@ class ElectronicSelfEnergy(BaseGreensFunction):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class HybridizationFunction(BaseGreensFunction):
     """
@@ -259,9 +253,6 @@ class HybridizationFunction(BaseGreensFunction):
     ) -> None:
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class QuasiparticleWeight(PhysicalProperty):

--- a/src/nomad_simulations/schema_packages/properties/hopping_matrix.py
+++ b/src/nomad_simulations/schema_packages/properties/hopping_matrix.py
@@ -54,9 +54,6 @@ class HoppingMatrix(PhysicalProperty):
 
     # TODO add normalization to extract DOS, band structure, etc, properties from `HoppingMatrix`
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class CrystalFieldSplitting(PhysicalProperty):
     """
@@ -89,6 +86,3 @@ class CrystalFieldSplitting(PhysicalProperty):
         # ! `n_orbitals` need to be set up during initialization of the class
         self.rank = [int(kwargs.get('n_orbitals'))]
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -522,9 +522,6 @@ class AbsorptionSpectrum(SpectralProfile):
         # Set the name of the section
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class XASSpectrum(AbsorptionSpectrum):
     """

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -31,9 +31,6 @@ class Pressure(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Volume(PhysicalProperty):
     """
@@ -52,9 +49,6 @@ class Volume(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Temperature(PhysicalProperty):
     """
@@ -68,26 +62,17 @@ class Temperature(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Heat(BaseEnergy):
     """
     The transfer of thermal energy **into** a system.
     """
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Work(BaseEnergy):
     """
     The energy transferred to a system by means of force applied over a distance.
     """
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class InternalEnergy(BaseEnergy):
@@ -97,17 +82,11 @@ class InternalEnergy(BaseEnergy):
     process may be expressed as the `Heat` minus the `Work`.
     """
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Enthalpy(BaseEnergy):
     """
     The total heat content of a system, defined as 'InternalEnergy' + 'Pressure' * 'Volume'.
     """
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class Entropy(PhysicalProperty):
@@ -133,9 +112,6 @@ class Entropy(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class GibbsFreeEnergy(BaseEnergy):
     """
@@ -143,18 +119,12 @@ class GibbsFreeEnergy(BaseEnergy):
     given by `Enthalpy` - `Temperature` * `Entropy`.
     """
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class HelmholtzFreeEnergy(BaseEnergy):
     """
     The energy available to do work in a system at constant volume and temperature,
     given by `InternalEnergy` - `Temperature` * `Entropy`.
     """
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class ChemicalPotential(BaseEnergy):
@@ -173,9 +143,6 @@ class ChemicalPotential(BaseEnergy):
         self.rank = []
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class HeatCapacity(PhysicalProperty):
     """
@@ -188,9 +155,6 @@ class HeatCapacity(PhysicalProperty):
         description="""
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 ################################
@@ -214,9 +178,6 @@ class VirialTensor(BaseEnergy):
         self.rank = [3, 3]
         self.name = self.m_def.name
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class MassDensity(PhysicalProperty):
     """
@@ -229,9 +190,6 @@ class MassDensity(PhysicalProperty):
         description="""
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 # ? fit better elsewhere
@@ -254,6 +212,3 @@ class Hessian(PhysicalProperty):
         super().__init__(m_def, m_context, **kwargs)
         self.rank = [3, 3]
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)


### PR DESCRIPTION
Aside from removing editable quantities, this PR also removes redundant normalizers

closes #161 