### PR TITLE
assign `representative_system_index` to zero for singleton cases

### DIFF
--- a/src/nomad_simulations/schema_packages/general.py
+++ b/src/nomad_simulations/schema_packages/general.py
@@ -277,6 +277,14 @@ class Simulation(BaseSimulation, Schema):
         if len(rep_idx) == 0:
             self.model_system[-1].is_representative = True
             self.representative_system_index = -1
+
+            # - Singleton: store concrete index 0
+            # - Multi-system: keep sentinel -1 ("last element")
+            if len(self.model_system) == 1:
+                self.representative_system_index = 0
+            else:
+                self.representative_system_index = -1
+
         elif len(rep_idx) > 1:
             logger.warning(
                 'Multiple representative systems found, one allowed.'

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -325,8 +325,8 @@ class TestSimulation:
         ([True, False, True, False], 2, [False, False, True, False]),
         # 3) exactly one representative → preserve it
         ([False, True, False], 1, [False, True, False]),
-        # 4) singleton without representative → promote itself, index -1 (first pass)
-        ([False], -1, [True]),
+        # 4) singleton without representative → promote itself, index 0
+        ([False], 0, [True]),
     ],
 )
 def test_representative_selection(initial_flags, expected_index, expected_flags):


### PR DESCRIPTION
- For a single `ModelSystem` with no representative set, normalization now uses `representative_system_index = 0` instead of -1.

- Multi-system behavior (sentinel -1 when no rep is marked) is unchanged.

- Updated the corresponding test to match the new singleton behavior.


**Rationale**

The majority of entries typically has a single `ModelSystem.`
Storing` representative_system_index = 0` for this case is more intuitive, avoids downstream handling of -1, and aligns with how the representative system is conceptually interpreted.