### PR TITLE
particle_indices and particle_states 

### DIFF
--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -1130,8 +1130,77 @@ class ModelSystem(System):
 
         return system_type, dimensionality
 
+    def _walk_depth_first(self):
+        """Yield self and every descendant ModelSystem (depth-first)."""
+        yield self
+        for sub in self.sub_systems:
+            yield from sub._walk_depth_first()
+
+    def _consolidate_particle_states(self, logger):
+        """
+        Make sure the representative (top-level) ModelSystem owns a complete,
+        ordered ``particle_states`` list, even if only descendants populated it.
+        """
+        if not self.is_representative:
+            return  # run only on the root
+
+        # 1. Determine how many atoms we expect
+        n_atoms = self.n_particles
+        if n_atoms is None:
+            max_idx = -1
+            for ms in self._walk_depth_first():
+                if ms.particle_indices:
+                    max_idx = max(max_idx, *ms.particle_indices)
+            n_atoms = max_idx + 1
+
+        if n_atoms <= 0:
+            logger.debug('No particles detected; nothing to consolidate.')
+            return
+
+        # 2. Ensure self.particle_states has the right length
+        if not self.particle_states:
+            self.particle_states = [None] * n_atoms
+        elif len(self.particle_states) < n_atoms:
+            self.particle_states.extend([None] * (n_atoms - len(self.particle_states)))
+
+        # 3. Walk the tree and pull states up
+        for ms in self._walk_depth_first():
+            if not ms.particle_states:
+                continue
+            has_indices = (
+                ms.particle_indices is not None and len(ms.particle_indices) > 0
+            )
+            abs_indices = (
+                list(ms.particle_indices)
+                if has_indices
+                else list(range(len(ms.particle_states)))
+            )
+
+            for local_i, abs_i in enumerate(abs_indices):
+                state = ms.particle_states[local_i]
+                if state is None:
+                    continue
+                if self.particle_states[abs_i] is None:
+                    self.particle_states[abs_i] = state
+                elif self.particle_states[abs_i] is not state:
+                    logger.warning(
+                        'Conflicting ParticleState at absolute index %d; '
+                        'keeping the first encountered instance.',
+                        abs_i,
+                    )
+
+        # 4. Sanity check
+        if any(st is None for st in self.particle_states):
+            logger.error(
+                'Consolidation failed: some particle_states remain unresolved.'
+            )
+
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
+
+        # Check particle_states
+        if self.is_representative:
+            self._consolidate_particle_states(logger)
 
         # We don't need to normalize if the system is not representative
         if is_not_representative(model_system=self, logger=logger):

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -982,7 +982,27 @@ class ModelSystem(System):
     particle_states = SubSection(
         section_def=ParticleState.m_def,
         repeats=True,
-        description='Particle states',
+        description="""
+            Per-particle state information.
+
+            - Ordering: In the representative (top-level) `ModelSystem` this list
+            has exactly `n_particles` entries and the order matches
+            `positions[i]`.
+
+            - Normalisation behavior: If parsers fill the list only in child
+            subsystems, the normalizer pulls those states up so the root is always
+            complete. 
+
+            Example
+            -------
+            A water molecule (H₂O):
+
+                positions       : [[…], […], […]]      # 3 atoms
+                particle_states :
+                    [0] AtomsState(H)
+                    [1] AtomsState(H)
+                    [2] AtomsState(O)
+            """,
     )
 
     sub_systems = SubSection(sub_section=SectionProxy('ModelSystem'), repeats=True)

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -760,7 +760,8 @@ class ModelSystem(System):
 
     Atom positions at the top level in the quantity “positions”
     and the per‐atom state (including electronic state information) in the subsection “particle_states”.
-    Downstream subsystems refer to atoms via particle_indices.
+
+    Every sub-system references atoms via the global `particle_indices` that point back to this representative `ModelSystem`.
 
     Definitions:
         - `name` refers to all the verbose and user-dependent naming in ModelSystem,
@@ -812,7 +813,7 @@ class ModelSystem(System):
 
         - Example 5, a passivated heterostructure Si/(GaAs-CO2) has: 1 parent ModelSystem
         section (for Si/(GaAs-CO2)), 2 child ModelSystem sections (for Si and GaAs-CO2),
