### PR TITLE
Add shape decorators

### DIFF
--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -55,7 +55,7 @@ def extract_shapes(instance, shape_requirements: dict) -> list[int]:
         list[int]: List of shape values for specified dimensions
         
     Raises:
-        AttributeError: If quantities are not array-like
+        TypeError: If quantities are not array-like and cannot be converted to arrays
         IndexError: If dimension indices are invalid
     """
     return [

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -128,7 +128,7 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
 
             try:
                 proj_shapes = extract_shapes(self, shape_requirements)
-            except AttributeError:
+            except TypeError:
                 logger.warning(
                     f'Some quantities in {self.__class__.__name__} are not array-like.'
                 )

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -93,7 +93,8 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     """
     Decorator that defers shape validation until normalization.
     Only flags mismatching shapes as a warning. If a shape is not defined or populated, it is ignored.
-    
+    Any modifications are inherited by the child classes.
+
     Args:
         quantities (dict[str, set[int]]): `keys` determine the quantity names, while `values` are sets of dimension indices to check.
             Multiple axes indicates squareness along that slice of the quantity.
@@ -144,6 +145,45 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
         cls._validate_shapes = _validate_shapes
         return cls
 
+    return decorator
+
+
+def remove_shape_checks(quantities: dict[str, set[int]] = None):
+    """
+    Decorator to selectively remove shape validation for specific quantities/axes.
+    Any modifications are inherited by the child classes.
+    
+    Args:
+        quantities (dict[str, set[int]], optional): Mapping of quantity names to sets of dimension indices to remove.
+            `None` and empty set `{}` will remove all shape validation, both at the class and quantitiy level.
+
+    Examples:
+        @remove_shape_checks()  # Remove all shape validation
+        @remove_shape_checks({'positions': {}})  # Remove all positions dim checks
+        @remove_shape_checks({'energy': {0}})  # Remove only energy dim 0 check
+        @remove_shape_checks({'forces': {0, 1}})  # Remove forces dims 0,1 checks
+    """
+    def decorator(cls):
+        if quantities is None or quantities == {}:
+            cls._shape_requirements = {}
+            cls._shape_kwargs = {}
+        else:
+            current_requirements = accumulate_class_attributes(cls, '_shape_requirements', {})
+            current_kwargs = accumulate_class_attributes(cls, '_shape_kwargs', {})
+            
+            # Remove specified quantities/axes
+            for quantity_name, axes_to_remove in quantities.items():
+                if quantity_name in current_requirements:
+                    if axes_to_remove is None or axes_to_remove == {}:
+                        del current_requirements[quantity_name]
+                    elif isinstance(current_requirements[quantity_name], set):
+                        current_requirements[quantity_name].difference_update(axes_to_remove)
+            
+            cls._shape_requirements = current_requirements
+            cls._shape_kwargs = current_kwargs
+        
+        return cls
+    
     return decorator
 
 

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -20,39 +20,37 @@ from nomad_simulations.schema_packages.variables import Variables
 logger = utils.get_logger(__name__)
 
 
-def validate_quantity_wrt_value(name: str = ''):
+def same_shapes(quantities: dict[str, int] = {}):  # ? logger
     """
-    Decorator to validate the existence of a quantity and its shape with respect to the `PhysicalProperty.value`
-    before calling a method. An example can be found in the module `properties/band_structure.py` for the method
-    `ElectronicEigenvalues.order_eigenvalues()`.
-
+    Decorator for validating whether the shapes of the quantities in a class are the same.
+    Only flags mismatching shapes as a warning. If a shape is not defined or populated, it is ignored.
+    
     Args:
-        name (str, optional): The name of the `quantity` to validate. Defaults to ''.
+        quantities (dict[str, int]): `keys` determine the quantity names, while `values` .
     """
 
