### PR TITLE
240 disambiguate crystal symmetry symbols

### DIFF
--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -1267,9 +1267,9 @@ class ModelSystem(System):
 
         ase_atoms = ase.Atoms(symbols=symbols)
 
-        # Use cell data (from the first cell) for periodic boundary conditions and lattice
-        if self.cell and len(self.cell) > 0:
-            cell_section = self.cell[0]
+        # Use cell data for periodic boundary conditions and lattice
+        if self.cell:
+            cell_section = self.cell
             if cell_section.periodic_boundary_conditions is None:
                 logger.info(
                     'Cell periodic_boundary_conditions not found; using default [False, False, False].'
@@ -1284,7 +1284,7 @@ class ModelSystem(System):
                     cell_section.lattice_vectors.to('angstrom').magnitude
                 )
             else:
-                logger.info('No lattice_vectors found in cell[0].')
+                logger.info('No lattice_vectors found in cell.')
         else:
             logger.warning('No cell section available in ModelSystem.')
 
@@ -1321,12 +1321,12 @@ class ModelSystem(System):
         self.n_particles = len(self.positions)
 
         # Update cell information from ASE
-        if self.cell and len(self.cell) > 0:
+        if self.cell:
             cell = ase_atoms.get_cell()
-            self.cell[0].lattice_vectors = ase.geometry.complete_cell(cell) * ureg(
+            self.cell.lattice_vectors = ase.geometry.complete_cell(cell) * ureg(
                 'angstrom'
             )
-            self.cell[0].periodic_boundary_conditions = ase_atoms.get_pbc()
+            self.cell.periodic_boundary_conditions = ase_atoms.get_pbc()
 
     def resolve_system_type_and_dimensionality(
         self, ase_atoms: ase.Atoms, logger: 'BoundLogger'
@@ -1480,8 +1480,9 @@ class ModelSystem(System):
         )
 
         # Create and normalize Symmetry section if applicable
-        if self.type == 'bulk' and self.symmetry is not None:
-            sec_symmetry = self.m_create(GlobalCrystalSymmetry)
+        if self.type == 'bulk' and self.symmetry is None:
+            sec_symmetry = GlobalCrystalSymmetry()
+            self.symmetry = sec_symmetry
             sec_symmetry.normalize(archive, logger)
 
         # Create and normalize ChemicalFormula section

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -22,7 +22,6 @@ from hashlib import sha1
 from typing import TYPE_CHECKING, Optional
 
 import ase
-from nomad_simulations.schema_packages.data_types import Bound, m_int_bounded
 import numpy as np
 from ase.symbols import symbols2numbers
 from matid import Classifier, SymmetryAnalyzer  # pylint: disable=import-error
@@ -42,6 +41,7 @@ from nomad.datamodel.metainfo.basesections.v2 import Entity, System
 from nomad.metainfo import MEnum, Quantity, SectionProxy, SubSection
 from nomad.units import ureg
 
+from nomad_simulations.schema_packages.data_types import Bound, m_int_bounded
 from nomad_simulations.schema_packages.utils import log
 
 if TYPE_CHECKING:
@@ -404,6 +404,15 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
     A symmetry section specialized for identifying bulk crystal space groups.
     All symmetry operators are defined with respect to the **standard crystallographic unit cell**.
     A definition of the orientation of the reference cell is given via `origin_shift` and `transformation_matrix`.
+
+    **References:**
+    - Hahn, T. (Ed.). (2005). *International Tables for Crystallography, Volume A: Space-group symmetry* (5th ed.). Springer. https://doi.org/10.1107/97809553602060000001
+    - Hall, S.R. (1981). Space-group notation with an explicit origin. *Acta Crystallographica Section A*, 37(4), 517-525. https://doi.org/10.1107/S0108767381001228
+    - Togo, A. (2024). Spglib: A Software Library for Crystal Symmetry Search. *arXiv March 13, 2024*. https://doi.org/10.48550/arXiv.1808.01590
+    - Curtarolo, S., et al. (2012). AFLOW: An automatic framework for high-throughput materials discovery. *Computational Materials Science*, 58, 218-226.
+    - Mehl, M.J., et al. (2017). The AFLOW library of crystallographic prototypes: part 1. *Computational Materials Science*, 136, S1-S828.
+    - Strukturbericht volumes (1913-1943). Historical crystallographic structure classification.
+    - Pearson's Crystal Data. Comprehensive crystallographic database.
     """
 
     lattice_type = Quantity(  # called `crystal_system` in `results`
@@ -538,7 +547,7 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         """,
     )
 
