### PR TITLE
fixed import typo

### DIFF
--- a/src/nomad_simulations/schema_packages/workflow/elastic.py
+++ b/src/nomad_simulations/schema_packages/workflow/elastic.py
@@ -1,5 +1,5 @@
 import numpy as np
-from noamd.datamodel.data import ArchiveSection
+from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel import EntryArchive
 from nomad.datamodel.metainfo.workflow import Link, TaskReference
 from nomad.metainfo import (

--- a/src/nomad_simulations/schema_packages/workflow/elastic.py
+++ b/src/nomad_simulations/schema_packages/workflow/elastic.py
@@ -1,6 +1,6 @@
 import numpy as np
-from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel import EntryArchive
+from nomad.datamodel.data import ArchiveSection
 from nomad.datamodel.metainfo.workflow import Link, TaskReference
 from nomad.metainfo import (
     MEnum,

--- a/src/nomad_simulations/schema_packages/workflow/equation_of_state.py
+++ b/src/nomad_simulations/schema_packages/workflow/equation_of_state.py
@@ -60,7 +60,7 @@ class EOSFit(ArchiveSection):
     m_def = Section(validate=False)
 
     function_name = Quantity(
-        type=MEnum(**tuple(FUNCTION_NAMES.keys())),
+        type=MEnum(*tuple(FUNCTION_NAMES.keys())),
         shape=[],
         description="""
         Specifies the function used to perform the fitting of the volume-energy data. Value


### PR DESCRIPTION
@ladinesa 

Are you aware of the issues from the workflow migration? I just fixed one typo here but then saw that there are a number of other problems...

Errors from parser tests:

```bash


============================================================================= ERRORS =============================================================================
______________________________________________________ ERROR collecting tests/parsers/test_abinit_parser.py ______________________________________________________
tests/parsers/test_abinit_parser.py:4: in <module>
    from nomad_simulation_parsers.parsers.abinit.parser import AbinitParser
src/nomad_simulation_parsers/parsers/abinit/parser.py:15: in <module>
    from nomad_simulations.schema_packages.workflow import (
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/__init__.py:3: in <module>
    from .equation_of_state import EquationOfState
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:55: in <module>
    class EOSFit(ArchiveSection):
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:63: in EOSFit
    type=MEnum(**tuple(FUNCTION_NAMES.keys())),
E   TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
_____________________________________________________ ERROR collecting tests/parsers/test_fhiaims_parser.py ______________________________________________________
tests/parsers/test_fhiaims_parser.py:4: in <module>
    from nomad_simulation_parsers.parsers.fhiaims.parser import FHIAimsParser
src/nomad_simulation_parsers/parsers/fhiaims/parser.py:21: in <module>
    from nomad_simulations.schema_packages.workflow import (
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/__init__.py:3: in <module>
    from .equation_of_state import EquationOfState
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:55: in <module>
    class EOSFit(ArchiveSection):
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:63: in EOSFit
    type=MEnum(**tuple(FUNCTION_NAMES.keys())),
E   TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
_________________________________________________ ERROR collecting tests/parsers/test_quantumespresso_parser.py __________________________________________________
tests/parsers/test_quantumespresso_parser.py:4: in <module>
    from nomad_simulation_parsers.parsers.quantumespresso.parser import (
src/nomad_simulation_parsers/parsers/quantumespresso/parser.py:19: in <module>
    from nomad_simulations.schema_packages.workflow import (
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/__init__.py:3: in <module>
    from .equation_of_state import EquationOfState
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:55: in <module>
    class EOSFit(ArchiveSection):
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:63: in EOSFit
    type=MEnum(**tuple(FUNCTION_NAMES.keys())),
E   TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
____________________________________________________ ERROR collecting tests/parsers/test_wannier90_parser.py _____________________________________________________
tests/parsers/test_wannier90_parser.py:4: in <module>
    from nomad_simulation_parsers.parsers.wannier90.parser import Wannier90Parser
src/nomad_simulation_parsers/parsers/wannier90/parser.py:17: in <module>
    from nomad_simulations.schema_packages.workflow import SinglePoint
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/__init__.py:3: in <module>
    from .equation_of_state import EquationOfState
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:55: in <module>
    class EOSFit(ArchiveSection):
../nomad-simulations/src/nomad_simulations/schema_packages/workflow/equation_of_state.py:63: in EOSFit
    type=MEnum(**tuple(FUNCTION_NAMES.keys())),
E   TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
==================================================================== short test summary info =====================================================================
ERROR tests/parsers/test_abinit_parser.py - TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
ERROR tests/parsers/test_fhiaims_parser.py - TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
ERROR tests/parsers/test_quantumespresso_parser.py - TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
ERROR tests/parsers/test_wannier90_parser.py - TypeError: nomad.metainfo.data_type.Enum() argument after ** must be a mapping, not tuple
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================================= 4 errors in 15.43s
```