### PR TITLE
Restructure SCF

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -88,6 +88,13 @@ class ModelMethodElectronic(ModelMethod):
     calculations (TB, DFT, GW, BSE, DMFT, etc).
     """
 
+    is_scf_calculation = Quantity(
+        type=bool,
+        description="""
+        Denotes whether the calculation is run self-consistently or not.
+        """,
+    )
+
     # ? Is this necessary or will it be defined in another way?
     is_spin_polarized = Quantity(
         type=bool,

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -855,7 +855,7 @@ class SelfConsistency(NumericalSettings):
         """,
     )
 
-    differential_threshold = Quantity(
+    convergence_tolerance = Quantity(
         type=np.float64,
         # guideline: specialize the unit
         description="""
@@ -867,10 +867,10 @@ class SelfConsistency(NumericalSettings):
 
 
 class EnergySelfConsistency(SelfConsistency):
-    differential_threshold = SelfConsistency.m_def.differential_threshold.m_copy()
-    differential_threshold.unit = 'J'
+    convergence_tolerance = SelfConsistency.convergence_tolerance.m_copy()
+    convergence_tolerance.unit = 'J'
 
 
 class ForceSelfConsistency(SelfConsistency):
-    differential_threshold = SelfConsistency.m_def.differential_threshold.m_copy()
-    differential_threshold.unit = 'N'
+    convergence_tolerance = SelfConsistency.convergence_tolerance.m_copy()
+    convergence_tolerance.unit = 'N'

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -865,6 +865,7 @@ class SelfConsistency(NumericalSettings):
         """,
     )
 
+
 class EnergySelfConsistency(SelfConsistency):
     differential_threshold = SelfConsistency.m_def.differential_threshold.m_copy()
     differential_threshold.unit = 'J'

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -837,12 +837,6 @@ class KSpace(NumericalSettings):
 class SelfConsistency(NumericalSettings):
     """
     A base section used to define the convergence settings of self-consistent field (SCF) calculation.
-    It determines the conditions for `is_scf_converged` in `SCFOutputs` (see outputs.py). The convergence
-    criteria covered are:
-
-        1. The number of iterations is smaller than or equal to `n_max_iterations`.
-        2. The total change between two subsequent self-consistent iterations for an output property is below
-        `threshold_change`.
     """
 
     # TODO add examples or MEnum?
@@ -863,9 +857,19 @@ class SelfConsistency(NumericalSettings):
 
     differential_threshold = Quantity(
         type=np.float64,
+        # guideline: specialize the unit
         description="""
         Specifies the threshold for the change between two subsequent self-consistent iterations on
         a given output property. The simulation `is_scf_converged` if this total change is below
         this threshold.
         """,
     )
+
+class EnergySelfConsistency(SelfConsistency):
+    differential_threshold = SelfConsistency.m_def.differential_threshold.m_copy()
+    differential_threshold.unit = 'J'
+
+
+class ForceSelfConsistency(SelfConsistency):
+    differential_threshold = SelfConsistency.m_def.differential_threshold.m_copy()
+    differential_threshold.unit = 'N'

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -886,6 +886,15 @@ class SelfConsistency(NumericalSettings):
         """,
     )
 
+    is_required = Quantity(
+        type=bool,
+        description="""
+        Indicates whether the metric specified is required for the calculation to be considered convergence.
+        If unset (i.e. `None`), the role of the metric is unknown.
+        """,
+    )
+    # Extend to groups for general case of `(... && ...) || (... && ...) || ...`
+
 
 class EnergySelfConsistency(SelfConsistency):
     convergence_tolerance = SelfConsistency.convergence_tolerance.m_copy()

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -861,7 +861,7 @@ class SelfConsistency(NumericalSettings):
         """,
     )
 
