### PR TITLE
Update Python version in CI/CD

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{matrix.python_version}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.3.0",
+    "nomad-lab>=1.3.15",
     "matid>=2.0.0.dev2",
 ]
 
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    'mypy==1.0.1',
+    'mypy>=1.15',
     'pytest>= 5.3.0, <8',
     'pytest-timeout>=1.4.2',
     'pytest-cov>=2.7.1',

--- a/src/nomad_simulations/schema_packages/general.py
+++ b/src/nomad_simulations/schema_packages/general.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -220,14 +220,12 @@ class Simulation(BaseSimulation, Schema):
                 to the atom indices stored in system.
             """
             if not subsystems:
-                atom_indices = (
-                    system.atom_indices if system.atom_indices is not None else []
-                )
-                subsystem_labels = (
-                    [np.array(atom_labels)[atom_indices]]
-                    if atom_labels
-                    else ['Unknown' for atom in range(len(atom_indices))]
-                )
+                if system.atom_indices is not None and atom_labels:
+                    subsystem_labels = [atom_labels[i] for i in system.atom_indices]
+                elif system.atom_indices is not None:
+                    subsystem_labels = ['Unknown'] * len(system.atom_indices)
+                else:
+                    subsystem_labels = []
             else:
                 subsystem_labels = [
                     subsystem.branch_label


### PR DESCRIPTION
The current `nomad-lab` version no longer supports Python 3.9, but Python 3.12 instead.
Bumping this is necessary for cross-compatiblity of dependencies like `pydantic`.