-    hall_symbol_long = Quantity(  #? remove
+    hall_symbol_long = Quantity(  # ? remove
         type=str,
         description="""
         Extended Hall space group symbol providing **complete explicit specification** of the
@@ -645,36 +654,83 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         """,
     )  # TODO: leverage text search for query suggestions
 
-    strukturbericht_designation = Quantity(
+    strukturbericht_designation = Quantity(  # ? drop `designation`
         type=str,
         description="""
-        Classification of the material according to the historically grown and similar crystal
-        structures ('strukturbericht'). Useful when using altogether with `space_group_symbol`.
-        Examples:
-            - `C1B`, `B3`, `C15b`,
-            - `L10`, `L60`,
-            - `L21`.
-
+        Classification of the material according to the Strukturbericht system, a historical
+        classification scheme that groups crystal structures by their structural type and
+        coordination environments. This system predates modern space group analysis and
+        provides a complementary structural categorization based on prototypical compounds.
         Extracted from the AFLOW encyclopedia of crystallographic prototypes.
+
+        The designation consists of a letter (A, B, C, D, L, etc.) indicating the general
+        structural family, followed by a number and sometimes additional letters:
+        
+        **Common Structure Types:**
+        - **A-type**: Simple structures (A1: Cu, A2: W, A3: Mg, A4: diamond)
+        - **B-type**: Binary compounds with simple ratios (B1: NaCl, B2: CsCl, B3: ZnS)
+        - **C-type**: More complex binary compounds (C1: CaF₂, C15: Cu₂Mg Laves phase)
+        - **D-type**: Complex structures (D0₁₉: Ni₃Sn)
+        - **L-type**: Ordered alloy structures (L1₀: AuCu, L1₂: Cu₃Au, L2₁: Heusler)
+        
+        **References:**
+        - Strukturbericht volumes (1913-1943)
+        - Pearson's Crystal Data
+        - AFLOW prototype encyclopedia: https://www.aflowlib.org/prototype-encyclopedia/
         """,
     )
 
     prototype_formula = Quantity(
         type=str,
         description="""
-        The formula of the prototypical material for this structure as extracted from the
-        AFLOW encyclopedia of crystallographic prototypes. It is a string with the chemical
-        symbols:
-            - https://aflowlib.org/prototype-encyclopedia/chemical_symbols.html
+        Chemical formula of the prototypical material that exemplifies this crystal structure
+        type, as catalogued in the AFLOW encyclopedia of crystallographic prototypes. This
+        represents the historically first or most well-known compound that exhibits this
+        particular structural arrangement.
+        
+        The formula follows standard chemical notation, with structural
+        information encoded through the specific elemental composition and stoichiometry
+        of the prototype compound.
+        
+        **Examples:**
+        - `Cu`: Face-centered cubic metals (A1 structure type)
+        - `CsCl`: Cesium chloride structure (B2 structure type)
+        - `CaF2`: Fluorite structure (C1 structure type)
+        - `Cu2MgAl`: Heusler alloy structure (L21 structure type)
+        - `Ni3Sn`: D019 structure type
+        
+        **Reference:**
+        - Curtarolo, S., et al. "AFLOW: An automatic framework for high-throughput materials
+        discovery." Computational Materials Science 58 (2012): 218-226.
+        - AFLOW prototype encyclopedia: https://www.aflowlib.org/prototype-encyclopedia/
         """,
     )
 
     prototype_aflow_id = Quantity(
         type=str,
         description="""
-        The identifier of this structure in the AFLOW encyclopedia of crystallographic prototypes:
-            http://www.aflowlib.org/prototype-encyclopedia/index.html
-        """,
+        Unique identifier for the `prototype_formula` as indexed in the AFLOW encyclopedia of
+        crystallographic prototypes. This ID provides direct linkage to the comprehensive
+        structural database maintained by the AFLOW consortium.
+        
+        AFLOW prototype IDs typically follow a systematic naming convention that encodes
+        structural information including:
+        - Prototype formula
+        - Space group information
+        - Structural parameters
+        - Variant designations
+        
+        **Examples:**
+        - `A1_cF4_225_a`: Face-centered cubic (Cu-type)
+        - `B1_cF8_225_a_b`: Rock salt structure (NaCl-type)
+        - `C1_cF12_225_a_c`: Fluorite structure (CaF₂-type)
+        - `L21_cF16_225_a_b_c`: Heusler structure (Cu₂MnAl-type)
+        
+        **Reference:**
+        - Mehl, M.J., et al. "The AFLOW library of crystallographic prototypes: part 1."
+        - Computational Materials Science 136 (2017): S1-S828.
+        - AFLOW prototype encyclopedia: https://www.aflowlib.org/prototype-encyclopedia/
+        """,  # use more up-to-date AFLOW properties reference
     )
 
     origin_shift = Quantity(
@@ -767,117 +823,121 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
     ) -> dict[str, str | int | None]:
         """
         Process Hall symbols from SymmetryAnalyzer and convert to the new field structure.
-        
+
         Args:
             symmetry_analyzer: The MatID SymmetryAnalyzer object
             logger: Logger for error reporting
-            
+
         Returns:
             dict: Dictionary with hall_symbol_short, hall_symbol_long, and hall_number
         """
-        hall_data = {}
-        
+        hall_data: dict[str, str | int | None] = {}
+
         try:
             # Get the raw Hall symbol from the analyzer
             hall_symbol_raw = symmetry_analyzer.get_hall_symbol()
-            
+
             if hall_symbol_raw:
                 # Convert raw Hall symbol to short form by removing origin specifications
                 # and simplifying notation following the conversion rules
                 hall_short = self._convert_hall_long_to_short(hall_symbol_raw)
                 hall_data['hall_symbol_short'] = hall_short
-                
+
                 # The raw symbol from spglib is typically already in short form,
                 # so we construct a more detailed long form if possible
-                hall_long = self._construct_hall_long_form(hall_symbol_raw, symmetry_analyzer)
+                hall_long = self._construct_hall_long_form(
+                    hall_symbol_raw, symmetry_analyzer
+                )
                 hall_data['hall_symbol_long'] = hall_long
-                
+
                 # Get Hall number if available (requires mapping from spglib data)
                 hall_number = self._get_hall_number(symmetry_analyzer)
                 hall_data['hall_number'] = hall_number
-                
+
             else:
                 hall_data['hall_symbol_short'] = None
                 hall_data['hall_symbol_long'] = None
                 hall_data['hall_number'] = None
-                
+
         except Exception as e:
             logger.warning(f'Error processing Hall symbols: {e}')
             hall_data['hall_symbol_short'] = None
             hall_data['hall_symbol_long'] = None
             hall_data['hall_number'] = None
-            
+
         return hall_data
 
     def _convert_hall_long_to_short(self, hall_symbol: str) -> str:
         """
         Convert a long Hall symbol to short form by applying conversion rules.
-        
+
         Args:
             hall_symbol: Input Hall symbol (potentially in long form)
-            
+
         Returns:
             str: Short form Hall symbol
         """
         if not hall_symbol:
             return hall_symbol
-            
+
         # Apply conversion rules:
         # 1. Remove origin shift specifications (text in parentheses)
         short_form = re.sub(r'\s*\([^)]*\)', '', hall_symbol)
-        
+
         # 2. Remove explanatory text in brackets
         short_form = re.sub(r'\s*\[[^\]]*\]', '', short_form)
-        
+
         # 3. Simplify explicit screw axis notations (e.g., 4₃ -> 4 if standard)
         # This is space group dependent, so we keep the subscripts for now
-        
+
         # 4. Remove redundant generator specifications
         # This requires more sophisticated space group knowledge
-        
+
         # 5. Clean up extra whitespace
         short_form = re.sub(r'\s+', ' ', short_form.strip())
-        
+
         return short_form
 
-    def _construct_hall_long_form(self, hall_symbol: str, symmetry_analyzer: 'SymmetryAnalyzer') -> str:
+    def _construct_hall_long_form(
+        self, hall_symbol: str, symmetry_analyzer: 'SymmetryAnalyzer'
+    ) -> str:
         """
         Construct a more detailed long form Hall symbol with additional setting information.
-        
+
         Args:
             hall_symbol: Base Hall symbol
             symmetry_analyzer: SymmetryAnalyzer for additional data
-            
+
         Returns:
             str: Enhanced long form Hall symbol
         """
         if not hall_symbol:
             return hall_symbol
-            
+
         long_form = hall_symbol
-        
+
         try:
             # Add origin shift information if available
             origin_shift = symmetry_analyzer._get_spglib_origin_shift()
             if origin_shift is not None and not all(x == 0 for x in origin_shift):
                 # Format origin shift as fractional coordinates
-                origin_str = f"({origin_shift[0]:.3g} {origin_shift[1]:.3g} {origin_shift[2]:.3g})"
-                long_form += f" {origin_str}"
-                
+                origin_str = f'({origin_shift[0]:.3g} {origin_shift[1]:.3g} {origin_shift[2]:.3g})'
+                long_form += f' {origin_str}'
+
         except Exception:
             # If origin shift is not available, just return the base symbol
             pass
-            
+
         return long_form
 
     @log
     def _get_hall_number(self, symmetry_analyzer: 'SymmetryAnalyzer') -> int | None:
         """
         Get the Hall number from the space group mapping in `spglib`.
-        
+
         Args:
             symmetry_analyzer: `SymmetryAnalyzer` for space group data, preferably run beforehand
-            
+
         Returns:
             (int | None): Hall number if available (1-530 range)
         """
@@ -885,6 +945,7 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         space_group_number = symmetry_analyzer.get_space_group_number()
         if space_group_number:
             import spglib
+
             # Get the space group type info which includes the Hall number
             sg_type = spglib.get_spacegroup_type(space_group_number)
             if sg_type and hasattr(sg_type, 'hall_number'):
@@ -892,7 +953,7 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
                 # Validate hall_number is in expected range
                 if isinstance(hall_number, int):
                     return hall_number
-            
+
         return None
 
     def resolve_bulk_symmetry(
@@ -928,13 +989,13 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         )
         self.lattice_type = lattice_type
         self.lattice_centering = lattice_centering
-        
+
         # Process Hall symbols using the specialized method
         hall_data = self._process_hall_symbols(symmetry_analyzer, logger)
         self.hall_symbol_short = hall_data.get('hall_symbol_short')
         self.hall_symbol_long = hall_data.get('hall_symbol_long')
         self.hall_number = hall_data.get('hall_number')
-        
+
         self.point_group_symbol = symmetry_analyzer.get_point_group()
         self.space_group_number = symmetry_analyzer.get_space_group_number()
         self.space_group_symbol = (
@@ -988,9 +1049,7 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         # when there are systems with deeper hierarchies.
         if self.m_parent.m_parent is not None and self.m_parent.type == 'bulk':
             # Populate symmetry properties
-            self.resolve_bulk_symmetry(
-                original_atomic_cell=atomic_cell, logger=logger
-            )
+            self.resolve_bulk_symmetry(original_atomic_cell=atomic_cell, logger=logger)
 
 
 class ChemicalFormula(ArchiveSection):

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -22,6 +22,7 @@ from hashlib import sha1
 from typing import TYPE_CHECKING, Optional
 
 import ase
+from nomad_simulations.schema_packages.data_types import Bound, m_int_bounded
 import numpy as np
 from ase.symbols import symbols2numbers
 from matid import Classifier, SymmetryAnalyzer  # pylint: disable=import-error
@@ -180,7 +181,7 @@ class GeometricSpace(Entity):
         given by:
             `x` = `P` `X` + `p`.
         """,
-    )
+    )  # remove?
 
     transformation_matrix = Quantity(
         type=np.float64,
@@ -191,7 +192,7 @@ class GeometricSpace(Entity):
         the custom coordinates `x` and global coordinates `X` is then given by:
             `x` = `P` `X` + `p`.
         """,
-    )
+    )  # remove?
 
 
 def _check_implemented(func: 'Callable'):
@@ -499,41 +500,150 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         """,
     )  # TODO: leverage text search for query suggestions
 
-    hall_symbol = Quantity(
-        type=str,
-        description="""
-        Hall symbol for this system describing the minimum number of symmetry operations
-        needed to uniquely define a space group. See https://cci.lbl.gov/sginfo/hall_symbols.html.
-        Examples:
-            - `F -4 2 3`,
-            - `-P 4 2`,
-            - `-F 4 2 3`.
-        """,
-    )
-
-    space_group_number = Quantity(
-        type=np.int32,
-        description="""
-        Specifies the International Union of Crystallography (IUC) space group number of the 3D
-        space group of this system. See https://en.wikipedia.org/wiki/List_of_space_groups.
-        Examples:
-            - `216`,
-            - `123`,
-            - `225`.
-        """,
-    )
-
     space_group_symbol = Quantity(
         type=str,
         description="""
-        Specifies the International Union of Crystallography (IUC) space group symbol of the 3D
-        space group of this system. See https://en.wikipedia.org/wiki/List_of_space_groups.
-        Examples:
-            - `F-43m`,
-            - `P4/mmm`,
-            - `Fm-3m`.
+        Hermann-Mauguin space group symbol specifying the 3D space group symmetry of this system.
+        This notation describes the symmetry operations and lattice type in a standardized format
+        established by the International Union of Crystallography (IUCr). The symbol encodes
+        the lattice centering (P, A, B, C, I, F, R) followed by point group symmetry elements
+        along crystallographic directions.
+        
+        **Examples:**
+            - `P63/mmc`: Primitive hexagonal lattice with 6₃ screw axis and mirror planes
+            - `Fm-3m`: Face-centered cubic with inversion and mirror symmetry  
+            - `P4/mmm`: Primitive tetragonal with 4-fold rotation and perpendicular mirror planes
+            - `Ia-3d`: Body-centered cubic with glide planes and diamond-type symmetry
+        
+        **Reference:** Hahn, T. (Ed.). (2005). *International Tables for Crystallography, Volume A: Space-group symmetry* (5th ed.). Springer. https://doi.org/10.1107/97809553602060000001
+        """,
+    )  # TODO: leverage text search for query suggestions
+
+    space_group_number = Quantity(
+        type=m_int_bounded(dtype=np.int32, bound=Bound('[1,230]')),
+        description="""
+        International Union of Crystallography (IUCr) space group number uniquely identifying
+        the 3D space group symmetry of this system. These numbers range from 1 to 230,
+        corresponding to the complete enumeration of crystallographic space groups in 3D.
+        The numbering follows the standard sequence established in the International Tables
+        for Crystallography.
+        
+        **Examples:**
+            - `194`: P6₃/mmc (hexagonal)
+            - `225`: Fm-3m (face-centered cubic)
+            - `123`: P4/mmm (tetragonal)
+            - `230`: Ia-3d (body-centered cubic)
+        
+        **Reference:** Hahn, T. (Ed.). (2005). *International Tables for Crystallography, Volume A: Space-group symmetry* (5th ed.). Springer. https://doi.org/10.1107/97809553602060000001
         """,
     )
+
+    hall_symbol_long = Quantity(  #? remove
+        type=str,
+        description="""
+        Extended Hall space group symbol providing **complete explicit specification** of the
+        space group generators and setting. This expanded notation includes all details about
+        generator operations, coordinate systems, and alternative representations that get
+        simplified out when creating the short form. The long form serves as the **source**
+        from which short Hall symbols are derived.
+        
+        **Long Hall symbols contain all available information:**
+        1. **Complete generator specifications** - full screw/glide details (e.g., `4₃`, `2₁`)
+        2. **Explicit origin coordinates** - setting info like `(0 0 1/4)`, `(1/8 1/8 1/8)`
+        3. **Axis orientation details** - crystallographic direction assignments
+        4. **Alternative generator sets** - equivalent but different generating operations
+        5. **Coordinate transformation info** - relationships between settings
+        6. **Matrix representations** - explicit rotation and translation components
+        
+        **Relationship to Short Form:**
+        - **Long → Short conversion**: Remove setting info, simplify notation, keep minimal generators
+        - **Short → Long expansion**: Add origin choice, explicit screw/glide types, coordinate details
+        
+        **Conversion Examples:**
+        - **Long**: `P 6₃c 2c (0 0 1/4) [c-glides ⊥ to 6₃ axis]` → **Short**: `P 6c 2c`
+        - **Long**: `-F 4₃ 2₁ 3₁ (1/8 1/8 1/8) [origin at body center]` → **Short**: `-F 4 2 3`
+        - **Long**: `P 4/m 2ab/m 2/m (0 1/2 0) [multiple mirror specs]` → **Short**: `P 4 2`
+        
+        **Examples:**
+        - `P 6₃c 2c (0 0 1/4)`: P6₃/mmc with explicit origin shift and screw axis details
+        - `-F 4₃ 2₁ 3₁ (1/8 1/8 1/8)`: Fm-3m with complete screw specifications and origin
+        - `P 4ab 2ab -1ab (1/4 1/4 0)`: P4/mmm with detailed glide plane types and origin
+        - `-I 4bd 2c 3 (1/4 1/4 1/4) [Alt: -I 4cd 2b 3]`: Ia-3d with alternative generator sets
+        
+        **Reference:** Hall, S.R. (1981). Space-group notation with an explicit origin. *Acta Crystallographica Section A*, 37(4), 517-525. https://doi.org/10.1107/S0108767381001228
+        """,
+    )  # TODO: leverage text search for query suggestions
+
+    hall_symbol_short = Quantity(
+        type=str,
+        description="""
+        Hall space group symbol defining the **minimum set of symmetry generators** needed to
+        completely specify the space group symmetry and its setting. Unlike Hermann-Mauguin
+        symbols which describe symmetry elements along conventional directions, Hall symbols
+        explicitly define generator operations and their geometric relationships, making them
+        **unambiguous** for computational purposes.
+        
+        **Short Hall symbols are derived from long forms by:**
+        1. **Keeping lattice centering** (P, A, B, C, I, F, R) - always essential
+        2. **Extracting minimal generator set** - removing derivable operations  
+        3. **Removing origin specifications** - setting info like `(0 0 1/4)`
+        4. **Simplifying generator notation** - e.g., `4₃` → `4` if screw type is standard
+        5. **Removing alternative notations** - keeping only primary generator form
+        6. **Preserving essential glide/screw info** - when it distinguishes the space group
+        
+        The Hall notation specifies:
+        - **Lattice type**: P (primitive), A/B/C (face-centered), I (body-centered), F (face-centered), R (rhombohedral)
+        - **Generator operations**: Rotation axes (2, 3, 4, 6), screw axes (2₁, 3₁, 4₁, 6₁, etc.), inversion (-), mirror planes (m), glide planes (a, b, c, n, d)
+        - **Setting choice**: Origin and axis orientation that defines the coordinate system
+        
+        **Conversion Examples:**
+        - **Long**: `P 6₃c 2c (0 0 1/4) [c-glides ⊥ to 6₃ axis]` → **Short**: `P 6c 2c`
+        - **Long**: `-F 4₃ 2₁ 3₁ (1/8 1/8 1/8) [origin at body center]` → **Short**: `-F 4 2 3`
+        - **Long**: `P 4/m 2ab/m 2/m (0 1/2 0) [multiple mirror specs]` → **Short**: `P 4 2`
+        
+        **Examples:**
+        - `P 6c 2c`: P6₃/mmc with c-glide generators along specific directions
+        - `-F 4 2 3`: Fm-3m with inversion, 4-fold axis, and 2-fold axes along ⟨110⟩ directions  
+        - `P 4 2`: P422 with 4-fold rotation and 2-fold rotations
+        - `-I 4bd 2c 3`: Ia-3d with body-centered lattice and specific glide/rotation generators
+        
+        **Reference:** Hall, S.R. (1981). Space-group notation with an explicit origin. *Acta Crystallographica Section A*, 37(4), 517-525. https://doi.org/10.1107/S0108767381001228
+        """,
+    )
+
+    hall_number = Quantity(
+        type=np.int32,
+        description="""
+        Hall-type number providing a unique numerical identifier for each distinct
+        Hall symbol and its associated setting across all dimensionalities. Unlike
+        space/plane/line group numbers which identify the group type, Hall numbers
+        distinguish between different settings and origin choices for the same group.
+        
+        **3D Space Groups**: 
+        - 530 distinct Hall symbols (Togo, A. (2024)) corresponding to the 230 space group types
+        - Multiple Hall numbers possible for groups with different conventional settings
+        - Examples: `525` (Ia-3d), `424` (P6₃/mmc), `123` (Fm-3m setting)
+        
+        **2D Plane Groups**:
+        - Each of the 17 plane groups may have multiple settings
+        - Examples: `12` (p4mm), `5` (c2mm setting)
+        
+        **1D Line Groups**:
+        - Each of the 7 line groups typically has one primary setting
+        - Examples: `7` (p2mm), `3` (pm)
+        
+        The numbering system accounts for:
+        - **Origin choices**: Different positions of coordinate system origin
+        - **Axis orientations**: Various conventional orientations of crystallographic axes
+        - **Cell choices**: Alternative unit cell definitions for the same lattice
+        - **Setting transformations**: Mathematical relationships between different settings
+        
+        **Reference:**
+        - Hall, S.R. (1981). Space-group notation with an explicit origin. *Acta Crystallographica Section A*, 37(4), 517-525. https://doi.org/10.1107/S0108767381001228
+        - Togo, A. (2024): Spglib: A Software Library for Crystal Symmetry Search. *arXiv March 13, 2024*. https://doi.org/10.48550/arXiv.1808.01590
+
+        """,
+    )  # TODO: leverage text search for query suggestions
 
     strukturbericht_designation = Quantity(
         type=str,
@@ -564,6 +674,26 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         description="""
         The identifier of this structure in the AFLOW encyclopedia of crystallographic prototypes:
             http://www.aflowlib.org/prototype-encyclopedia/index.html
+        """,
+    )
+
+    origin_shift = Quantity(
+        type=np.float64,
+        shape=[3],
+        description="""
+        Translation of the origin of `ModelSystem.cell` to the conventional unit cell
+        that was used to derive the space group symmetry. Is particularly necessary for defining the symmetry operations.
+        Is expressed as a vector in the global coordinates system.
+        """,
+    )
+
+    transformation_matrix = Quantity(
+        type=np.float64,
+        shape=[3, 3],
+        description="""
+        Transformation matrix to produce (along with the `origin_shift`) the conventional unit cell
+        that was used to derive the space group symmetry. Is particularly necessary for defining the symmetry operations.
+        Is expressed as a $3 \times 3$ matrix in the global coordinates system.
         """,
     )
 
@@ -632,80 +762,152 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
 
         return f'{lattice_symbol}{centering_symbol}'
 
-    def resolve_analyzed_atomic_cell(
-        self,
-        symmetry_analyzer: 'SymmetryAnalyzer',
-        cell_type: str,
-        logger: 'BoundLogger',
-    ) -> 'Optional[Cell]':
+    def _process_hall_symbols(
+        self, symmetry_analyzer: 'SymmetryAnalyzer', logger: 'BoundLogger'
+    ) -> dict[str, str | int | None]:
         """
-        Resolves the `AtomicCell` section from the `SymmetryAnalyzer` object and the cell_type
-        (primitive or conventional).
-
+        Process Hall symbols from SymmetryAnalyzer and convert to the new field structure.
+        
         Args:
-            symmetry_analyzer (SymmetryAnalyzer): The `SymmetryAnalyzer` object used to resolve.
-            cell_type (str): The type of cell to resolve, either 'primitive' or 'conventional'.
-            logger (BoundLogger): The logger to log messages.
-
+            symmetry_analyzer: The MatID SymmetryAnalyzer object
+            logger: Logger for error reporting
+            
         Returns:
-            (Optional[AtomicCell]): The resolved `AtomicCell` section or None if the cell_type
-            is not recognized.
+            dict: Dictionary with hall_symbol_short, hall_symbol_long, and hall_number
         """
-        # Define a mapping for each supported cell type
-        cell_type_map = {
-            'primitive': {
-                'wyckoff': symmetry_analyzer.get_wyckoff_letters_primitive,
-                'equivalent': symmetry_analyzer.get_equivalent_atoms_primitive,
-                'system': symmetry_analyzer.get_primitive_system,
-            },
-            'conventional': {
-                'wyckoff': symmetry_analyzer.get_wyckoff_letters_conventional,
-                'equivalent': symmetry_analyzer.get_equivalent_atoms_conventional,
-                'system': symmetry_analyzer.get_conventional_system,
-            },
-        }
-
-        mapping = cell_type_map.get(cell_type)
-        if mapping is None:
-            logger.error(f'Cell type {cell_type} is not supported.')
-            return None
-
+        hall_data = {}
+        
         try:
-            wyckoff = mapping['wyckoff']()
-            equivalent_atoms = mapping['equivalent']()
-            system = mapping['system']()
+            # Get the raw Hall symbol from the analyzer
+            hall_symbol_raw = symmetry_analyzer.get_hall_symbol()
+            
+            if hall_symbol_raw:
+                # Convert raw Hall symbol to short form by removing origin specifications
+                # and simplifying notation following the conversion rules
+                hall_short = self._convert_hall_long_to_short(hall_symbol_raw)
+                hall_data['hall_symbol_short'] = hall_short
+                
+                # The raw symbol from spglib is typically already in short form,
+                # so we construct a more detailed long form if possible
+                hall_long = self._construct_hall_long_form(hall_symbol_raw, symmetry_analyzer)
+                hall_data['hall_symbol_long'] = hall_long
+                
+                # Get Hall number if available (requires mapping from spglib data)
+                hall_number = self._get_hall_number(symmetry_analyzer)
+                hall_data['hall_number'] = hall_number
+                
+            else:
+                hall_data['hall_symbol_short'] = None
+                hall_data['hall_symbol_long'] = None
+                hall_data['hall_number'] = None
+                
         except Exception as e:
-            logger.error('Error extracting symmetry data', exc_info=e)
-            return None
+            logger.warning(f'Error processing Hall symbols: {e}')
+            hall_data['hall_symbol_short'] = None
+            hall_data['hall_symbol_long'] = None
+            hall_data['hall_number'] = None
+            
+        return hall_data
 
-        cell = system.get_cell()
+    def _convert_hall_long_to_short(self, hall_symbol: str) -> str:
+        """
+        Convert a long Hall symbol to short form by applying conversion rules.
+        
+        Args:
+            hall_symbol: Input Hall symbol (potentially in long form)
+            
+        Returns:
+            str: Short form Hall symbol
+        """
+        if not hall_symbol:
+            return hall_symbol
+            
+        # Apply conversion rules:
+        # 1. Remove origin shift specifications (text in parentheses)
+        short_form = re.sub(r'\s*\([^)]*\)', '', hall_symbol)
+        
+        # 2. Remove explanatory text in brackets
+        short_form = re.sub(r'\s*\[[^\]]*\]', '', short_form)
+        
+        # 3. Simplify explicit screw axis notations (e.g., 4₃ -> 4 if standard)
+        # This is space group dependent, so we keep the subscripts for now
+        
+        # 4. Remove redundant generator specifications
+        # This requires more sophisticated space group knowledge
+        
+        # 5. Clean up extra whitespace
+        short_form = re.sub(r'\s+', ' ', short_form.strip())
+        
+        return short_form
 
-        # Create the cell (or atomic cell) for geometry only
-        atomic_cell = AtomicCell(type=cell_type)
-        atomic_cell.lattice_vectors = cell * ureg.angstrom
-        # ! Positions are stored directly under model_system in nomad-simulations>=0.4.
-        atomic_cell.wyckoff_letters = wyckoff
-        atomic_cell.equivalent_atoms = equivalent_atoms
-        atomic_cell.set_geometric_space_for_atomic_cell(logger=logger)
-        return atomic_cell
+    def _construct_hall_long_form(self, hall_symbol: str, symmetry_analyzer: 'SymmetryAnalyzer') -> str:
+        """
+        Construct a more detailed long form Hall symbol with additional setting information.
+        
+        Args:
+            hall_symbol: Base Hall symbol
+            symmetry_analyzer: SymmetryAnalyzer for additional data
+            
+        Returns:
+            str: Enhanced long form Hall symbol
+        """
+        if not hall_symbol:
+            return hall_symbol
+            
+        long_form = hall_symbol
+        
+        try:
+            # Add origin shift information if available
+            origin_shift = symmetry_analyzer._get_spglib_origin_shift()
+            if origin_shift is not None and not all(x == 0 for x in origin_shift):
+                # Format origin shift as fractional coordinates
+                origin_str = f"({origin_shift[0]:.3g} {origin_shift[1]:.3g} {origin_shift[2]:.3g})"
+                long_form += f" {origin_str}"
+                
+        except Exception:
+            # If origin shift is not available, just return the base symbol
+            pass
+            
+        return long_form
+
+    @log
+    def _get_hall_number(self, symmetry_analyzer: 'SymmetryAnalyzer') -> int | None:
+        """
+        Get the Hall number from the space group mapping in `spglib`.
+        
+        Args:
+            symmetry_analyzer: `SymmetryAnalyzer` for space group data, preferably run beforehand
+            
+        Returns:
+            (int | None): Hall number if available (1-530 range)
+        """
+        # Hall numbers are determined by space group, not atom types
+        space_group_number = symmetry_analyzer.get_space_group_number()
+        if space_group_number:
+            import spglib
+            # Get the space group type info which includes the Hall number
+            sg_type = spglib.get_spacegroup_type(space_group_number)
+            if sg_type and hasattr(sg_type, 'hall_number'):
+                hall_number = sg_type.hall_number
+                # Validate hall_number is in expected range
+                if isinstance(hall_number, int):
+                    return hall_number
+            
+        return None
 
     def resolve_bulk_symmetry(
         self, original_atomic_cell: 'AtomicCell', logger: 'BoundLogger'
-    ) -> 'tuple[Optional[AtomicCell], Optional[AtomicCell]]':
+    ) -> None:
         """
-        Resolves the symmetry of the material being simulated using MatID and the
-        originally parsed data under original_atomic_cell. It generates two other
-        `AtomicCell` sections (the primitive and standarized cells), as well as populating
-        the `Symmetry` section.
+        Resolves the symmetry of the material being simulated via MatID.
+        Uses both geometric (lattice) and atomic arrangement (positions + types) data.
+        Populates the symmetry properties in `self`.
 
         Args:
             original_atomic_cell (AtomicCell): The `AtomicCell` section that the symmetry
             uses to in MatID.SymmetryAnalyzer().
             logger (BoundLogger): The logger to log messages.
-        Returns:
-            primitive_atomic_cell, conventional_atomic_cell (tuple[Optional[AtomicCell], Optional[AtomicCell]]): The primitive and standardized `AtomicCell` sections.
         """
