### PR TITLE
Map `model_system` to `outputs`

### DIFF
--- a/docs/normalize.md
+++ b/docs/normalize.md
@@ -61,7 +61,7 @@ By checking on the `normalize()` functions and **rule 3**, we can establish whet
 
 The `normalize` interface accepts an optional `logger` variable, via which it can store _info_, _warning_, or _error_ messages. <!-- add link to other docs -->
 When `logger` is left `None`, NOMAD will provide its own logger.
-The advantage of providing you own `logger` comes from customization and labelling of code portions.
+The advantage of providing your own `logger` comes from customization and labelling of code portions.
 
 ## Cross-referencing between Sections
 
@@ -73,5 +73,5 @@ If the schema allows for a reference, NOMAD will perform the conversion to and f
 
 ### How To
 
-- **between sections at the same level:** use `self.m_parent` to go one node up in the schema hiearchy. Then climb the schema ladder from any of the connecting sections using up till the first common node.
+- **between sections at the same level:** use `self.m_parent` to go one node up in the schema hierarchy. Then climb the schema ladder from any of the connecting sections using up till the first common node.
 - **between repeating sections:** obtain any subsection's index via `self.m_parent_index`. If they are not `repeating`, the index defaults to `-1`.

--- a/docs/normalize.md
+++ b/docs/normalize.md
@@ -69,6 +69,8 @@ Sections like `model_system` tend to follow a similar structure as `outputs`.
 Our schema highlights this structure by providing references in each section to its counterpart.
 These sections cannot be directly populated by the `MappingAnnotation` parsing technique, but should connected afterwards at the parsing or normalization level.
 
+If the schema allows for a reference, NOMAD will perform the conversion to and from its underlying section automatically.
+
 ### How To
 
 - **between sections at the same level:** use `self.m_parent` to go one node up in the schema hiearchy. Then climb the schema ladder from any of the connecting sections using up till the first common node.

--- a/docs/normalize.md
+++ b/docs/normalize.md
@@ -1,4 +1,6 @@
-# The `normalize()` function
+# Normalization
+
+## The `normalize()` function
 
 Each base section defined using the NOMAD schema has a set of public functions which can be used at any moment when reading and parsing files in NOMAD. The `normalize(archive, logger)` function is a special case of such functions, which warrants an in-depth description.
 