-    threshold_change = Quantity(
+    differential_threshold = Quantity(
         type=np.float64,
         description="""
         Specifies the threshold for the change between two subsequent self-consistent iterations on
@@ -869,15 +869,3 @@ class SelfConsistency(NumericalSettings):
         this threshold.
         """,
     )
-
-    threshold_change_unit = Quantity(
-        type=str,
-        description="""
-        Unit using the pint UnitRegistry() notation for the `threshold_change`.
-        """,
-    )
-
-    def __init__(self, m_def: 'Section' = None, m_context: 'Context' = None, **kwargs):
-        super().__init__(m_def, m_context, **kwargs)
-        # Set the name of the section
-        self.name = self.m_def.name

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -30,7 +30,7 @@ class NumericalSettings(ArchiveSection):
         `NumericalSettings` section. Possible values: "KMesh", "FrequencyMesh", "TimeMesh",
         "SelfConsistency", "BasisSet".
         """,
-    )
+    )  # ? to be removed
 
 
 class Smearing(NumericalSettings):
@@ -838,6 +838,27 @@ class SelfConsistency(NumericalSettings):
     """
     A base section used to define the convergence settings of self-consistent field (SCF) calculation.
     """
+
+    comparison_mode = Quantity(
+        type=MEnum('absolute', 'relative', 'maximum', 'rms', 'residuum'),
+        description="""
+            Specifies the mathematical method used to evaluate convergence between successive self-consistent field (SCF) iterations. 
+    This determines how differences between iterations are calculated and compared against the convergence threshold.
+    
+    The available comparison modes are:
+    
+    | Mode | Description |
+    | --------- | -------------------------------- |
+    | `'absolute'` | Measures the straightforward absolute difference between two subsequent iterations (e.g., |E_n - E_{n-1}|). Most common for energy convergence. |
+    | `'relative'` | Calculates the relative difference as a fraction of the total property value (e.g., |E_n - E_{n-1}|/|E_n|). Useful when the magnitude of the property varies widely across systems. |
+    | `'residuum'` | Computes the absolute difference between the current value and the value estimated from the wavefunction at the start of the step. Often used for evaluating convergence of the electron density. |
+    | `'maximum'` | Reports the maximum absolute difference across all components of a multi-component property (e.g., max|F_i,n - F_i,{n-1}| for forces). Suitable for vector quantities like forces or stress tensor elements. |
+    | `'rms'` | Calculates the root mean square of differences across all components (e.g., √(∑|F_i,n - F_i,{n-1}|²/N)). Provides a statistical measure of overall convergence for multi-component properties. |
+    
+    The mode used affects both convergence behavior and computational efficiency. Different codes may default to different comparison modes for the same physical property.
+        """,
+    )
+        
 
     # TODO add examples or MEnum?
     scf_minimization_algorithm = Quantity(

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -202,56 +202,6 @@ class SCFOutputs(Outputs):
     `Simulation` entry in NOMAD contains the final output properties and all the SCF steps.
     """
 
-    scf_steps = SubSection(
-        sub_section=Outputs.m_def,
-        repeats=True,
-        description="""
-        Self-consistent (SCF) steps performed for converging a given output property. Note that the SCF steps belong to
-        the same minimal `Simulation` workflow entry which is known as `SinglePoint`.
-        """,
-    )
-
-    def get_last_scf_steps_value(  # TODO: redo
-        self,
-        scf_last_steps: list[Outputs],
-        property_name: str,
-        i_property: int,
-        scf_parameters: Optional[SelfConsistency],
-        logger: 'BoundLogger',
-    ) -> Optional[list]:
-        """
-        Get the last two SCF values' magnitudes of a physical property and appends them in a list.
-
-        Args:
-            scf_last_steps (list[Outputs]): The list of SCF steps. This must be of length 2 in order to the method to work.
-            property_name (str): The name of the physical property.
-            i_property (int): The index of the physical property.
-            scf_parameters (Optional[SelfConsistency]): The self-consistency parameters section stored under `ModelMethod`.
-            logger (BoundLogger): The logger to log messages.
-
-        Returns:
-            (Optional[list]): The list of the last two SCF values (in magnitude) of the physical property.
-        """
-        # Initial check
-        if len(scf_last_steps) != 2:
-            logger.warning(
-                '`scf_last_steps` needs to be of length 2, pointing to the last 2 SCF steps performed in the simulation.'
-            )
-            return []
-
-        scf_values = []
-        for step in scf_last_steps:
-            try:
-                scf_phys_property = getattr(step, property_name)[i_property]
-                if scf_phys_property.value.u != scf_parameters.threshold_change_unit:
-                    logger.error(
-                        f'The units of the `scf_step.{property_name}.value` does not coincide with the units of the `self_consistency_ref.threshold_unit`.'
-                    )
-                    return []
-            except Exception:
-                return []
-            scf_values.append(scf_phys_property.value.magnitude)
-        return scf_values
 
     def resolve_is_scf_converged(
         self,
@@ -259,7 +209,7 @@ class SCFOutputs(Outputs):
         i_property: int,
         physical_property: PhysicalProperty,
         logger: 'BoundLogger',
-    ) -> bool:
+    ) -> bool:  # TODO: move to `results`?
         """
         Resolves if the physical property is converged or not after a SCF process. This is only ran
         when there are at least two `scf_steps` elements.

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -202,7 +202,6 @@ class SCFOutputs(Outputs):
     `Simulation` entry in NOMAD contains the final output properties and all the SCF steps.
     """
 
