### PR TITLE
temporary fix: 'molecule / cluster' breaks ModelSystem.type enum

### DIFF
--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -843,11 +843,13 @@ class ModelSystem(System):
     )
 
     # TODO work on improving and extending this quantity and the description
+    # TODO distinguish between molecule and cluster
     type = Quantity(
         type=MEnum(
             'atom',
             'active_atom',
-            'molecule / cluster',
+            'molecule',
+            'molecule / cluster',  # this is kept due to MatID Class0D classification
             'monomer',
             '1D',
             'surface',

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -847,9 +847,8 @@ class ModelSystem(System):
         type=MEnum(
             'atom',
             'active_atom',
-            'molecule',
+            'molecule / cluster',
             'monomer',
-            'cluster',
             '1D',
             'surface',
             '2D',

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -849,6 +849,7 @@ class ModelSystem(System):
             'atom',
             'active_atom',
             'molecule',
+            'cluster',
             'molecule / cluster',  # this is kept due to MatID Class0D classification
             'monomer',
             '1D',

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -139,7 +139,7 @@ class TestModelSystem:
         [
             (np.array([[0, 0, 0]]), [False, False, False], 'atom', 0),
             (np.array([[0, 0, 0], [0.5, 0.5, 0.5]]), [True, True, True], 'bulk', 3),
-            # etc. Adjust as needed
+            (np.array([[0, 0, 0], [0, 0, 0.74]]), [False, False, False], 'molecule / cluster', 0),
         ],
     )
     def test_resolve_system_type_dim(self, positions, pbc, expected_type, expected_dim):

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -139,7 +139,12 @@ class TestModelSystem:
         [
             (np.array([[0, 0, 0]]), [False, False, False], 'atom', 0),
             (np.array([[0, 0, 0], [0.5, 0.5, 0.5]]), [True, True, True], 'bulk', 3),
-            (np.array([[0, 0, 0], [0, 0, 0.74]]), [False, False, False], 'molecule / cluster', 0),
+            (
+                np.array([[0, 0, 0], [0, 0, 0.74]]),
+                [False, False, False],
+                'molecule / cluster',
+                0,
+            ),
         ],
     )
     def test_resolve_system_type_dim(self, positions, pbc, expected_type, expected_dim):


### PR DESCRIPTION
here i fix #226, and extend the ModelSystem tests