-    def decorator(func):
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            # Checks if `quantity` is defined
-            quantity = getattr(self, name, None)
-            if quantity is None or len(quantity) == 0:
-                logger.warning(f'The quantity `{name}` is not defined.')
-                return False
+    def decorator(cls):
+        full_shapes = [getattr(cls, name, '') for name in quantities]
+        try:
+            proj_shapes = [np.size(val, i) for val, i in zip(full_shapes, quantities.values()) if val]
+        except AttributeError:
+            logger.warning(
+                f'Some quantities in {cls.__name__} are not array-like.'
+            )
+            return cls
+        except IndexError:
+            logger.warning(
+                f'Some quantities in {cls.__name__} do not have valid ranks.'
+            )
+            return cls
 
-            # Checks if `value` exists and has the same shape as `quantity`
-            value = getattr(self, 'value', None)
-            if value is None:
-                logger.warning('The quantity `value` is not defined.')
-                return False
-            if value is not None and value.shape != quantity.shape:
-                logger.warning(
-                    f'The shape of the quantity `{name}` does not match the shape of the `value`.'
-                )
-                return False
+        if len(set(proj_shapes)) > 1:
+            logger.warning(
+                f'The shapes of the requested quantities in {cls.__name__} do not match. '
+                f'Expected shapes: {quantities.values()}, but got: {proj_shapes}'
+            )
 
-            return func(self, *args, **kwargs)
-
-        return wrapper
+        return cls
 
     return decorator
 

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -33,9 +33,12 @@ def same_shapes(quantities: dict[str, int] = {}, **kwargs):
         if (logger := kwargs.get('logger')) is None:
             logger = utils.get_logger(__name__)
 
-        full_shapes = [getattr(cls, name, '') for name in quantities]
         try:
-            proj_shapes = [np.size(val, i) for val, i in zip(full_shapes, quantities.values()) if val]
+            proj_shapes = [
+                np.size(val, dim_idx) 
+                for name, dim_idx in quantities.items() 
+                if (val := getattr(cls, name, ''))
+            ]
         except AttributeError:
             logger.warning(
                 f'Some quantities in {cls.__name__} are not array-like.'

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -20,7 +20,7 @@ from nomad_simulations.schema_packages.variables import Variables
 logger = utils.get_logger(__name__)
 
 
-def same_shapes(quantities: dict[str, int] = {}):  # ? logger
+def same_shapes(quantities: dict[str, int] = {}, **kwargs):
     """
     Decorator for validating whether the shapes of the quantities in a class are the same.
     Only flags mismatching shapes as a warning. If a shape is not defined or populated, it is ignored.
@@ -30,6 +30,9 @@ def same_shapes(quantities: dict[str, int] = {}):  # ? logger
     """
 
     def decorator(cls):
+        if (logger := kwargs.get('logger')) is None:
+            logger = utils.get_logger(__name__)
+
         full_shapes = [getattr(cls, name, '') for name in quantities]
         try:
             proj_shapes = [np.size(val, i) for val, i in zip(full_shapes, quantities.values()) if val]
@@ -44,10 +47,16 @@ def same_shapes(quantities: dict[str, int] = {}):  # ? logger
             )
             return cls
 
-        if len(set(proj_shapes)) > 1:
+        if isinstance((target := kwargs.get('target')), int):
+            if proj_shapes != [target] * len(proj_shapes):
+                logger.warning(
+                    f'The shapes of the requested quantities in {cls.__name__} do not match the target shape {target}. '
+                    f'Expected shape of {target}, but got: {proj_shapes}.'
+                )
+        elif len(set(proj_shapes)) > 1:
             logger.warning(
                 f'The shapes of the requested quantities in {cls.__name__} do not match. '
-                f'Expected shapes: {quantities.values()}, but got: {proj_shapes}'
+                f'Expected shapes: {quantities.values()}, but got: {proj_shapes}.'
             )
 
         return cls

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -20,13 +20,13 @@ from nomad_simulations.schema_packages.variables import Variables
 logger = utils.get_logger(__name__)
 
 
-def same_shapes(quantities: dict[str, int] = {}, **kwargs):
+def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     """
     Decorator for validating whether the shapes of the quantities in a class are the same.
     Only flags mismatching shapes as a warning. If a shape is not defined or populated, it is ignored.
     
     Args:
-        quantities (dict[str, int]): `keys` determine the quantity names, while `values` .
+        quantities (dict[str, set[int]]): `keys` determine the quantity names, while `values` are sets of dimension indices to check.
     """
 
     def decorator(cls):
