### PR TITLE
Add labels to identify pull request scope

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,10 @@
+changelog:
+  exclude:
+    authors: [github-actions, pre-commit-ci]
+  categories:
+    - title: 💥 Incompatible API Changes
+      labels: [breaking, refactor]
+    - title: 💡 Added Functionalities (Backward Compatible)
+      labels: [feature, enhancement, DX, UX, docs, tests]
+    - title: 🛠 Backward Compatible Bug Fixes And Minor Changes (Backward Compatible)
+      labels: [dependencies, fix, datamodel, pkg]


### PR DESCRIPTION
@JFRudzinski please check this out. With this yaml + changing the current labels + assigning labels ONLY in pull requests, the management of the package can be done more easy. This is so that when a new release is done, we know exactly which number to pump:

> Given a version number MAJOR.MINOR.PATCH, increment the:
> 
> MAJOR version when you make incompatible API changes
> MINOR version when you add functionality in a backward compatible manner
> PATCH version when you make backward compatible bug fixes

Feel free to check and see whether some other potential labels are necessary. I think these are more than enough, but others can be defined if we find that are important later on.