### PR TITLE
reverted electronicoutputs

### DIFF
--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -68,12 +68,6 @@ class Outputs(Time):
         """,
     )
 
-
-class ElectronicStructureOutputs(Outputs):
-    # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-    # List of properties
-    # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
     fermi_levels = SubSection(sub_section=FermiLevel.m_def, repeats=True)
 
     chemical_potentials = SubSection(sub_section=ChemicalPotential.m_def, repeats=True)
@@ -199,9 +193,7 @@ class ElectronicStructureOutputs(Outputs):
             self.model_method_ref = self.set_model_method_ref()
 
 
-class SCFOutputs(
-    ElectronicStructureOutputs
-):  # TODO: separate out from `ElectronicStructureOutputs`
+class SCFOutputs(Outputs):
     """
     This section contains the self-consistent (SCF) steps performed to converge an output property.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from nomad_simulations.schema_packages.numerical_settings import (
     SelfConsistency,
 )
 from nomad_simulations.schema_packages.outputs import (
-    ElectronicStructureOutputs,
+    Outputs,
     Outputs,
     SCFOutputs,
 )
@@ -158,9 +158,7 @@ def generate_scf_electronic_band_gap_template(
     value = None
     for i in range(n_scf_steps):
         value = 1 + sum([1 / (10**j) for j in range(1, i + 2)])
-        scf_step = ElectronicStructureOutputs(
-            electronic_band_gaps=[ElectronicBandGap(value=value)]
-        )
+        scf_step = Outputs(electronic_band_gaps=[ElectronicBandGap(value=value)])
         scf_outputs.scf_steps.append(scf_step)
     # Add a SCF calculated PhysicalProperty
     if value is not None:
@@ -188,12 +186,12 @@ def generate_simulation_electronic_dos(
     energy_points: list[int] = [-3, -2, -1, 0, 1, 2, 3],
 ) -> Simulation:
     """
-    Generate a `Simulation` section with an `ElectronicDensityOfStates` section under `ElectronicStructureOutputs`. It uses
+    Generate a `Simulation` section with an `ElectronicDensityOfStates` section under `Outputs`. It uses
     the template of the model_system created with the `generate_model_system` function.
     """
     # Create the `Simulation` section to make refs work
     model_system = generate_model_system()
-    outputs = ElectronicStructureOutputs()
+    outputs = Outputs()
     simulation = generate_simulation(model_system=model_system, outputs=outputs)
 
     # Populating the `ElectronicDensityOfStates` section
@@ -325,7 +323,7 @@ def generate_electronic_eigenvalues(
     """
     Generate an `ElectronicEigenvalues` section with the given parameters.
     """
-    outputs = ElectronicStructureOutputs()
+    outputs = Outputs()
     k_space = KSpace(
         k_line_path=KLinePathSettings(
             points=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ from nomad_simulations.schema_packages.numerical_settings import (
 )
 from nomad_simulations.schema_packages.outputs import (
     Outputs,
-    Outputs,
     SCFOutputs,
 )
 from nomad_simulations.schema_packages.properties import (

--- a/tests/properties/test_band_structure.py
+++ b/tests/properties/test_band_structure.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from nomad.datamodel import EntryArchive
 
-from nomad_simulations.schema_packages.outputs import ElectronicStructureOutputs
+from nomad_simulations.schema_packages.outputs import Outputs
 from nomad_simulations.schema_packages.properties import ElectronicEigenvalues
 
 from ..conftest import generate_electronic_eigenvalues

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -8,7 +8,7 @@ from nomad.units import ureg
 from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_system import AtomicCell, ModelSystem
-from nomad_simulations.schema_packages.outputs import ElectronicStructureOutputs
+from nomad_simulations.schema_packages.outputs import Outputs
 from nomad_simulations.schema_packages.properties import (
     AbsorptionSpectrum,
     ElectronicDensityOfStates,
@@ -67,7 +67,7 @@ class TestElectronicDensityOfStates:
         Test the `resolve_normalization_factor` method.
         """
         simulation = Simulation()
-        outputs = ElectronicStructureOutputs()
+        outputs = Outputs()
         # We only used the `simulation_electronic_dos` fixture to get the `ElectronicDensityOfStates` to test missing refs
         electronic_dos = simulation_electronic_dos.outputs[0].electronic_dos[0]
         electronic_dos.energies_origin = 0.5 * ureg.joule

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -7,7 +7,7 @@ from nomad_simulations.schema_packages.model_method import ModelMethod
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
 from nomad_simulations.schema_packages.outputs import (
-    ElectronicStructureOutputs,
+    Outputs,
     SCFOutputs,
 )
 from nomad_simulations.schema_packages.properties import ElectronicBandGap
@@ -18,15 +18,15 @@ from .conftest import generate_scf_electronic_band_gap_template, generate_simula
 
 class TestOutputs:
     """
-    Test the `ElectronicStructureOutputs` class defined in `outputs.py`.
+    Test the `Outputs` class defined in `outputs.py`.
     """
 
     def test_number_of_properties(self):  # TODO: remove this test
         """
-        Test how many properties are defined under `ElectronicStructureOutputs` and its order. This test is done in order to control better
+        Test how many properties are defined under `Outputs` and its order. This test is done in order to control better
         which properties are already defined and in which order to control their normalizations
         """
-        outputs = ElectronicStructureOutputs()
+        outputs = Outputs()
         assert len(outputs.m_def.all_sub_sections) == 22
         defined_properties = [
             'fermi_levels',
@@ -87,12 +87,12 @@ class TestOutputs:
         Test the `extract_spin_polarized_property` method.
 
         Args:
-            band_gaps (list[ElectronicBandGap]): The `ElectronicBandGap` sections to be stored under `ElectronicStructureOutputs`.
+            band_gaps (list[ElectronicBandGap]): The `ElectronicBandGap` sections to be stored under `Outputs`.
             values (list[float]): The values to be assigned to the `ElectronicBandGap` sections.
             result_length (int): The expected length extracted from `extract_spin_polarized_property`.
             result (list[ElectronicBandGap]): The expected result of the `extract_spin_polarized_property` method.
         """
-        outputs = ElectronicStructureOutputs()
+        outputs = Outputs()
 
         for i, band_gap in enumerate(band_gaps):
             band_gap.value = [values[i]]
@@ -119,9 +119,9 @@ class TestOutputs:
 
         Args:
             model_system (Optional[ModelSystem]): The `ModelSystem` to be tested for the `model_system_ref` reference
-            stored in `ElectronicStructureOutputs`.
+            stored in `Outputs`.
         """
-        outputs = ElectronicStructureOutputs()
+        outputs = Outputs()
         simulation = generate_simulation(model_system=model_system, outputs=outputs)
         model_system_ref = outputs.set_model_system_ref()
         if model_system is not None:
@@ -140,9 +140,9 @@ class TestOutputs:
 
         Args:
             model_method (Optional[ModelMethod]): The `ModelMethod` to be tested for the `model_method_ref` reference
-            stored in `ElectronicStructureOutputs`.
+            stored in `Outputs`.
         """
-        outputs = ElectronicStructureOutputs()
+        outputs = Outputs()
         simulation = generate_simulation(model_method=model_method, outputs=outputs)
         model_method_ref = outputs.set_model_method_ref()
         if model_method is not None:
@@ -172,7 +172,7 @@ class TestOutputs:
             model_method (Optional[ModelMethod]): The expected `model_method_ref` obtained after normalization and
             initially stored under `Simulation.model_method[0]`.
         """
-        outputs = ElectronicStructureOutputs()
+        outputs = Outputs()
         simulation = generate_simulation(
             model_system=model_system, model_method=model_method, outputs=outputs
         )
@@ -200,10 +200,10 @@ class TestSCFOutputs:
             # empty `scf_last_steps`
             ([], 0, None, None, []),
             # length of `scf_last_steps` is different from 2
-            ([ElectronicStructureOutputs()], 0, None, None, []),
+            ([Outputs()], 0, None, None, []),
             # no property matching `'electronic_band_gaps'` stored under the `scf_last_steps`
             (
-                [ElectronicStructureOutputs(), ElectronicStructureOutputs()],
+                [Outputs(), Outputs()],
                 0,
                 None,
                 None,
@@ -212,12 +212,8 @@ class TestSCFOutputs:
             # `i_property` is out of range
             (
                 [
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
                 ],
                 2,
                 None,
@@ -227,12 +223,8 @@ class TestSCFOutputs:
             # no `value` stored in the `scf_last_steps` property
             (
                 [
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
                 ],
                 0,
                 None,
@@ -242,12 +234,8 @@ class TestSCFOutputs:
             # no `SelfConsistency` section and `threshold_change_unit` defined and matching units for property `value` (`'joule'`)
             (
                 [
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
                 ],
                 0,
                 [1.0, 2.0],
@@ -257,12 +245,8 @@ class TestSCFOutputs:
             # valid case
             (
                 [
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
-                    ElectronicStructureOutputs(
-                        electronic_band_gaps=[ElectronicBandGap()]
-                    ),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
+                    Outputs(electronic_band_gaps=[ElectronicBandGap()]),
                 ],
                 0,
                 [1.0, 2.0],
@@ -273,7 +257,7 @@ class TestSCFOutputs:
     )
     def test_get_last_scf_steps_value(
         self,
-        scf_last_steps: list[ElectronicStructureOutputs],
+        scf_last_steps: list[Outputs],
         i_property: int,
         values: list[float],
         scf_parameters: Optional[SelfConsistency],


### PR DESCRIPTION
@ndaelman-hu I needed to revert this change, as suggested by Alvin for my parser to work with TrajectoryOutputs(). If we want to split outputs later and have a holistic solution that is fine, but for now I suggest merging this into your branch and then merging yours to develop, ok?

I just want to run one more test before I do that, but I need to fix my distro-dev, so it may not happen till tomorrow. 