@@ -36,8 +36,9 @@ def same_shapes(quantities: dict[str, int] = {}, **kwargs):
         try:
             proj_shapes = [
                 np.asarray(val).shape[dim_idx]
-                for name, dim_idx in quantities.items() 
+                for name, dim_indices in quantities.items()
                 if (val := getattr(cls, name, ''))
+                for dim_idx in dim_indices
             ]
         except AttributeError:
             logger.warning(

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -22,7 +22,7 @@ logger = utils.get_logger(__name__)
 
 def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     """
-    Decorator for validating whether the shapes of the quantities in a class are the same.
+    Decorator that defers shape validation until normalization.
     Only flags mismatching shapes as a warning. If a shape is not defined or populated, it is ignored.
     
     Args:
@@ -33,45 +33,59 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
             logger (BoundLogger, optional): Logger instance for warnings. If not provided, uses module logger.
     """
 
-    #? Add support for target as a quantity
-
     def decorator(cls):
-        # Set up logger
-        if (logger := kwargs.get('logger')) is None:
-            logger = utils.get_logger(__name__)
-
-        # Extract all shapes along the specified axes of the quantities
-        try:
-            proj_shapes = [
-                np.asarray(val).shape[dim_idx]
-                for name, dim_indices in quantities.items()
-                if (val := getattr(cls, name, ''))
-                for dim_idx in dim_indices
-            ]
-        except AttributeError:
-            logger.warning(
-                f'Some quantities in {cls.__name__} are not array-like.'
-            )
-            return cls
-        except IndexError:
-            logger.warning(
-                f'Some quantities in {cls.__name__} do not have valid ranks.'
-            )
-            return cls
-
-        # Test the shapes
-        if isinstance((target := kwargs.get('target')), int):
-            if proj_shapes != [target] * len(proj_shapes):
+        # Store shape requirements on the class for later use
+        cls._shape_requirements = quantities
+        cls._shape_kwargs = kwargs
+        
+        # Wrap the existing normalize method
+        original_normalize = getattr(cls, 'normalize', None)
+        
+        def normalize_with_shape_check(self, archive, logger):
+            if original_normalize:
+                original_normalize(self, archive, logger)
+            self._validate_shapes(logger)
+        
+        def _validate_shapes(self, logger):
+            shape_requirements = getattr(self.__class__, '_shape_requirements', {})
+            shape_kwargs = getattr(self.__class__, '_shape_kwargs', {})
+            
+            if not shape_requirements:
+                return
+                
+            try:
+                proj_shapes = [
+                    np.asarray(val).shape[dim_idx]
+                    for name, dim_indices in shape_requirements.items()
+                    if (val := getattr(self, name, None)) is not None
+                    for dim_idx in dim_indices
+                ]
+            except AttributeError:
                 logger.warning(
-                    f'The shapes of the requested quantities in {cls.__name__} do not match the target shape {target}. '
-                    f'Expected shape of {target}, but got: {proj_shapes}.'
+                    f'Some quantities in {self.__class__.__name__} are not array-like.'
                 )
-        elif len(set(proj_shapes)) > 1:
-            logger.warning(
-                f'The shapes of the requested quantities in {cls.__name__} do not match. '
-                f'Expected shapes: {quantities.values()}, but got: {proj_shapes}.'
-            )
-
+                return
+            except IndexError:
+                logger.warning(
+                    f'Some quantities in {self.__class__.__name__} do not have valid ranks.'
+                )
+                return
+                
+            # Validation logic
+            if isinstance((target := shape_kwargs.get('target')), int):
+                if proj_shapes != [target] * len(proj_shapes):
+                    logger.warning(
+                        f'The shapes of the requested quantities in {self.__class__.__name__} do not match the target shape {target}. '
+                        f'Expected shape of {target}, but got: {proj_shapes}.'
+                    )
+            elif len(set(proj_shapes)) > 1:
+                logger.warning(
+                    f'The shapes of the requested quantities in {self.__class__.__name__} do not match. '
+                    f'Expected shapes: {shape_requirements.values()}, but got: {proj_shapes}.'
+                )
+        
+        cls.normalize = normalize_with_shape_check
+        cls._validate_shapes = _validate_shapes
         return cls
 
     return decorator

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -34,9 +34,18 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     """
 
     def decorator(cls):
-        # Store shape requirements on the class for later use
-        cls._shape_requirements = quantities
-        cls._shape_kwargs = kwargs
+        # Accumulate and merge shape requirements along inheritance hierarchy
+        parent_requirements = {}
+        parent_kwargs = {}
+        
+        for base in reversed(cls.__mro__[1:]):  # Skip self, reverse for proper precedence
+            if hasattr(base, '_shape_requirements'):
+                parent_requirements.update(base._shape_requirements)
+            if hasattr(base, '_shape_kwargs'):
+                parent_kwargs.update(base._shape_kwargs)
+        
+        cls._shape_requirements = {**parent_requirements, **quantities}
+        cls._shape_kwargs = {**parent_kwargs, **kwargs}
         
         # Wrap the existing normalize method
         original_normalize = getattr(cls, 'normalize', None)
@@ -52,7 +61,8 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
             
             if not shape_requirements:
                 return
-                
+
+            # Extract shapes of the quantities based on the requirements
             try:
                 proj_shapes = [
                     np.asarray(val).shape[dim_idx]

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -20,6 +20,75 @@ from nomad_simulations.schema_packages.variables import Variables
 logger = utils.get_logger(__name__)
 
 
+def accumulate_class_attributes(cls, attr_name: str, new_data: dict) -> dict:
+    """
+    Accumulate attributes from parent classes in MRO order.
+    Newer additions to the attributes take precedence over inherited ones.
+    
+    Args:
+        cls: The class to process
+        attr_name: Name of the attribute to accumulate
+        new_data: New data to merge with inherited data
+        
+    Returns:
+        dict: Accumulated data with child classes taking precedence
+    """
+    accumulated = {}
+
+    for base in reversed(cls.__mro__[1:]):
+        if hasattr(base, attr_name):
+            accumulated.update(getattr(base, attr_name))
+    
+    accumulated.update(new_data)
+    return accumulated
+
+
+def extract_shapes(instance, shape_requirements: dict) -> list[int]:
+    """
+    Extract shape values from instance quantities based on requirements.
+    
+    Args:
+        instance: Object instance to extract shapes from
+        shape_requirements: Dict mapping quantity names to dimension sets
+        
+    Returns:
+        list[int]: List of shape values for specified dimensions
+        
+    Raises:
+        AttributeError: If quantities are not array-like
+        IndexError: If dimension indices are invalid
+    """
+    return [
+        np.asarray(val).shape[dim_idx]
+        for name, dim_indices in shape_requirements.items()
+        if (val := getattr(instance, name, None)) is not None
+        for dim_idx in dim_indices
+    ]
+
+
+def validate_shape_consistency(proj_shapes: list[int], shape_kwargs: dict, class_name: str, logger) -> None:
+    """
+    Validate that extracted shapes meet consistency requirements.
+    
+    Args:
+        proj_shapes: List of shape values to validate
+        shape_kwargs: Validation parameters (target, etc.)
+        class_name: Name of class being validated (for logging)
+        logger: Logger for warnings
+    """
+    if isinstance((target := shape_kwargs.get('target')), int):
+        if proj_shapes != [target] * len(proj_shapes):
+            logger.warning(
+                f'The shapes of the requested quantities in {class_name} do not match the target shape {target}. '
+                f'Expected shape of {target}, but got: {proj_shapes}.'
+            )
+    elif len(set(proj_shapes)) > 1:
+        logger.warning(
+            f'The shapes of the requested quantities in {class_name} do not match. '
+            f'Got: {proj_shapes}.'
+        )
+
+
 def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     """
     Decorator that defers shape validation until normalization.
@@ -34,26 +103,20 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     """
 
     def decorator(cls):
-        # Accumulate and merge shape requirements along inheritance hierarchy
-        parent_requirements = {}
-        parent_kwargs = {}
-        
-        for base in reversed(cls.__mro__[1:]):  # Skip self, reverse for proper precedence
-            if hasattr(base, '_shape_requirements'):
-                parent_requirements.update(base._shape_requirements)
-            if hasattr(base, '_shape_kwargs'):
-                parent_kwargs.update(base._shape_kwargs)
-        
-        cls._shape_requirements = {**parent_requirements, **quantities}
-        cls._shape_kwargs = {**parent_kwargs, **kwargs}
+        # Always accumulate requirements
+        cls._shape_requirements = accumulate_class_attributes(cls, '_shape_requirements', quantities)
+        cls._shape_kwargs = accumulate_class_attributes(cls, '_shape_kwargs', kwargs)
         
         # Wrap the existing normalize method
         original_normalize = getattr(cls, 'normalize', None)
         
-        def normalize_with_shape_check(self, archive, logger):
+        def normalize_with_validation(self, archive, logger):
             if original_normalize:
                 original_normalize(self, archive, logger)
-            self._validate_shapes(logger)
+            
+            # Only validate if this is the actual instance type (leaf class)
+            if type(self) is cls:
+                self._validate_shapes(logger)
         
         def _validate_shapes(self, logger):
             shape_requirements = getattr(self.__class__, '_shape_requirements', {})
@@ -62,14 +125,8 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
             if not shape_requirements:
                 return
 
-            # Extract shapes of the quantities based on the requirements
             try:
-                proj_shapes = [
-                    np.asarray(val).shape[dim_idx]
-                    for name, dim_indices in shape_requirements.items()
-                    if (val := getattr(self, name, None)) is not None
-                    for dim_idx in dim_indices
-                ]
+                proj_shapes = extract_shapes(self, shape_requirements)
             except AttributeError:
                 logger.warning(
                     f'Some quantities in {self.__class__.__name__} are not array-like.'
@@ -81,20 +138,9 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
                 )
                 return
                 
-            # Validation logic
-            if isinstance((target := shape_kwargs.get('target')), int):
-                if proj_shapes != [target] * len(proj_shapes):
-                    logger.warning(
-                        f'The shapes of the requested quantities in {self.__class__.__name__} do not match the target shape {target}. '
-                        f'Expected shape of {target}, but got: {proj_shapes}.'
-                    )
-            elif len(set(proj_shapes)) > 1:
-                logger.warning(
-                    f'The shapes of the requested quantities in {self.__class__.__name__} do not match. '
-                    f'Expected shapes: {shape_requirements.values()}, but got: {proj_shapes}.'
-                )
+            validate_shape_consistency(proj_shapes, shape_kwargs, self.__class__.__name__, logger)
         
-        cls.normalize = normalize_with_shape_check
+        cls.normalize = normalize_with_validation
         cls._validate_shapes = _validate_shapes
         return cls
 

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -177,7 +177,7 @@ def remove_shape_checks(quantities: dict[str, set[int]], **kwargs):
             # Remove specified quantities/axes
             for quantity_name, axes_to_remove in quantities.items():
                 if quantity_name in current_requirements:
-                    if axes_to_remove == {}:
+                    if not axes_to_remove:
                         del current_requirements[quantity_name]
                     elif isinstance(current_requirements[quantity_name], set):
                         current_requirements[quantity_name].difference_update(axes_to_remove)

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -148,23 +148,26 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     return decorator
 
 
-def remove_shape_checks(quantities: dict[str, set[int]] = None):
+def remove_shape_checks(quantities: dict[str, set[int]], **kwargs):
     """
     Decorator to selectively remove shape validation for specific quantities/axes.
     Any modifications are inherited by the child classes.
     
     Args:
-        quantities (dict[str, set[int]], optional): Mapping of quantity names to sets of dimension indices to remove.
-            `None` and empty set `{}` will remove all shape validation, both at the class and quantitiy level.
+        quantities (dict[str, set[int]]): Mapping of quantity names to sets of dimension indices to remove.
+            Empty set `{}` will remove all shape validation, either at the class or quantity level.
 
     Examples:
-        @remove_shape_checks()  # Remove all shape validation
+        @remove_shape_checks({})  # Remove all shape validation
         @remove_shape_checks({'positions': {}})  # Remove all positions dim checks
         @remove_shape_checks({'energy': {0}})  # Remove only energy dim 0 check
         @remove_shape_checks({'forces': {0, 1}})  # Remove forces dims 0,1 checks
     """
     def decorator(cls):
-        if quantities is None or quantities == {}:
+        if (logger := kwargs.get('logger')) is None:
+            logger = utils.get_logger(__name__)
+
+        if quantities == {}:
             cls._shape_requirements = {}
             cls._shape_kwargs = {}
         else:
@@ -174,10 +177,16 @@ def remove_shape_checks(quantities: dict[str, set[int]] = None):
             # Remove specified quantities/axes
             for quantity_name, axes_to_remove in quantities.items():
                 if quantity_name in current_requirements:
-                    if axes_to_remove is None or axes_to_remove == {}:
+                    if axes_to_remove == {}:
                         del current_requirements[quantity_name]
                     elif isinstance(current_requirements[quantity_name], set):
                         current_requirements[quantity_name].difference_update(axes_to_remove)
+                    else:
+                        logger.warning(
+                            f'Invalid type for quantity {quantity_name} in {cls.__name__}. '
+                            f'Expected set, got {type(current_requirements[quantity_name])}.'
+                        )
+                        return cls  # Invalid type, return original class
             
             cls._shape_requirements = current_requirements
             cls._shape_kwargs = current_kwargs

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -35,7 +35,7 @@ def same_shapes(quantities: dict[str, int] = {}, **kwargs):
 
         try:
             proj_shapes = [
-                np.size(val, dim_idx) 
+                np.asarray(val).shape[dim_idx]
                 for name, dim_idx in quantities.items() 
                 if (val := getattr(cls, name, ''))
             ]

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -33,10 +33,14 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
             logger (BoundLogger, optional): Logger instance for warnings. If not provided, uses module logger.
     """
 
+    #? Add support for target as a quantity
+
     def decorator(cls):
+        # Set up logger
         if (logger := kwargs.get('logger')) is None:
             logger = utils.get_logger(__name__)
 
+        # Extract all shapes along the specified axes of the quantities
         try:
             proj_shapes = [
                 np.asarray(val).shape[dim_idx]
@@ -55,6 +59,7 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
             )
             return cls
 
+        # Test the shapes
         if isinstance((target := kwargs.get('target')), int):
             if proj_shapes != [target] * len(proj_shapes):
                 logger.warning(

--- a/src/nomad_simulations/schema_packages/physical_property.py
+++ b/src/nomad_simulations/schema_packages/physical_property.py
@@ -27,6 +27,10 @@ def same_shapes(quantities: dict[str, set[int]] = {}, **kwargs):
     
     Args:
         quantities (dict[str, set[int]]): `keys` determine the quantity names, while `values` are sets of dimension indices to check.
+            Multiple axes indicates squareness along that slice of the quantity.
+        **kwargs: Optional keyword arguments:
+            target (int, optional): Expected shape value that all dimensions should match. If left unspecified, checks for uniformity across all dimensions.
+            logger (BoundLogger, optional): Logger instance for warnings. If not provided, uses module logger.
     """
 
     def decorator(cls):

--- a/src/nomad_simulations/schema_packages/properties/band_structure.py
+++ b/src/nomad_simulations/schema_packages/properties/band_structure.py
@@ -15,8 +15,7 @@ if TYPE_CHECKING:
 from nomad_simulations.schema_packages.atoms_state import AtomsState, OrbitalsState
 from nomad_simulations.schema_packages.numerical_settings import KSpace
 from nomad_simulations.schema_packages.physical_property import (
-    PhysicalProperty,
-    validate_quantity_wrt_value,
+    PhysicalProperty, same_shapes
 )
 from nomad_simulations.schema_packages.properties.band_gap import ElectronicBandGap
 from nomad_simulations.schema_packages.properties.fermi_surface import FermiSurface
@@ -34,13 +33,6 @@ class BaseElectronicEigenvalues(PhysicalProperty):
 
     iri = ''
 
-    n_bands = Quantity(
-        type=np.int32,
-        description="""
-        Number of bands / eigenvalues.
-        """,
-    )
-
     value = Quantity(
         type=np.float64,
         unit='joule',
@@ -51,6 +43,7 @@ class BaseElectronicEigenvalues(PhysicalProperty):
     )
 
 
+@same_shapes({'value': {1}, 'occupation': {1}})
 class ElectronicEigenvalues(BaseElectronicEigenvalues):
     """ """
 
@@ -65,7 +58,7 @@ class ElectronicEigenvalues(BaseElectronicEigenvalues):
 
     occupation = Quantity(
         type=np.float64,
-        shape=['*', 'n_bands'],
+        shape=['*', '*'],
         description="""
         Occupation of the electronic eigenvalues. This is a number depending whether the `spin_channel` has been set or not.
         If `spin_channel` is set, then this number is between 0 and 1, where 0 means that the state is unoccupied and 1 means
@@ -124,7 +117,6 @@ class ElectronicEigenvalues(BaseElectronicEigenvalues):
         super().__init__(m_def, m_context, **kwargs)
         self.name = self.m_def.name
 
-    @validate_quantity_wrt_value(name='occupation')
     def order_eigenvalues(self) -> Union[bool, tuple[pint.Quantity, np.ndarray]]:
         """
         Order the eigenvalues based on the `value` and `occupation`. The return `value` and
@@ -299,7 +291,7 @@ class ElectronicEigenvalues(BaseElectronicEigenvalues):
         # Resolve `reciprocal_cell` from the `KSpace` numerical settings section
         self.reciprocal_cell = self.resolve_reciprocal_cell()
 
-
+@same_shapes({'k_path': {0}, 'value': {0}, 'occupation': {0}})
 class ElectronicBandStructure(ElectronicEigenvalues):
     """
     Accessible energies by the charges (electrons and holes) in the reciprocal space.

--- a/tests/test_physical_properties.py
+++ b/tests/test_physical_properties.py
@@ -2,13 +2,14 @@ from typing import Optional, Union
 
 import numpy as np
 import pytest
+from _pytest.logging import LoggingPlugin
 from nomad.datamodel import EntryArchive
 from nomad.metainfo import Quantity
 from nomad.units import ureg
 
 from nomad_simulations.schema_packages.physical_property import (
     PhysicalProperty,
-    validate_quantity_wrt_value,
+    same_shapes,
 )
 
 # from nomad_simulations.schema_packages.variables import Variables
@@ -64,47 +65,103 @@ class TestPhysicalProperty:
         assert derived_physical_property.is_derived is True
 
 
-# testing `validate_quantity_wrt_value` decorator
-class ValidatingClass:
-    def __init__(self, value=None, occupation=None):
-        self.value = value
-        self.occupation = occupation
-
-    @validate_quantity_wrt_value('occupation')
-    def validate_occupation(self) -> Union[bool, np.ndarray]:
-        return self.occupation
-
-
 @pytest.mark.parametrize(
-    'value, occupation, result',
+    'quantities, class_attrs, target, warning_text',
     [
-        (None, None, False),  # Both value and occupation are None
-        (np.array([[1, 2], [3, 4]]), None, False),  # occupation is None
-        (None, np.array([[0.5, 1], [0, 0.5]]), False),  # value is None
-        (np.array([[1, 2], [3, 4]]), np.array([]), False),  # occupation is empty
+        # Matching shapes - no warning
         (
-            np.array([[1, 2], [3, 4]]),
-            np.array([[0.5, 1]]),
-            False,
-        ),  # Shapes do not match
+            {'arr1': {0}, 'arr2': {0}},
+            {'arr1': np.array([[1, 2], [3, 4]]), 'arr2': np.array([[5, 6], [7, 8]])},
+            None,
+            '',
+        ),
+        # Mismatched shapes - warning
         (
-            np.array([[1, 2], [3, 4]]),
-            np.array([[0.5, 1], [0, 0.5]]),
-            np.array([[0.5, 1], [0, 0.5]]),
-        ),  # Valid case (return `occupation`)
+            {'arr1': {0}, 'arr2': {0}},
+            {'arr1': np.array([[1, 2], [3, 4]]), 'arr2': np.array([[[1, 2]], [[3, 4]], [[5, 6]]])},
+            None,
+            "do not match",
+        ),
+        # Target shape matching - no warning
+        (
+            {'arr1': {0}, 'arr2': {1}},
+            {'arr1': np.array([[1, 2], [3, 4], [5, 6]]), 'arr2': np.array([[1, 2, 3], [4, 5, 6]])},
+            3,
+            '',
+        ),
+        # Target shape mismatch - warning
+        (
+            {'arr1': {0}},
+            {'arr1': np.array([[1, 2], [3, 4]])},
+            5,
+            "target shape 5",
+        ),
+        # Multiple dimensions matching - no warning
+        (
+            {'arr1': {0, 1}},
+            {'arr1': np.array([[1, 2], [3, 4]])},
+            None,
+            '',
+        ),
+        # Multiple dimensions mismatch - warning
+        (
+            {'arr1': {0, 1}},
+            {'arr1': np.array([[1, 2, 3], [4, 5, 6]])},
+            None,
+            "do not match",
+        ),
+        # Empty quantities - no warning
+        (
+            {},
+            {'arr1': np.array([1, 2, 3])},
+            None,
+            '',
+        ),
+        # Missing attributes - no warning (ignored)
+        (
+            {'nonexistent': {0}},
+            {'arr1': np.array([1, 2, 3])},
+            None,
+            '',
+        ),
+        # Non-array attribute - warning
+        (
+            {'not_array': {0}},
+            {'not_array': "string"},
+            None,
+            "not array-like",
+        ),
+        # Invalid dimension index - warning
+        (
+            {'arr1': {5}},
+            {'arr1': np.array([1, 2, 3])},
+            None,
+            "valid ranks",
+        ),
     ],
 )