-
     def resolve_is_scf_converged(
         self,
         property_name: str,

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -110,12 +110,6 @@ class PhysicalProperty(ArchiveSection):
         # ! add more examples in the description to improve the understanding of this quantity
     )
 
-    # variables = SubSection(sub_section=Variables.m_def, repeats=True)
-
-    # * `value` must be overwritten in the derived classes defining its type, unit, and description
-    # TODO use abstract to enforce policy?
-    value: Quantity = None
-
     entity_ref = Quantity(
         type=Entity,
         description="""

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -140,22 +140,6 @@ class PhysicalProperty(ArchiveSection):
         """,
     )
 
-    is_scf_converged = Quantity(
-        type=bool,
-        description="""
-        Flag indicating whether the physical property is converged or not after a SCF process. This quantity is connected
-        with `SelfConsistency` defined in the `numerical_settings.py` module.
-        """,
-    )
-
-    self_consistency_ref = Quantity(
-        type=SelfConsistency,
-        description="""
-        Reference to the `SelfConsistency` section that defines the numerical settings to converge the
-        physical property (see numerical_settings.py).
-        """,
-    )
-
     @property
     def full_shape(self) -> list[int]:
         """

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -156,22 +156,6 @@ class PhysicalProperty(ArchiveSection):
         """,
     )
 
-    # @property
-    # def variables_shape(self) -> Optional[list]:
-    #    """
-    #    Shape of the variables over which the physical property varies. This is extracted from
-    #    `Variables.n_points` and appended in a list.
-    #
-    #    Example, a physical property which varies with `Temperature` and `ElectricField` will
-    #    return `variables_shape = [n_temperatures, n_electric_fields]`.
-    #
-    #    Returns:
-    #        (list): The shape of the variables over which the physical property varies.
-    #    """
-    #    if self.variables is not None:
-    #        return [v.get_n_points(logger) for v in self.variables]
-    #    return []
-
     @property
     def full_shape(self) -> list[int]:
         """

--- a/src/nomad_simulations/schema_packages/properties/convergence.py
+++ b/src/nomad_simulations/schema_packages/properties/convergence.py
@@ -1,0 +1,90 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nomad.datamodel.datamodel import EntryArchive
+    from structlog.stdlib import BoundLogger
+
+import numpy as np
+
+from nomad_simulations.schema_packages.physical_property import PhysicalProperty
+from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
+from nomad.metainfo import Section, Quantity, Reference
+
+
+class ConvergenceMetric(PhysicalProperty):
+    """
+    Abstract physical property section linking a property contribution to a convergence
+    from some method.
+
+    Abstract class for incorporating specific convergence of a physical property, while
+    linking this convergence to a specific component (of class `BaseModelMethod`) of the
+    over `ModelMethod` using the `model_method_ref` quantity.
+    """
+
+    m_def = Section(
+        a_plotly_express=[
+            {
+                'label': 'convergence',
+                'x': '#iteration_cycles',
+                'y': '#value',
+                'mode': 'lines',
+                'secondary_y': False,
+            },
+            {
+                'label': 'convergence',
+                'x': '#iteration_cycles',
+                'y': '#diff_value',
+                'mode': 'scatter',
+                'secondary_y': True,
+            },
+        ],
+        a_plotly_graph_object={
+            'type': 'line',
+            'x0': 0,
+            'x1': '#settings.n_max_iterations',
+            'y0': '#settings.differential_threshold',
+            'y1': '#settings.differential_threshold',
+        },
+    )
+
+    settings = Quantity(
+        type=Reference(SelfConsistency),
+        description="""
+        Reference to the `SelfConsistency` section to which the convergence is linked to.
+        """,
+    )
+
+    iteration_cycles = Quantity(
+        type=int,
+        shape=['*'],
+        description="""
+        Number of iteration cycles performed to reach the convergence.
+        """,
+    )  # ? Could this be set dynamically
+
+    value = Quantity(
+        type=np.dtype(np.float64),
+        # guideline: specialize the unit
+        shape=['*'],
+        description="""
+        Value of the physical property. The shape of the value is defined by the `variables_shape` and
+        the `value.shape` of the physical property.
+        """,
+    )
+
+    diff_value = Quantity(
+        type=np.dtype(np.float64),
+        # guideline: specialize the unit
+        shape=['*'],
+        description="""
+        Difference of the physical property. The shape of the value is defined by the `variables_shape` and
+        the `value.shape` of the physical property.
+        """,
+    )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+        if not self.iteration_cycles:
+            self.iteration_cycles = list(range(len(self.value)))
+        if not self.diff_value:
+            self.diff_value = np.diff(self.value.magnitude) * self.value.unit

--- a/src/nomad_simulations/schema_packages/properties/convergence.py
+++ b/src/nomad_simulations/schema_packages/properties/convergence.py
@@ -5,10 +5,10 @@ if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
 
 import numpy as np
+from nomad.metainfo import Quantity, Reference, Section
 
-from nomad_simulations.schema_packages.physical_property import PhysicalProperty
 from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
-from nomad.metainfo import Section, Quantity, Reference
+from nomad_simulations.schema_packages.physical_property import PhysicalProperty
 
 
 class ConvergenceMetric(PhysicalProperty):
@@ -73,7 +73,7 @@ class ConvergenceMetric(PhysicalProperty):
     )
 
     diff_value = Quantity(
-        type=np.dtype(np.float64),   #? absolute value
+        type=np.dtype(np.float64),  # ? absolute value
         # guideline: specialize the unit
         shape=['*'],
         description="""