-        and 2 additional children sections in one of the childs (for GaAs and CO2). The number
+        and 2 additional children sections in one of the children (for GaAs and CO2). The number
         of AtomicCell and Symmetry sections can be inferred using a combination of example
         2 and 3.
     """
@@ -900,11 +901,13 @@ class ModelSystem(System):
         type=np.int32,
         shape=['*'],
         description="""
-        Indices of the particles/atoms in the child with respect to its parent. Example:
-            - We have SrTiO3, where `AtomicCell.labels = ['Sr', 'Ti', 'O', 'O', 'O']`. If
-            we create a `model_system` child for the `'Ti'` atom only, then in that child
-            `ModelSystem.sub_systems[0].particle_indices = [1]`. If now we want to refer both to
-            the `'Ti'` and the last `'O'` atoms, `ModelSystem.sub_systems[0].particle_indices = [1, 4]`.
+        Global indices of the particles that belong to this subsystem, 
+        counted from the representative (top-level) ModelSystem.
+
+        **Example (SrTiO_3 primitive cell)**
+        parent particle_states   : ['Sr', 'Ti', 'O', 'O', 'O']  # → indices 0-4
+        Ti-only subsystem      : particle_indices = [1]
+        Ti + apical-O subsystem: particle_indices = [1, 4]
         """,
     )
 

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -300,3 +300,42 @@ def test_hierarchical_composition_and_branch_depth(n_h2o):
         assert leaf.composition_formula == 'H(2)O(1)'
     # Cu leaf should read "Cu(1)"
     assert cu.composition_formula == 'Cu(1)'
+
+
+def test_consolidate_particle_states_from_children():
+    """
+    Case: the parser populates ParticleState objects only in a child
+    subsystem and leaves the top-level list empty.  After running
+    normalisation on both the Simulation and the representative
+    ModelSystem, the root must own a complete and correctly ordered
+    particle_states list.
+    """
+    # ── build hierarchy ──────────────────────────────────────────────
+    root = ModelSystem(is_representative=True)
+    root.positions = np.zeros((3, 3)) * ureg.angstrom  # three atoms
+    root.n_particles = 3
+    root.cell.append(Cell())  # minimal cell
+
+    leaf = ModelSystem(branch_label='leaf', is_representative=False)
+    root.sub_systems.append(leaf)
+
+    # Child holds all three states, indices [0, 1, 2]
+    leaf.particle_indices = [0, 1, 2]
+    leaf_states = [AtomsState(chemical_symbol='H', atomic_number=1) for _ in range(3)]
+    leaf.particle_states.extend(leaf_states)
+
+    assert not root.particle_states  # root intentionally empty
+
+    # ── run normalisation ───────────────────────────────────────────
+    sim = Simulation(model_system=[root])
+    sim.normalize(EntryArchive(), logger=logger)  # sets branch depth, etc.
+    root.normalize(EntryArchive(), logger=logger)  # triggers consolidation
+
+    # ── assertions ──────────────────────────────────────────────────
+    # root now has a full, ordered list
+    assert len(root.particle_states) == 3
+    for i in range(3):
+        assert root.particle_states[i] is leaf_states[i]
+
+    # leaf still keeps its original list
+    assert leaf.particle_states == leaf_states


### PR DESCRIPTION
## What this PR does

* **Clarifies indexing**  
  * `particle_indices` are now clearly documented as *global indices
    in the top-level `ModelSystem`* (not relative to the direct parent).
  * The `ModelSystem` and `particle_states` doc-strings were updated to repeat
    the rule and give a concrete example.

* **Makes `particle_states` stable**  
  * Added two small helpers:
    * `_walk_depth_first()` – iterate over all sub-systems.
    * `_consolidate_particle_states()` – if the root list is empty, pull the
      states up from the children and build a full, ordered list.
  * The consolidation runs as the very first step in `ModelSystem.normalize()`.

* **RElated tests**  
  * New test `test_consolidate_particle_states_from_children` checks that a
    root with no states gets them correctly from a child.

## Why 

* People weren’t sure whether `particle_indices` should be relative to the
  immediate parent or to the root – we now say “always the root”.
* Some parsers create all `particle_states` at the root, others only in the
  leaves.  After this patch both approaches work without extra glue code.

## Bottom linw

* No schema fields were renamed or removed.
* Existing archives that already store all states at the root behave exactly
  as before (consolidation is a no-op).  
* Child systems can still keep their own copies, nothing is deleted.