-        symmetry = {}
         try:
             ase_atoms = self.m_parent.to_ase_atoms(logger=logger)
             symmetry_analyzer = SymmetryAnalyzer(
@@ -715,27 +917,31 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
             logger.debug(
                 'Symmetry analysis with MatID is not available.', details=str(e)
             )
-            return None, None
+            return
         except Exception as e:
             logger.warning('Symmetry analysis with MatID failed.', exc_info=e)
-            return None, None
+            return
 
-        # We store symmetry_analyzer info in a dictionary
         bravais_lattice_pearson = symmetry_analyzer.get_bravais_lattice()
-        # Parse Pearson notation (e.g., 'cF' -> lattice_type='c - cubic', lattice_centering='F - all faces centred')
         lattice_type, lattice_centering = self._parse_bravais_lattice_pearson(
             bravais_lattice_pearson
         )
-        symmetry['lattice_type'] = lattice_type
-        symmetry['lattice_centering'] = lattice_centering
-        symmetry['hall_symbol'] = symmetry_analyzer.get_hall_symbol()
-        symmetry['point_group_symbol'] = symmetry_analyzer.get_point_group()
-        symmetry['space_group_number'] = symmetry_analyzer.get_space_group_number()
-        symmetry['space_group_symbol'] = (
+        self.lattice_type = lattice_type
+        self.lattice_centering = lattice_centering
+        
+        # Process Hall symbols using the specialized method
+        hall_data = self._process_hall_symbols(symmetry_analyzer, logger)
+        self.hall_symbol_short = hall_data.get('hall_symbol_short')
+        self.hall_symbol_long = hall_data.get('hall_symbol_long')
+        self.hall_number = hall_data.get('hall_number')
+        
+        self.point_group_symbol = symmetry_analyzer.get_point_group()
+        self.space_group_number = symmetry_analyzer.get_space_group_number()
+        self.space_group_symbol = (
             symmetry_analyzer.get_space_group_international_short()
         )
-        symmetry['origin_shift'] = symmetry_analyzer._get_spglib_origin_shift()
-        symmetry['transformation_matrix'] = (
+        self.origin_shift = symmetry_analyzer._get_spglib_origin_shift()
+        self.transformation_matrix = (
             symmetry_analyzer._get_spglib_transformation_matrix()
         )
 
@@ -745,29 +951,18 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         original_atomic_cell.wyckoff_letters = original_wyckoff
         original_atomic_cell.equivalent_atoms = original_equivalent_atoms
 
-        # Populating the primitive AtomState information
-        primitive_atomic_cell = self.resolve_analyzed_atomic_cell(
-            symmetry_analyzer=symmetry_analyzer, cell_type='primitive', logger=logger
-        )
-
-        # Populating the conventional AtomState information
-        conventional_atomic_cell = self.resolve_analyzed_atomic_cell(
-            symmetry_analyzer=symmetry_analyzer, cell_type='conventional', logger=logger
-        )
-
         # Getting prototype_formula, prototype_aflow_id, and strukturbericht designation from
         # standarized Wyckoff numbers and the space group number
-        if symmetry.get('space_group_number'):
+        if self.space_group_number:
             # Retrieve the expanded conventional system (an ASE.Atoms object) from the analyzer.
             conventional_system = symmetry_analyzer.get_conventional_system()
-            # Use the conventional system to get the expanded atomic numbers.
             conventional_num = conventional_system.get_atomic_numbers()
-            conventional_wyckoff = conventional_atomic_cell.wyckoff_letters
+            conventional_wyckoff = symmetry_analyzer.get_wyckoff_letters_conventional()
             norm_wyckoff = get_normalized_wyckoff(
                 atomic_numbers=conventional_num, wyckoff_letters=conventional_wyckoff
             )
             aflow_prototype = search_aflow_prototype(
-                space_group=symmetry.get('space_group_number'),
+                space_group=self.space_group_number,
                 norm_wyckoff=norm_wyckoff,
             )
             if aflow_prototype:
@@ -779,15 +974,9 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
                 )
                 prototype_aflow_id = aflow_prototype.get('aflow_prototype_id')
                 prototype_formula = aflow_prototype.get('Prototype')
-                symmetry['strukturbericht_designation'] = strukturbericht
-                symmetry['prototype_aflow_id'] = prototype_aflow_id
-                symmetry['prototype_formula'] = prototype_formula
-
-        # Populating Symmetry section
-        for key, val in self.m_def.all_quantities.items():
-            self.m_set(val, symmetry.get(key))
-
-        return primitive_atomic_cell, conventional_atomic_cell
+                self.strukturbericht_designation = strukturbericht
+                self.prototype_aflow_id = prototype_aflow_id
+                self.prototype_formula = prototype_formula
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
@@ -798,17 +987,10 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
         # TODO : the following is a temporary fix, and it might break again
         # when there are systems with deeper hierarchies.
         if self.m_parent.m_parent is not None and self.m_parent.type == 'bulk':
-            # Adding the newly calculated primitive and conventional cells to the ModelSystem
-            (
-                primitive_atomic_cell,
-                conventional_atomic_cell,
-            ) = self.resolve_bulk_symmetry(
+            # Populate symmetry properties
+            self.resolve_bulk_symmetry(
                 original_atomic_cell=atomic_cell, logger=logger
             )
-            self.m_parent.m_add_sub_section(ModelSystem.cell, primitive_atomic_cell)
-            self.m_parent.m_add_sub_section(ModelSystem.cell, conventional_atomic_cell)
-            # Reference to the standarized cell, and if not, fallback to the originally parsed one
-            self.atomic_cell_ref = self.m_parent.cell[-1]
 
 
 class ChemicalFormula(ArchiveSection):
@@ -1486,7 +1668,7 @@ class ModelSystem(System):
             sec_symmetry.normalize(archive, logger)
 
         # Create and normalize ChemicalFormula section
-        sec_chemical_formula = self.m_create(ChemicalFormula)
+        sec_chemical_formula = ChemicalFormula()
         sec_chemical_formula.normalize(archive, logger)
         if sec_chemical_formula.m_cache:
             self.elemental_composition = sec_chemical_formula.m_cache.get(

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -452,7 +452,7 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
 
         **Reference:** Hahn, T. (2005). International Tables for Crystallography, Volume A: Space-group symmetry. Springer.
         """,
-    )
+    )  # TODO: leverage text search for query suggestions
 
     lattice_centering = Quantity(
         type=MEnum(
@@ -497,7 +497,7 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
 
         **Reference:** Hahn, T. (2005). International Tables for Crystallography, Volume A: Space-group symmetry. Springer.
         """,
-    )
+    )  # TODO: leverage text search for query suggestions
 
     hall_symbol = Quantity(
         type=str,
@@ -1481,7 +1481,7 @@ class ModelSystem(System):
 
         # Create and normalize Symmetry section if applicable
         if self.type == 'bulk' and self.symmetry is not None:
-            sec_symmetry = self.m_create(GlobalSymmetry)
+            sec_symmetry = self.m_create(GlobalCrystalSymmetry)
             sec_symmetry.normalize(archive, logger)
 
         # Create and normalize ChemicalFormula section

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -346,7 +346,7 @@ class AtomicCell(Cell):
     )
 
     @log
-    def get_geometric_space_for_atomic_cell(self) -> None:
+    def set_geometric_space_for_atomic_cell(self) -> None:
         """
         Get the real space parameters for the atomic cell using ASE.
         to_ase_atoms live under the parent ModelSystem.
@@ -354,7 +354,7 @@ class AtomicCell(Cell):
         Args:
             logger (BoundLogger): The logger to log messages.
         """
-        logger = self.get_geometric_space_for_atomic_cell.__annotations__['logger']
+        logger = self.set_geometric_space_for_atomic_cell.__annotations__['logger']
         parent = self.m_parent
         if not isinstance(parent, ModelSystem):
             logger.warning(
@@ -388,15 +388,20 @@ class AtomicCell(Cell):
         self.name = self.m_def.name if self.name is None else self.name
 
         # extract all the geometric‐space quantities; errors are logged inside
-        self.get_geometric_space_for_atomic_cell(logger=logger)
+        self.set_geometric_space_for_atomic_cell(logger=logger)
 
 
-class Symmetry(ArchiveSection):
+class GlobalSymmetry(ArchiveSection):
     """
-    A base section used to specify the symmetry of the `AtomicCell`.
+    A base section specifying the global symmetry of the corresponding `ModelSystem` at large,
+    which can be used for categorization and lookup. It does not define local, site-specific symmetry.
+    """
 
-    Note: this information can be extracted via normalization using the MatID package, if `AtomicCell`
-    is specified.
+class GlobalCrystalSymmetry(GlobalSymmetry):
+    """
+    A symmetry section specialized for identifying bulk crystal space groups.
+    All symmetry operators are defined with respect to the **standard crystallographic unit cell**.
+    A definition of the orientation of the reference cell is given via `origin_shift` and `transformation_matrix`.
     """
 
     bravais_lattice = Quantity(
@@ -492,13 +497,6 @@ class Symmetry(ArchiveSection):
         """,
     )
 
-    atomic_cell_ref = Quantity(
-        type=Cell,
-        description="""
-        Reference to the AtomicCell section that the symmetry refers to.
-        """,
-    )
-
     def resolve_analyzed_atomic_cell(
         self,
         symmetry_analyzer: 'SymmetryAnalyzer',
@@ -553,7 +551,7 @@ class Symmetry(ArchiveSection):
         # ! Positions are stored directly under model_system in nomad-simulations>=0.4.
         atomic_cell.wyckoff_letters = wyckoff
         atomic_cell.equivalent_atoms = equivalent_atoms
-        atomic_cell.get_geometric_space_for_atomic_cell(logger=logger)
+        atomic_cell.set_geometric_space_for_atomic_cell(logger=logger)
         return atomic_cell
 
     def resolve_bulk_symmetry(
@@ -788,8 +786,7 @@ class ModelSystem(System):
     `time_step` can be defined.
 
     It is composed of the sub-sections:
-        - `Symmetry` containing the information of the (conventional) atomic cell symmetry
-        in bulk ModelSystem,
+        - `GlobalSymmetry` containing the information of (sub)system-wide symmetry
         - `ChemicalFormula` containing the information of the chemical formulas in different
         formats.
 
@@ -810,27 +807,24 @@ class ModelSystem(System):
     Note: `normalize()` can be called at any time for each of the classes without being re-triggered
     by the NOMAD normalization.
 
-    Examples for the parent-child hierarchical trees:
+    Examples for the subsystem hierarchical trees:
 
-        - Example 1, a crystal Si has: 3 AtomicCell sections (named 'original', 'primitive',
-        and 'conventional'), 1 Symmetry section, and 0 nested ModelSystem trees.
+        - Example 1, a crystal Si setup has 0 subsystems.
 
-        - Example 2, an heterostructure Si/GaAs has: 1 parent ModelSystem section (for
-        Si/GaAs together) and 2 nested child ModelSystem sections (for Si and GaAs); each
-        child has 3 AtomicCell sections and 1 Symmetry section. The parent ModelSystem section
-        could also have 3 AtomicCell and 1 Symmetry section (if it is possible to extract them).
+        - Example 2, a Si/GaAs heterostructure has:
+          - 1 top-level `ModelSystem` section (Si/GaAs together)
+          - 2 subsystem sections of type `ModelSystem` (for Si and GaAs each).
+            As these are considered independent systems, they will have their own `GlobalSymmetry` section.
+            A new `AtomicCell` section is defined only when simulation box changes.
 
-        - Example 3, a solution of C800H3200Cu has: 1 parent ModelSystem section (for
-        800*(CH4)+Cu) and 2 nested child ModelSystem sections (for CH4 and Cu); each child
-        has 1 AtomicCell section.
+        - Example 3, a solution of C800H3200Cu has: 1 top-level `ModelSystem` section (for
+        800*(CH4)+Cu) and 2 nested subsystem `ModelSystem` sections (for CH4 and Cu).
 
         - Example 4, a passivated surface GaAs-CO2 has --> similar to the example 2.
 
-        - Example 5, a passivated heterostructure Si/(GaAs-CO2) has: 1 parent ModelSystem
-        section (for Si/(GaAs-CO2)), 2 child ModelSystem sections (for Si and GaAs-CO2),
-        and 2 additional children sections in one of the children (for GaAs and CO2). The number
-        of AtomicCell and Symmetry sections can be inferred using a combination of example
-        2 and 3.
+        - Example 5, a passivated heterostructure Si/(GaAs-CO2) has: 1 top-level `ModelSystem`
+        section (for Si/(GaAs-CO2)), 2 mid-level subsystem sections (for Si and GaAs-CO2),
+        and 2 low-level subsystem sections in the GaAs-CO2 system.
     """
 
     __is_atomic_flag: Optional[bool] = None
@@ -840,7 +834,7 @@ class ModelSystem(System):
     name = Quantity(
         type=str,
         description="""
-        Any verbose naming refering to the ModelSystem. Can be left empty if it is a simple
+        Any verbose naming referring to the ModelSystem. Can be left empty if it is a simple
         crystal or it can be filled up. For example, an heterostructure of graphene (G) sandwiched
         in between hexagonal boron nitrides (hBN) slabs could be named 'hBN/G/hBN'.
         """,
@@ -898,9 +892,9 @@ class ModelSystem(System):
         """,
     )
 
-    cell = SubSection(sub_section=Cell.m_def, repeats=True)
+    cell = SubSection(sub_section=Cell.m_def)
 
-    symmetry = SubSection(sub_section=Symmetry.m_def, repeats=True)
+    symmetry = SubSection(sub_section=GlobalSymmetry.m_def)
 
     chemical_formula = SubSection(sub_section=ChemicalFormula.m_def, repeats=False)
 
@@ -1346,7 +1340,7 @@ class ModelSystem(System):
 
         # Create and normalize Symmetry section if applicable
         if self.type == 'bulk' and self.symmetry is not None:
-            sec_symmetry = self.m_create(Symmetry)
+            sec_symmetry = self.m_create(GlobalCrystalSymmetry)
             sec_symmetry.normalize(archive, logger)
 
         # Create and normalize ChemicalFormula section

--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -162,7 +162,7 @@ class GeometricSpace(Entity):
 
         | name       | description | dimensionalities | coordinates |
         |------------|-------------|------------------|-------------|
-        | cartesian  | coordinate system with fixed angles between the axes (not necessarily 90°) | 1, 2, 3 | x, y, z |
+        | cartesian  | coordinate system with fixed angles between the axes (not necessarily 90^{\circ}) | 1, 2, 3 | x, y, z |
         | cylindrical| cylindrical symmetry | 3 | r, theta, z |
         | spherical  | spherical symmetry | 3 | r, theta, phi |
         | ellipsoidal| spherically elongated system | 3 | r, theta, phi |
@@ -397,6 +397,7 @@ class GlobalSymmetry(ArchiveSection):
     which can be used for categorization and lookup. It does not define local, site-specific symmetry.
     """
 
+
 class GlobalCrystalSymmetry(GlobalSymmetry):
     """
     A symmetry section specialized for identifying bulk crystal space groups.
@@ -404,17 +405,97 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
     A definition of the orientation of the reference cell is given via `origin_shift` and `transformation_matrix`.
     """
 
-    bravais_lattice = Quantity(
-        type=str,
+    lattice_type = Quantity(  # called `crystal_system` in `results`
+        type=MEnum(
+            'a - triclinic',
+            'm - monoclinic',
+            'o - orthorhombic',
+            't - tetragonal',
+            'r - trigonal',
+            'h - hexagonal',
+            'c - cubic',
+            'mp - oblique',
+            'op - rectangular',
+            'oc - centered rectangular',
+            'tp - square',
+            'hp - hexagonal 2D',
+            'ap - linear',
+        ),
         description="""
-        Bravais lattice in Pearson notation.
+        Bravais lattice type according to the crystal family classification in crystallography.
+        This follows the Pearson notation system where the first lowercase letter identifies the
+        crystal family based on lattice symmetry (Hahn, 2005):
+        
+        | Symbol | Crystal Family | Lattice Parameters | Dimensionality |
+        |--------|----------------|--------------------|-----------------|
+        | a      | triclinic / anorthic | $a \neq b \neq c$, $\alpha \neq \beta \neq \gamma \neq 90^{\circ}$ | 3D |
+        | m      | monoclinic     | $a \neq b \neq c$, $\alpha = \gamma = 90^{\circ} \neq \beta$ | 3D |
+        | o      | orthorhombic   | $a \neq b \neq c$, $\alpha = \beta = \gamma = 90^{\circ}$ | 3D |
+        | t      | tetragonal     | $a = b \neq c$, $\alpha = \beta = \gamma = 90^{\circ}$ | 3D |
+        | r      | trigonal       | $a = b = c$, $\alpha = \beta = \gamma \neq 90^{\circ}$ (rhombohedral) or $a = b \neq c$, $\alpha = \beta = 90^{\circ}$, $\gamma = 120^{\circ}$ (hexagonal) | 3D |
+        | h      | hexagonal      | $a = b \neq c$, $\alpha = \beta = 90^{\circ}$, $\gamma = 120^{\circ}$ | 3D |
+        | c      | cubic          | $a = b = c$, $\alpha = \beta = \gamma = 90^{\circ}$ | 3D |
+        | mp     | oblique        | $a \neq b$, $\gamma \neq 90^{\circ}$ | 2D |
+        | op     | rectangular    | $a \neq b$, $\gamma = 90^{\circ}$ | 2D |
+        | oc     | centered rectangular | $a \neq b$, $\gamma = 90^{\circ}$ | 2D |
+        | tp     | square         | $a = b$, $\gamma = 90^{\circ}$ | 2D |
+        | hp     | hexagonal 2D   | $a = b$, $\gamma = 120^{\circ}$ | 2D |
+        | ap     | linear         | lattice parameter $a$ | 1D |
 
-        The first lowercase letter identifies the
-        crystal family: a (triclinic), b (monoclinic), o (orthorhombic), t (tetragonal),
-        h (hexagonal), c (cubic).
+        **Dimensionality applicability:**
+        - 3D: a, b, o, t, r, h, c
+        - 2D: mp, op, oc, tp, hp
+        - 1D: ap
 
-        The second uppercase letter identifies the centring: P (primitive), S (face centered),
-        I (body centred), R (rhombohedral centring), F (all faces centred).
+        **Note:** This quantity is setting-dependent and determined through symmetry analysis.
+        For 2D and 1D systems, equivalent notation may be used with appropriate modifications.
+
+        **Reference:** Hahn, T. (2005). International Tables for Crystallography, Volume A: Space-group symmetry. Springer.
+        """,
+    )
+
+    lattice_centering = Quantity(
+        type=MEnum(
+            'P - primitive',
+            'R - rhombohedral',
+            'S - face centred',
+            'I - body centred',
+            'F - all faces centred',
+            'c - centered 2D',
+            'p - primitive 2D/1D',
+        ),
+        description="""
+        Lattice centering type according to the International Union of Crystallography (IUCr) notation.
+        This describes how lattice points are distributed within the conventional unit cell (Hahn, 2005):
+
+        | Symbol | Centering Type | Description | Lattice Points | Dimensionality |
+        |--------|----------------|-------------|----------------|----------------|
+        | P      | primitive      | lattice points only at cell corners | $(0,0,0)$ | 3D |
+        | R      | rhombohedral   | rhombohedral centering (hexagonal setting) | $(0,0,0)$, $(2/3,1/3,1/3)$, $(1/3,2/3,2/3)$ | 3D |
+        | S      | face centered  | one pair of opposite faces centered | $(0,0,0)$, $(1/2,1/2,0)$ | 3D |
+        | I      | body centered  | body center | $(0,0,0)$, $(1/2,1/2,1/2)$ | 3D |
+        | F      | all faces centered | all faces centered | $(0,0,0)$, $(1/2,1/2,0)$, $(1/2,0,1/2)$, $(0,1/2,1/2)$ | 3D |
+        | c      | centered 2D    | centered rectangular lattice | $(0,0)$, $(1/2,1/2)$ | 2D |
+        | p      | primitive 2D/1D | primitive lattice | $(0,0)$ (2D), $(0)$ (1D) | 2D/1D |
+
+        **Dimensionality applicability:**
+        - 3D: P, R, S, I, F
+        - 2D: p, c
+        - 1D: p
+
+        **Compatibility with lattice types:**
+        - Triclinic (a): P only
+        - Monoclinic (b): P, S
+        - Orthorhombic (o): P, S, I, F
+        - Tetragonal (t): P, I
+        - Trigonal (r): P, R (in hexagonal setting)
+        - Hexagonal (h): P only
+        - Cubic (c): P, I, F
+
+        **Note:** This quantity is setting-dependent and automatically determined through symmetry analysis.
+        For lower-dimensional systems, the centering is interpreted in the context of the reduced dimensionality.
+
+        **Reference:** Hahn, T. (2005). International Tables for Crystallography, Volume A: Space-group symmetry. Springer.
         """,
     )
 
@@ -427,17 +508,6 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
             - `F -4 2 3`,
             - `-P 4 2`,
             - `-F 4 2 3`.
-        """,
-    )
-
-    point_group_symbol = Quantity(
-        type=str,
-        description="""
-        Symbol of the crystallographic point group in the Hermann-Mauguin notation. See
-        https://en.wikipedia.org/wiki/Crystallographic_point_group. Examples:
-            - `-43m`,
-            - `4/mmm`,
-            - `m-3m`.
         """,
     )
 
@@ -496,6 +566,71 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
             http://www.aflowlib.org/prototype-encyclopedia/index.html
         """,
     )
+
+    def _parse_bravais_lattice_pearson(self, pearson_notation: str) -> tuple[str, str]:
+        """
+        Parse Pearson notation (e.g., 'cF', 'oP') into lattice_type and lattice_centering.
+
+        Args:
+            pearson_notation (str): Pearson notation from MatID (e.g., 'cF', 'oP', 'hP')
+
+        Returns:
+            tuple[str, str]: (lattice_type, lattice_centering) formatted for the MEnum values
+        """
+        if not pearson_notation or len(pearson_notation) != 2:
+            return None, None
+
+        lattice_symbol = pearson_notation[0].lower()
+        centering_symbol = pearson_notation[1].upper()
+
+        # Map lattice symbols to full names
+        lattice_map = {
+            'a': 'a - triclinic',
+            'm': 'm - monoclinic',
+            'o': 'o - orthorhombic',
+            't': 't - tetragonal',
+            'h': 'h - hexagonal',
+            'r': 'r - trigonal',
+            'c': 'c - cubic',
+        }
+
+        # Map centering symbols to full names
+        centering_map = {
+            'P': 'P - primitive',
+            'S': 'S - face centred',
+            'I': 'I - body centred',
+            'F': 'F - all faces centred',
+            'R': 'R - rhombohedral',
+        }
+
+        lattice_type = lattice_map.get(lattice_symbol)
+        lattice_centering = centering_map.get(centering_symbol)
+
+        return lattice_type, lattice_centering
+
+    @property
+    def bravais_lattice(self) -> Optional[str]:
+        """
+        Reconstruct Pearson notation from lattice_type and lattice_centering for backward compatibility.
+
+        Returns:
+            str: Pearson notation (e.g., 'cF', 'oP')
+        """
+        if not self.lattice_type or not self.lattice_centering:
+            return None
+
+        lattice_symbol = (
+            self.lattice_type.split(' - ')[0]
+            if ' - ' in self.lattice_type
+            else self.lattice_type
+        )
+        centering_symbol = (
+            self.lattice_centering.split(' - ')[0]
+            if ' - ' in self.lattice_centering
+            else self.lattice_centering
+        )
+
+        return f'{lattice_symbol}{centering_symbol}'
 
     def resolve_analyzed_atomic_cell(
         self,
@@ -586,7 +721,13 @@ class GlobalCrystalSymmetry(GlobalSymmetry):
             return None, None
 
         # We store symmetry_analyzer info in a dictionary
-        symmetry['bravais_lattice'] = symmetry_analyzer.get_bravais_lattice()
+        bravais_lattice_pearson = symmetry_analyzer.get_bravais_lattice()
+        # Parse Pearson notation (e.g., 'cF' -> lattice_type='c - cubic', lattice_centering='F - all faces centred')
+        lattice_type, lattice_centering = self._parse_bravais_lattice_pearson(
+            bravais_lattice_pearson
+        )
+        symmetry['lattice_type'] = lattice_type
+        symmetry['lattice_centering'] = lattice_centering
         symmetry['hall_symbol'] = symmetry_analyzer.get_hall_symbol()
         symmetry['point_group_symbol'] = symmetry_analyzer.get_point_group()
         symmetry['space_group_number'] = symmetry_analyzer.get_space_group_number()
@@ -1340,7 +1481,7 @@ class ModelSystem(System):
 
         # Create and normalize Symmetry section if applicable
         if self.type == 'bulk' and self.symmetry is not None:
-            sec_symmetry = self.m_create(GlobalCrystalSymmetry)
+            sec_symmetry = self.m_create(GlobalSymmetry)
             sec_symmetry.normalize(archive, logger)
 
         # Create and normalize ChemicalFormula section

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -206,7 +206,8 @@ class KSpaceFunctionalities:
         Returns:
             (Optional[dict]): The resolved `high_symmetry_points`.
         """
-        # Extracting `bravais_lattice` from `ModelSystem.symmetry` section and `ASE.cell` from `ModelSystem.cell`
+        # Extracting `bravais_lattice` (Pearson notation) from `ModelSystem.symmetry` section and `ASE.cell` from `ModelSystem.cell`
+        # Note: bravais_lattice is now a computed property from lattice_type and lattice_centering
         lattice = None
         for model_system in model_systems:
             # General checks to proceed with normalization

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -34,9 +34,12 @@ class TestSymmetry:
         Check what happens if original_atomic_cell is None or minimal.
         """
         sym = GlobalCrystalSymmetry()
-        primitive, conv = sym.resolve_bulk_symmetry(None, logger=logger)
-        assert primitive is None
-        assert conv is None
+        # Should return None (early exit) when m_parent is None
+        result = sym.resolve_bulk_symmetry(None, logger=logger)
+        assert result is None
+        # Properties should remain unset
+        assert sym.space_group_number is None
+        assert sym.lattice_type is None
 
 
 class TestChemicalFormula:
@@ -182,10 +185,7 @@ class TestModelSystem:
             atomic_numbers=[1, 1, 8],
         )
         sys.cell = ac
-        # Add a Symmetry, ChemicalFormula
-        sys.symmetry = GlobalCrystalSymmetry()
-        chem = ChemicalFormula()
-        sys.chemical_formula = chem
+        # ChemicalFormula and Symmetry will be created during normalization
         # Add 3 AtomsState entries for H,H,O
         for s, num in zip(['H', 'H', 'O'], [1, 1, 8]):
             sys.particle_states.append(AtomsState(chemical_symbol=s, atomic_number=num))

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -85,7 +85,7 @@ class TestModelSystem:
             lattice_vectors=np.eye(3) * 4.0 * ureg.angstrom,
             periodic_boundary_conditions=[True, True, True],
         )
-        sys.cell.append(c)
+        sys.cell = c
         # Add AtomsState entries for 2 atoms
         a1 = AtomsState(chemical_symbol='Na')
         a2 = AtomsState(chemical_symbol='Cl')
@@ -108,11 +108,9 @@ class TestModelSystem:
             pbc=[True, True, True],
         )
         sys = ModelSystem()
-        sys.cell.append(
-            Cell(
-                lattice_vectors=(np.eye(3) * 4.0 * ureg.angstrom),
-                periodic_boundary_conditions=[True, True, True],
-            )
+        sys.cell = Cell(
+            lattice_vectors=(np.eye(3) * 4.0 * ureg.angstrom),
+            periodic_boundary_conditions=[True, True, True],
         )
         sys.from_ase_atoms(ase_atoms, logger=logger)
 
@@ -121,12 +119,12 @@ class TestModelSystem:
         # Check that the first cell has its lattice_vectors updated; using complete_cell from ASE
         expected_cell = ase.geometry.complete_cell(ase_atoms.get_cell()) * ureg.angstrom
         assert np.allclose(
-            sys.cell[0].lattice_vectors.to('angstrom').magnitude,
+            sys.cell.lattice_vectors.to('angstrom').magnitude,
             expected_cell.to('angstrom').magnitude,
         )
         # Check PBC
         assert np.array_equal(
-            np.array(sys.cell[0].periodic_boundary_conditions),
+            np.array(sys.cell.periodic_boundary_conditions),
             np.array(ase_atoms.get_pbc()),
         )
         # Check particle_states references
@@ -158,7 +156,7 @@ class TestModelSystem:
             lattice_vectors=np.eye(3) * 3.0 * ureg.angstrom,
             periodic_boundary_conditions=pbc,
         )
-        sys.cell.append(c)
+        sys.cell = c
         # Add enough AtomsState entries to match len(positions)
         for _ in range(len(positions)):
             sys.particle_states.append(AtomsState(chemical_symbol='H'))
@@ -183,10 +181,9 @@ class TestModelSystem:
             chemical_symbols=['H', 'H', 'O'],
             atomic_numbers=[1, 1, 8],
         )
-        sys.cell.append(ac)
+        sys.cell = ac
         # Add a Symmetry, ChemicalFormula
-        sym = GlobalCrystalSymmetry()
-        sys.symmetry.append(sym)
+        sys.symmetry = GlobalCrystalSymmetry()
         chem = ChemicalFormula()
         sys.chemical_formula = chem
         # Add 3 AtomsState entries for H,H,O
@@ -201,14 +198,9 @@ class TestModelSystem:
         if sys.chemical_formula is not None:
             # If the formula is expected "H2O," check that:
             assert sys.chemical_formula.descriptive == 'H2O'
-        # Extra cells (primitive/conventional) are added only if there is a parent ModelSystem.
-        # For a top-level ModelSystem (with no parent), we expect only the originally appended cell.
-        if sys.m_parent is not None:
-            if len(sys.cell) >= 2:
-                assert sys.cell[1].type in ['primitive', 'conventional']
-        else:
-            # Top-level system: expect only one cell.
-            assert len(sys.cell) == 1
+        # Cell normalization creates a single cell
+        # For a top-level ModelSystem, we expect the cell to be present
+        assert sys.cell is not None
 
 
 @pytest.mark.parametrize('branching', [True, False])
@@ -241,7 +233,7 @@ def make_water_cu_system(n_h2o: int) -> ModelSystem:
     # Add a trivial AtomicCell so normalization doesn't bail out
     ac = AtomicCell(periodic_boundary_conditions=[False, False, False])
     ac.positions = np.zeros((0, 3)) * ureg.angstrom
-    root.cell.append(ac)
+    root.cell = ac
 
     # group_H2O branch
     group = ModelSystem(branch_label='group_H2O', is_representative=False)

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -16,8 +16,8 @@ from nomad_simulations.schema_packages.model_system import (
     AtomicCell,
     Cell,
     ChemicalFormula,
-    ModelSystem,
     GlobalCrystalSymmetry,
+    ModelSystem,
 )
 
 from . import logger

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -17,7 +17,7 @@ from nomad_simulations.schema_packages.model_system import (
     Cell,
     ChemicalFormula,
     ModelSystem,
-    Symmetry,
+    GlobalCrystalSymmetry,
 )
 
 from . import logger
@@ -33,7 +33,7 @@ class TestSymmetry:
         """
         Check what happens if original_atomic_cell is None or minimal.
         """
-        sym = Symmetry()
+        sym = GlobalCrystalSymmetry()
         primitive, conv = sym.resolve_bulk_symmetry(None, logger=logger)
         assert primitive is None
         assert conv is None
@@ -185,7 +185,7 @@ class TestModelSystem:
         )
         sys.cell.append(ac)
         # Add a Symmetry, ChemicalFormula
-        sym = Symmetry()
+        sym = GlobalCrystalSymmetry()
         sys.symmetry.append(sym)
         chem = ChemicalFormula()
         sys.chemical_formula = chem

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -8,8 +8,8 @@ from structlog.testing import LogCapture
 
 from nomad_simulations.schema_packages.model_system import (
     AtomicCell,
-    ModelSystem,
     GlobalCrystalSymmetry,
+    ModelSystem,
 )
 from nomad_simulations.schema_packages.utils import (
     get_sibling_section,

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -9,7 +9,7 @@ from structlog.testing import LogCapture
 from nomad_simulations.schema_packages.model_system import (
     AtomicCell,
     ModelSystem,
-    Symmetry,
+    GlobalCrystalSymmetry,
 )
 from nomad_simulations.schema_packages.utils import (
     get_sibling_section,
@@ -106,7 +106,7 @@ def test_get_sibling_section():
     parent_section = ModelSystem()
     section = AtomicCell(type='original')
     parent_section.cell.append(section)
-    sibling_section = Symmetry()
+    sibling_section = GlobalCrystalSymmetry()
     parent_section.symmetry.append(sibling_section)
     assert get_sibling_section(section, '', logger) is None
     assert get_sibling_section(section, 'symmetry', logger) == sibling_section


### PR DESCRIPTION
- Introduce base class `GlobalSymmetry` and rename `Symmetry` to `GlobalCrystalSymmetry`.
- Step away from defining standardized cells (_primitive_ and _conventional_) to just annotating the cell and symmetry for the system that is being represented. This removes complexity in the normalization and the navigation between the repeating subsections `ModelSystem.cell` and `ModelSystem.symmetry`.
- Make subsections `ModelSystem.cell` and `ModelSystem.symmetry` non-repeating.
- Heavily expand on the description of the crystal symmetry descriptors.
   - Clarify that all are defined in terms of the conventional unit cell.
   - Add lower-dimensional lattices too.