@@ -93,17 +93,21 @@ class ConvergenceMetric(PhysicalProperty):
         """
         Normalize the convergence metric by setting the iteration cycles and diff_value.
         `settings` should receive its data via `after_normalize`.
-        """  #? is `after_normalize` appropriate here
+        """  # ? is `after_normalize` appropriate here
         super().normalize(archive, logger)
         if not self.iteration_cycles:
             self.iteration_cycles = list(range(len(self.value)))
         if not self.diff_value:
             self.diff_value = np.abs(np.diff(self.value.magnitude)) * self.value.unit
         if not self.is_converged:
-            self.is_scf_converged = np.all(self.diff_value < self.settings.differential_threshold)
+            self.is_scf_converged = np.all(
+                self.diff_value < self.settings.differential_threshold
+            )
 
 
 class EnergyConvergence(ConvergenceMetric):
+    # TODO: generate enum for `name`
+
     value = ConvergenceMetric.m_def.value.m_copy()
     value.unit = 'J'
 

--- a/src/nomad_simulations/schema_packages/properties/convergence.py
+++ b/src/nomad_simulations/schema_packages/properties/convergence.py
@@ -73,7 +73,7 @@ class ConvergenceMetric(PhysicalProperty):
     )
 
     diff_value = Quantity(
-        type=np.dtype(np.float64),
+        type=np.dtype(np.float64),   #? absolute value
         # guideline: specialize the unit
         shape=['*'],
         description="""
@@ -82,9 +82,38 @@ class ConvergenceMetric(PhysicalProperty):
         """,
     )
 
+    is_scf_converged = Quantity(
+        type=bool,
+        description="""
+        Boolean value indicating whether the convergence is reached or not, according to the `settings`.
+        """,
+    )
+
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        """
+        Normalize the convergence metric by setting the iteration cycles and diff_value.
+        `settings` should receive its data via `after_normalize`.
+        """  #? is `after_normalize` appropriate here
         super().normalize(archive, logger)
         if not self.iteration_cycles:
             self.iteration_cycles = list(range(len(self.value)))
         if not self.diff_value:
-            self.diff_value = np.diff(self.value.magnitude) * self.value.unit
+            self.diff_value = np.abs(np.diff(self.value.magnitude)) * self.value.unit
+        if not self.is_converged:
+            self.is_scf_converged = np.all(self.diff_value < self.settings.differential_threshold)
+
+
+class EnergyConvergence(ConvergenceMetric):
+    value = ConvergenceMetric.m_def.value.m_copy()
+    value.unit = 'J'
+
+    diff_value = ConvergenceMetric.m_def.diff_value.m_copy()
+    diff_value.unit = 'J'
+
+
+class ForceConvergence(ConvergenceMetric):
+    value = ConvergenceMetric.m_def.value.m_copy()
+    value.unit = 'N'
+
+    diff_value = ConvergenceMetric.m_def.diff_value.m_copy()
+    diff_value.unit = 'N'

--- a/src/nomad_simulations/schema_packages/properties/convergence.py
+++ b/src/nomad_simulations/schema_packages/properties/convergence.py
@@ -99,7 +99,7 @@ class ConvergenceMetric(PhysicalProperty):
             self.iteration_cycles = list(range(len(self.value)))
         if not self.diff_value:
             self.diff_value = np.abs(np.diff(self.value.magnitude)) * self.value.unit
-        if not self.is_converged:
+        if not self.is_scf_converged:
             self.is_scf_converged = np.all(
                 self.diff_value < self.settings.differential_threshold
             )


### PR DESCRIPTION
Specialize convergence reporting to dedicated properties (`ConvergenceMetrics`), instead of the general `PhysicalProperty`.
Define convergence plots based on `ConvergenceMetrics`. Fall back to inheritance for unit specification.