@@ -54,3 +56,20 @@ In case we do not assign a value to `Section1.normalizer_level` and `Section2.no
 3. `ParentSection.normalize()`
 
 By checking on the `normalize()` functions and **rule 3**, we can establish whether `ArchiveSection.normalize()` will be run or not. In `Section1.normalize()`, it will not, while in the other sections, `Section2` and `ParentSection`, it will.
+
+### Logging Messages
+
+The `normalize` interface accepts an optional `logger` variable, via which it can store _info_, _warning_, or _error_ messages. <!-- add link to other docs -->
+When `logger` is left `None`, NOMAD will provide its own logger.
+The advantage of providing you own `logger` comes from customization and labelling of code portions.
+
+## Cross-referencing between Sections
+
+Sections like `model_system` tend to follow a similar structure as `outputs`.
+Our schema highlights this structure by providing references in each section to its counterpart.
+These sections cannot be directly populated by the `MappingAnnotation` parsing technique, but should connected afterwards at the parsing or normalization level.
+
+### How To
+
+- **between sections at the same level:** use `self.m_parent` to go one node up in the schema hiearchy. Then climb the schema ladder from any of the connecting sections using up till the first common node.
+- **between repeating sections:** obtain any subsection's index via `self.m_parent_index`. If they are not `repeating`, the index defaults to `-1`.

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -168,6 +168,7 @@ class Outputs(Time):
                 isinstance(model_systems, list)
                 and isinstance(outputs, list)
                 and len(model_systems) == len(outputs)
+                and len(model_systems) > 0
             ):
                 return model_systems[self.m_parent_index]
         return None

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -155,11 +155,10 @@ class Outputs(Time):
 
     def set_model_system_ref(self) -> Optional[ModelSystem]:
         """
-        Set the reference to the last `ModelSystem` if this is not set in the output. This is only
-        valid if there is only one `ModelSystem` in the parent section.
+        Provide a suggested `ModelSystem` that corresponds to the output collection.
 
         Returns:
-            (Optional[ModelSystem]): The reference to the last `ModelSystem`.
+            (Optional[ModelSystem]): corresponding `ModelSystem`. `None` if there is no such section.
         """
         if self.m_parent is not None:
             model_systems = self.m_parent.model_system

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -164,7 +164,11 @@ class Outputs(Time):
         if self.m_parent is not None:
             model_systems = self.m_parent.model_system
             outputs = self.m_parent.outputs
-            if isinstance(model_systems, list) and isinstance(outputs, list) and len(model_systems) == len(outputs):
+            if (
+                isinstance(model_systems, list)
+                and isinstance(outputs, list)
+                and len(model_systems) == len(outputs)
+            ):
                 return model_systems[self.m_parent_index]
         return None
 

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -163,8 +163,9 @@ class Outputs(Time):
         """
         if self.m_parent is not None:
             model_systems = self.m_parent.model_system
-            if model_systems is not None and len(model_systems) == 1:
-                return model_systems[-1]
+            outputs = self.m_parent.outputs
+            if isinstance(model_systems, list) and isinstance(outputs, list) and len(model_systems) == len(outputs):
+                return model_systems[self.m_parent_index]
         return None
 
     def set_model_method_ref(self) -> Optional[ModelMethod]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,16 +57,11 @@ def generate_simulation(
     """
     Generate a `Simulation` section with the main sub-sections, `ModelSystem`, `ModelMethod`, and `Outputs`.
     """
-    simulation = Simulation()
-    simulation.model_method = model_method
-    simulation.model_system = model_system
-    simulation.outputs = outputs
-
-    # Set up parent relationships for the 1-1 mapping
-    for i, output in enumerate(outputs):
-        output.m_parent = simulation
-        output.m_parent_index = i
-    return simulation
+    return Simulation(
+        model_method=model_method,
+        model_system=model_system,
+        outputs=outputs,
+    )
 
 
 def generate_model_system(
@@ -186,6 +181,8 @@ def generate_simulation_electronic_dos(
     model_system = generate_model_system()
     outputs = Outputs()
     simulation = generate_simulation(model_system=[model_system], outputs=[outputs])
+
+    outputs.normalize(EntryArchive(), logger)
 
     # Populating the `ElectronicDensityOfStates` section
     variables_energy = Energy(points=energy_points * ureg.joule)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def generate_simulation(
     simulation.model_method = model_method
     simulation.model_system = model_system
     simulation.outputs = outputs
-    
+
     # Set up parent relationships for the 1-1 mapping
     for i, output in enumerate(outputs):
         output.m_parent = simulation
@@ -166,7 +166,9 @@ def generate_scf_electronic_band_gap_template(
                 )
             ]
         )
-        simulation = generate_simulation(model_method=[model_method], outputs=[scf_outputs])
+        simulation = generate_simulation(
+            model_method=[model_method], outputs=[scf_outputs]
+        )
         scf_outputs.electronic_band_gaps[
             0
         ].self_consistency_ref = simulation.model_method[0].numerical_settings[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,22 +50,22 @@ if os.getenv('_PYTEST_RAISE', '0') != '0':
 
 
 def generate_simulation(
-    model_system: Optional[ModelSystem] = None,
-    model_method: Optional[ModelMethod] = None,
-    outputs: Optional[Outputs] = None,
+    model_system: list[ModelSystem] = [],
+    model_method: list[ModelMethod] = [],
+    outputs: list[Outputs] = [],
 ) -> Simulation:
     """
-    Generate a `Simulation` section with the main sub-sections, `ModelSystem`, `ModelMethod`, and `Outputs`. If `ModelSystem`
-    and `Outputs` are set, then it adds `ModelSystem` as a reference in `Outputs`.
+    Generate a `Simulation` section with the main sub-sections, `ModelSystem`, `ModelMethod`, and `Outputs`.
     """
     simulation = Simulation()
-    if model_method is not None:
-        simulation.model_method.append(model_method)
-    if model_system is not None:
-        simulation.model_system.append(model_system)
-    if outputs is not None:
-        simulation.outputs.append(outputs)
-        outputs.model_system_ref = model_system
+    simulation.model_method = model_method
+    simulation.model_system = model_system
+    simulation.outputs = outputs
+    
+    # Set up parent relationships for the 1-1 mapping
+    for i, output in enumerate(outputs):
+        output.m_parent = simulation
+        output.m_parent_index = i
     return simulation
 
 
@@ -166,7 +166,7 @@ def generate_scf_electronic_band_gap_template(
                 )
             ]
         )
-        simulation = generate_simulation(model_method=model_method, outputs=scf_outputs)
+        simulation = generate_simulation(model_method=[model_method], outputs=[scf_outputs])
         scf_outputs.electronic_band_gaps[
             0
         ].self_consistency_ref = simulation.model_method[0].numerical_settings[0]
@@ -183,7 +183,7 @@ def generate_simulation_electronic_dos(
     # Create the `Simulation` section to make refs work
     model_system = generate_model_system()
     outputs = Outputs()
-    simulation = generate_simulation(model_system=model_system, outputs=outputs)
+    simulation = generate_simulation(model_system=[model_system], outputs=[outputs])
 
     # Populating the `ElectronicDensityOfStates` section
     variables_energy = Energy(points=energy_points * ureg.joule)
@@ -279,7 +279,7 @@ def generate_k_space_simulation(
     # appending `KSpace` to `ModelMethod.numerical_settings`
     model_method = ModelMethod()
     model_method.numerical_settings.append(k_space)
-    return generate_simulation(model_method=model_method, model_system=model_system)
+    return generate_simulation(model_method=[model_method], model_system=[model_system])
 
 
 def generate_electronic_eigenvalues(
@@ -333,9 +333,9 @@ def generate_electronic_eigenvalues(
     if reciprocal_lattice_vectors:
         k_space.reciprocal_lattice_vectors = reciprocal_lattice_vectors
     _ = generate_simulation(
-        model_system=generate_model_system(),
-        model_method=model_method,
-        outputs=outputs,
+        model_system=[generate_model_system()],
+        model_method=[model_method],
+        outputs=[outputs],
     )
     electronic_eigenvalues = ElectronicEigenvalues(n_bands=2)
     outputs.electronic_eigenvalues = [electronic_eigenvalues]

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -133,7 +133,7 @@ class TestTB:
         from a model_system child typed 'active_atom'.
         """
         tb_method = TB()
-        simulation = generate_simulation(model_method=tb_method)
+        simulation = generate_simulation(model_method=[tb_method])
         simulation.model_system = model_systems
         orbitals_ref = tb_method.resolve_orbital_references(
             model_systems=model_systems,
@@ -246,7 +246,7 @@ class TestTB:
         checking that it sets .type and .orbitals_ref as needed.
         """
         # Attach the TB (or Wannier, or SlaterKoster) to a simulation
-        sim = generate_simulation(model_method=tb_section)
+        sim = generate_simulation(model_method=[tb_section])
         sim.model_system = model_systems
         tb_section.normalize(EntryArchive(), logger=logger)
         # Check the recognized type

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -110,25 +110,43 @@ class TestOutputs:
             assert gaps == result
 
     @pytest.mark.parametrize(
-        'model_system',
-        [(None), (ModelSystem(name='example'))],
+        'model_systems, outputs_list',
+        [
+            # empty lists
+            ([], []),
+            # single element
+            ([ModelSystem(name='system_0')], [Outputs()]),
+            # 3 elements
+            ([ModelSystem(name='system_0'), ModelSystem(name='system_1'), ModelSystem(name='system_2')], 
+             [Outputs(), Outputs(), Outputs()]),
+            # mismatched lengths
+            ([ModelSystem(name='system_0')], [Outputs(), Outputs()]),
+            ([ModelSystem(name='system_0'), ModelSystem(name='system_1')], [Outputs()]),
+        ],
     )
-    def test_set_model_system_ref(self, model_system: Optional[ModelSystem]):
+    def test_set_model_system_ref(self, model_systems: list[ModelSystem], outputs_list: list[Outputs]):
         """
-        Test the `set_model_system_ref` method.
+        Test the `set_model_system_ref` method with 1-1 mapping between model_system and outputs.
 
         Args:
-            model_system (Optional[ModelSystem]): The `ModelSystem` to be tested for the `model_system_ref` reference
-            stored in `Outputs`.
+            model_systems (list[ModelSystem]): List of `ModelSystem` objects to be tested.
+            outputs_list (list[Outputs]): List of `Outputs` objects to be tested.
         """
-        outputs = Outputs()
-        simulation = generate_simulation(model_system=model_system, outputs=outputs)
-        model_system_ref = outputs.set_model_system_ref()
-        if model_system is not None:
-            assert model_system_ref == simulation.model_system[-1]
-            assert model_system_ref.name == 'example'
-        else:
-            assert model_system_ref is None
+        simulation = generate_simulation(model_system=None, outputs=None)
+        simulation.model_system = model_systems
+        simulation.outputs = outputs_list
+
+        for i, output in enumerate(outputs_list):
+            output.m_parent = simulation
+            output.m_parent_index = i
+            
+            model_system_ref = output.set_model_system_ref()
+            
+            if len(model_systems) == len(outputs_list) and len(model_systems) > 0:
+                assert model_system_ref == model_systems[i]
+                assert model_system_ref.name == f'system_{i}'
+            else:
+                assert model_system_ref is None
 
     @pytest.mark.parametrize(
         'model_method',

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -117,14 +117,22 @@ class TestOutputs:
             # single element
             ([ModelSystem(name='system_0')], [Outputs()]),
             # 3 elements
-            ([ModelSystem(name='system_0'), ModelSystem(name='system_1'), ModelSystem(name='system_2')], 
-             [Outputs(), Outputs(), Outputs()]),
+            (
+                [
+                    ModelSystem(name='system_0'),
+                    ModelSystem(name='system_1'),
+                    ModelSystem(name='system_2'),
+                ],
+                [Outputs(), Outputs(), Outputs()],
+            ),
             # mismatched lengths
             ([ModelSystem(name='system_0')], [Outputs(), Outputs()]),
             ([ModelSystem(name='system_0'), ModelSystem(name='system_1')], [Outputs()]),
         ],
     )
-    def test_set_model_system_ref(self, model_systems: list[ModelSystem], outputs_list: list[Outputs]):
+    def test_set_model_system_ref(
+        self, model_systems: list[ModelSystem], outputs_list: list[Outputs]
+    ):
         """
         Test the `set_model_system_ref` method with 1-1 mapping between model_system and outputs.
 
@@ -139,9 +147,9 @@ class TestOutputs:
         for i, output in enumerate(outputs_list):
             output.m_parent = simulation
             output.m_parent_index = i
-            
+
             model_system_ref = output.set_model_system_ref()
-            
+
             if len(model_systems) == len(outputs_list) and len(model_systems) > 0:
                 assert model_system_ref == model_systems[i]
                 assert model_system_ref.name == f'system_{i}'
@@ -161,7 +169,9 @@ class TestOutputs:
             stored in `Outputs`.
         """
         outputs = Outputs()
-        simulation = generate_simulation(model_method=[model_method] if model_method else [], outputs=[outputs])
+        simulation = generate_simulation(
+            model_method=[model_method] if model_method else [], outputs=[outputs]
+        )
         model_method_ref = outputs.set_model_method_ref()
         if model_method is not None:
             assert model_method_ref == simulation.model_method[-1]
@@ -194,7 +204,7 @@ class TestOutputs:
         simulation = generate_simulation(
             model_system=[model_system] if model_system else [],
             model_method=[model_method] if model_method else [],
-            outputs=[outputs]
+            outputs=[outputs],
         )
         outputs.normalize(archive=EntryArchive(), logger=logger)
         if model_system is not None:

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -132,7 +132,7 @@ class TestOutputs:
             model_systems (list[ModelSystem]): List of `ModelSystem` objects to be tested.
             outputs_list (list[Outputs]): List of `Outputs` objects to be tested.
         """
-        simulation = generate_simulation(model_system=None, outputs=None)
+        simulation = generate_simulation()
         simulation.model_system = model_systems
         simulation.outputs = outputs_list
 
@@ -161,7 +161,7 @@ class TestOutputs:
             stored in `Outputs`.
         """
         outputs = Outputs()
-        simulation = generate_simulation(model_method=model_method, outputs=outputs)
+        simulation = generate_simulation(model_method=[model_method] if model_method else [], outputs=[outputs])
         model_method_ref = outputs.set_model_method_ref()
         if model_method is not None:
             assert model_method_ref == simulation.model_method[-1]
@@ -192,7 +192,9 @@ class TestOutputs:
         """
         outputs = Outputs()
         simulation = generate_simulation(
-            model_system=model_system, model_method=model_method, outputs=outputs
+            model_system=[model_system] if model_system else [],
+            model_method=[model_method] if model_method else [],
+            outputs=[outputs]
         )
         outputs.normalize(archive=EntryArchive(), logger=logger)
         if model_system is not None:


### PR DESCRIPTION
As shown here, `model_method` or `model_system` references in `outputs` are only populated when there is a single, clear section.
This is now extended to cover 1-1 mapping with `model_system`.

![Screenshot from 2025-05-23 14-46-33](https://github.com/user-attachments/assets/bff22025-cc2a-4a1a-b7b7-5a06bf76bbd0)