-def test_validate_quantity_wrt_value(
-    value: Optional[np.ndarray],
-    occupation: Optional[np.ndarray],
-    result: Union[bool, np.ndarray],
+def test_same_shapes(
+    quantities: dict[str, set[int]], 
+    class_attrs: dict[str, Union[np.ndarray, str]], 
+    target: Optional[int], 
+    warning_text: str, 
+    caplog: LoggingPlugin
 ):
-    """
-    Test the `validate_quantity_wrt_value` decorator.
-    """
-    obj = ValidatingClass(value=value, occupation=occupation)
-    validation = obj.validate_occupation()
-    if isinstance(validation, bool):
-        assert validation == result
+    """Test the same_shapes decorator with various scenarios."""
+    kwargs = {}
+    if target is not None:
+        kwargs['target'] = target
+    
+    @same_shapes(quantities, **kwargs)
+    class TestClass:
+        pass
+    
+    # Set attributes on the class
+    for attr_name, attr_value in class_attrs.items():
+        setattr(TestClass, attr_name, attr_value)
+    
+    if warning_text:
+        assert len(caplog.records) == 1
+        assert warning_text in caplog.records[0].message
     else:
-        assert np.allclose(validation, result)
+        assert len(caplog.records) == 0


### PR DESCRIPTION
While the rank / dimensionality is checked by `nomad`, the actual length along a specific axis typically isn't.
Atm, any length checks typically consist of the population of a `n_` quantity and specific checks for some quantities.

Given the frequency of these checks, it would be better to off-load them to a specialized mechanism. The mechanism should still trigger during normalization (at the end?). It also makes most `n_` quantities irrelevant, as they don't have any purpose in querying.

The PR takes a class decorator approach, for ease of collection and overview. While decorators are more modular, a compound behavior along inheritance will likely come across as most natural and less repetitive. In that case, a "removal" option is also necessary.