### PR TITLE
add label quantity to AtomsState

### DIFF
--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -595,6 +595,15 @@ class AtomsState(ParticleState):
         """,
     )
 
+    label = Quantity(
+        type=str,
+        description="""
+        User- or program-package-defined identifier for this atomic site.
+        e.g. 'H1', 'H1a', 'C_eq'.
+        It doesn't replace `chemical_symbol`, but merely gives users a more specialized token for the unique site name.
+        """,
+    )
+
     orbitals_state = SubSection(sub_section=OrbitalsState.m_def, repeats=True)
 
     core_hole = SubSection(sub_section=CoreHole.m_def, repeats=False)


### PR DESCRIPTION
Please see the following issue in the magres parser:
https://github.com/FAIRmat-NFDI/nomad-schema-plugin-nmr/issues/12

The intent is to let users pass DFT-style site labels such as H1, H1a, C_eq, etc., without disturbing the existing `chemical_symbol` / `atomic_number` logic