### PR TITLE
Add pseudo potential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ todos*
 questions*
 warnings*
 important*
+
+# Claude Code artifacts
+.claude/agents/
+*_contributions_*.md

--- a/docs/model_method/basis_sets.md
+++ b/docs/model_method/basis_sets.md
@@ -49,7 +49,44 @@ It can even derive the former from the latter via normalization.
 
 ### Pseudopotentials
 
-Under construction...
+Pseudopotentials replace the strong Coulomb potential of the nucleus and tightly-bound core electrons with a weaker effective potential acting on valence electrons. This approximation dramatically reduces the number of basis functions needed in plane-wave calculations while preserving chemical behavior.
+
+The `Pseudopotential` class stores metadata identifying which pseudopotential files were used. The actual numerical data (radial functions, projectors, augmentation charges) resides in external files (POTCAR, UPF, psp8, etc.) that are typically not archived due to size and licensing restrictions.
+
+#### Type Classification
+
+The `type` field classifies pseudopotentials by their fundamental formalism:
+
+- **NC** (Norm-conserving): Maintains charge norm in the pseudized core region. Highest transferability across chemical environments but requires higher plane-wave cutoffs. Generated using methods like Troullier-Martins or optimized dual-space approaches.
+
+- **US** (Ultrasoft): Vanderbilt's formalism that relaxes norm-conservation for significantly softer pseudopotentials. Lower cutoffs reduce computational cost but may sacrifice transferability. All ultrasoft pseudopotentials follow the same fundamental formalism.
+
+- **PAW** (Projector Augmented Wave): All-electron frozen-core method that reconstructs the full wavefunction within augmentation spheres. Standard PAW uses non-norm-conserving partial waves optimized for ground-state DFT.
+
+- **NC-PAW**: PAW with norm-conserving partial waves. More expensive than standard PAW but provides better scattering properties for high-energy states.
+
+- **NC-PAW-GW**: NC-PAW optimized for GW/BSE calculations. Includes additional projectors at higher energies to accurately describe quasiparticle states far above the Fermi level. Standard PAW and US systematically underestimate scattering into high-energy unoccupied states, which is critical for many-body perturbation theory.
+
+#### Cross-Code Terminology
+
+Different DFT codes use varying terminology and file organization schemes for pseudopotentials. The table below maps common code-specific naming conventions to the standardized schema fields:
+
+| Code | File Format | Hardness Indicators | Type Detection | Standard Sets |
+|------|-------------|---------------------|----------------|---------------|
+| **VASP** | POTCAR (proprietary) | `_h` (hard), `_s` (soft) suffixes; ENMAX/ENMIN in header | LPAW=T → PAW; LULTRA=T → US; _GW suffix → NC-PAW-GW | Licensed with VASP; organized by XC functional (PBE, LDA, etc.) |
+| **Quantum ESPRESSO** | UPF (XML) | Type-dependent recommended cutoffs; ecutwfc/ecutrho in input | Header `pseudo_type` field (NC/US/PAW); `paw_as_gipaw` flag | SSSP (precision/efficiency), PseudoDojo (standard/stringent), Quantum ESPRESSO library |
+| **CASTEP** | UPF or proprietary | COARSE/MEDIUM/FINE precision levels; `cut_off_energy` in file | Inferred from file content structure | "On-the-fly" generation (OTFG); NCP/USP libraries organized by functional |
+| **ABINIT** | psp8 (text), UPF | `high`/`low` suffixes in PseudoDojo sets; `ecut` recommendation in header | `pspcod` identifier (Troullier-Martins, HGH, PAW); format version | PseudoDojo (NC and PAW-XML), JTH table (PAW), HGH tables |
+
+**Notes:**
+
+- Hardness terminology across codes refers to the same underlying physics: smaller core radii require higher plane-wave cutoffs but provide better transferability and accuracy.
+
+- VASP, QE, and CASTEP all support PAW, but implementation details differ. VASP's PAW follows Kresse & Joubert (1999), while QE implements the original Blöchl formulation.
+
+- The Morrison-Bylander-Kleinman (MBK) separable form is an implementation technique used across all types in modern codes, not a distinct pseudopotential classification.
+
+- Standard pseudopotential libraries (SSSP, PseudoDojo) provide validation data including recommended cutoffs and accuracy metrics (Δ-gauge). These should be used when available rather than arbitrary cutoff choices.
 
 ## LAPW
 

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1134,7 +1134,7 @@ class AtomsState(ParticleState):
     electronic_state = SubSection(sub_section=ElectronicState.m_def)
 
     pseudopotential = Quantity(
-        type=Reference(SectionProxy('Pseudopotential')),
+        type=Reference(SectionProxy('nomad_simulations.schema_packages.numerical_settings.Pseudopotential')),
         description="""
         Reference to the pseudopotential used for this atomic species in plane-wave DFT
         calculations. The referenced `Pseudopotential` section is defined in `numerical_settings`

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1134,7 +1134,11 @@ class AtomsState(ParticleState):
     electronic_state = SubSection(sub_section=ElectronicState.m_def)
 
     pseudopotential = Quantity(
-        type=Reference(SectionProxy('nomad_simulations.schema_packages.numerical_settings.Pseudopotential')),
+        type=Reference(
+            SectionProxy(
+                'nomad_simulations.schema_packages.numerical_settings.Pseudopotential'
+            )
+        ),
         description="""
         Reference to the pseudopotential used for this atomic species in plane-wave DFT
         calculations. The referenced `Pseudopotential` section is defined in `numerical_settings`

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -6,7 +6,7 @@ import ase
 import numpy as np
 import pint
 from nomad.datamodel.metainfo.basesections.v2 import Entity
-from nomad.metainfo import MEnum, Quantity, SectionProxy, SubSection
+from nomad.metainfo import MEnum, Quantity, Reference, SectionProxy, SubSection
 from nomad.units import ureg
 
 if TYPE_CHECKING:
@@ -1132,6 +1132,16 @@ class AtomsState(ParticleState):
     )
 
     electronic_state = SubSection(sub_section=ElectronicState.m_def)
+
+    pseudopotential = Quantity(
+        type=Reference(SectionProxy('Pseudopotential')),
+        description="""
+        Reference to the pseudopotential used for this atomic species in plane-wave DFT
+        calculations. The referenced `Pseudopotential` section is defined in `numerical_settings`
+        and contains metadata such as pseudopotential type (PAW, ultrasoft, norm-conserving),
+        cutoff energy, and XC functional used to generate the pseudopotential.
+        """,
+    )
 
     @log
     def get_label(self) -> str | None:

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -333,9 +333,20 @@ class AtomCenteredFunction(ArchiveSection):
 
 class EffectiveCorePotential(BasisSetComponent):
     """
-    TREXIO-style ECP storage:
+    TREXIO-style ECP storage for quantum chemistry calculations with Gaussian basis sets.
+
+    Effective Core Potentials (ECPs) replace core electrons with analytical potentials
+    expressed as sums of Gaussian functions. This representation is used in quantum chemistry
+    codes (Gaussian, ORCA, Molpro, Q-Chem, NWChem) to reduce computational cost while
+    maintaining accuracy for valence electrons.
+
+    Storage format (TREXIO convention):
       - Per-nucleus arrays: z_core[nucleus], max_ang_mom_plus_1[nucleus]
       - Flat list of projector items: size ecp_num with nucleus_index, ang_mom, exponent, coefficient, power
+
+    Note: This class stores analytical ECPs for Gaussian basis set codes. It does NOT represent
+    pseudopotentials used in plane-wave DFT codes (PAW, ultrasoft, norm-conserving). For metadata
+    about plane-wave pseudopotentials, see the `Pseudopotential` class in numerical_settings.py.
     """
 
     # Optional human label

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -1,6 +1,6 @@
 import itertools
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from scipy import constants as const
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from nomad.metainfo import Section
     from structlog.stdlib import BoundLogger
 
+from nomad_simulations.schema_packages.model_method import RelativityModel
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.utils import log
 
@@ -1143,15 +1144,11 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
-    relativistic = Quantity(
-        type=MEnum('non-relativistic', 'scalar-relativistic', 'full-relativistic', 'unavailable'),
-        shape=[],
+    relativistic_treatment = SubSection(
+        sub_section=RelativityModel.m_def,
         description="""
-        Level of relativistic effects included in pseudopotential generation:
-        - `'non-relativistic'`: No relativistic corrections (light elements)
-        - `'scalar-relativistic'`: Scalar relativistic effects (spin-orbit coupling neglected)
-        - `'full-relativistic'`: Complete relativistic treatment (heavy elements, spin-orbit)
-        - `'unavailable'`: Relativistic treatment not specified or unknown
+        Relativistic treatment used during pseudopotential generation.
+        Does not imply anything about how treatment of the valence electrons.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1032,6 +1032,83 @@ class FrozenCore(NumericalSettings):
     )
 
 
+class Pseudopotential(NumericalSettings):
+    """
+    Section containing the parameters for pseudopotentials used in electronic structure calculations.
+    Pseudopotentials are used to approximate the potential of the core electrons and the nucleus,
+    allowing for a more efficient treatment of valence electrons.
+    """
+
+    name = Quantity(
+        type=str,
+        shape=[],
+        description="""
+        Native code name of the pseudopotential.
+        """,
+    )
+
+    type = Quantity(
+        type=MEnum('US V', 'US MBK', 'PAW'),
+        shape=[],
+        description="""
+        Pseudopotential classification.
+
+        | abbreviation | description | DOI |
+        | ------------ | ----------- | --------- |
+        | `'US'`       | Ultra-soft  | |
+        | `'PAW'`      | Projector augmented wave | |
+        | `'V'`        | Vanderbilt | https://doi.org/10.1103/PhysRevB.47.6728 |
+        | `'MBK'`      | Morrison-Bylander-Kleinman | https://doi.org/10.1103/PhysRevB.41.7892 |
+        """,
+    )
+
+    norm_conserving = Quantity(
+        type=bool,
+        shape=[],
+        description="""
+        Denotes whether the pseudopotential is norm-conserving.
+        """,
+    )
+
+    cutoff = Quantity(
+        type=np.float64,
+        shape=[],
+        unit='joule',
+        description="""
+        Minimum recommended spherical cutoff energy for any plane-wave basis set
+        using the pseudopotential.
+        """,
+    )
+
+    xc_functional_name = Quantity(
+        type=str,
+        shape=['*'],
+        description="""
+        Name of the exchange-correlation functional used to generate the pseudopotential.
+        Follows the libxc naming convention.
+        """,
+    )
+
+    l_max = Quantity(
+        type=np.int32,
+        shape=[],
+        description="""
+        Maximum angular momentum of the pseudopotential projectors.
+        """,
+    )
+
+    lm_max = Quantity(
+        type=np.int32,
+        shape=[],
+        description="""
+        Maximum magnetic momentum of the pseudopotential projectors.
+        """,
+    )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+
 class IntegralDecomposition(ArchiveSection):
     """
     A general class for integral decomposition techniques that approximate
@@ -1053,7 +1130,7 @@ class IntegralDecomposition(ArchiveSection):
         implementation of efficient, approximate MP2 theories,
         Theor. Chem. Acc. 97, 331-340 (1997).
       - S. Hättig, F. Weigend, J. Chem. Phys. 113, 5154 (2000). (RI-J)
-      - Neese et al., “Chain-of-spheres algorithms for HF exchange,”
+      - Neese et al., "Chain-of-spheres algorithms for HF exchange,"
         Chem. Phys. 356 (2008), 98-109.
     """
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -6,7 +6,7 @@ import numpy as np
 import pint
 from ase.dft.kpoints import get_monkhorst_pack_size_and_offset, monkhorst_pack
 from nomad.datamodel.data import ArchiveSection
-from nomad.metainfo import JSON, MEnum, Quantity, SubSection
+from nomad.metainfo import JSON, MEnum, Quantity, SectionProxy, SubSection
 from nomad.units import ureg
 
 if TYPE_CHECKING:
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from nomad.metainfo import Section
     from structlog.stdlib import BoundLogger
 
-from nomad_simulations.schema_packages.model_method import RelativityModel
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.utils import log
 
@@ -1175,20 +1174,22 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
-    xc_functional_name = Quantity(
-        type=str,
-        shape=['*'],
+    xc_functional = SubSection(
+        sub_section=SectionProxy('XCFunctional'),
         description="""
-        Name of the exchange-correlation functional used to generate the pseudopotential.
-        Follows the libxc naming convention.
+        Exchange-correlation functional used to generate this pseudopotential.
+
+        Should match (or be compatible with) the XC functional used in the calculation.
+        The functional_key field allows parsers to store simple aliases (e.g., 'PBE', 'LDA'),
+        which are automatically expanded to LibXC components during normalization.
         """,
     )
 
     relativistic_treatment = SubSection(
-        sub_section=RelativityModel.m_def,
+        sub_section=SectionProxy('RelativityModel'),
         description="""
         Relativistic treatment used during pseudopotential generation.
-        Does not imply anything about how treatment of the valence electrons.
+        Does not imply anything about treatment of the valence electrons.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1202,7 +1202,9 @@ class Pseudopotential(NumericalSettings):
     )
 
     xc_functional = SubSection(
-        sub_section=SectionProxy('nomad_simulations.schema_packages.model_method.XCFunctional'),
+        sub_section=SectionProxy(
+            'nomad_simulations.schema_packages.model_method.XCFunctional'
+        ),
         description="""
         Exchange-correlation functional used to generate this pseudopotential.
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1116,6 +1116,45 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
+    r_core = Quantity(
+        type=np.float64,
+        shape=[],
+        unit='meter',
+        description="""
+        Core radius defining the pseudopotential smoothing region:
+        - For norm-conserving and ultrasoft pseudopotentials: smaller values require higher
+          cutoff energies but provide better transferability and accuracy
+        - For PAW: augmentation sphere radius; PAW's all-electron reconstruction mitigates
+          the traditional hardness/cutoff tradeoff while maintaining accuracy
+        - Useful for detecting overlapping augmentation spheres in small unit cells
+        """,
+    )
+
+    pseudization_scheme = Quantity(
+        type=MEnum('Troullier-Martins', 'Polynomial', 'Bessel', 'Extra-Soft', 'unavailable'),
+        shape=[],
+        description="""
+        Method used to generate the smooth pseudopotential:
+        - `'Troullier-Martins'`: Standard scheme with continuous derivatives
+        - `'Polynomial'`: Polynomial matching at core radius
+        - `'Bessel'`: Bessel function based construction
+        - `'Extra-Soft'`: Optimized for low cutoff energies
+        - `'unavailable'`: Pseudization scheme not specified or unknown
+        """,
+    )
+
+    relativistic = Quantity(
+        type=MEnum('non-relativistic', 'scalar-relativistic', 'full-relativistic', 'unavailable'),
+        shape=[],
+        description="""
+        Level of relativistic effects included in pseudopotential generation:
+        - `'non-relativistic'`: No relativistic corrections (light elements)
+        - `'scalar-relativistic'`: Scalar relativistic effects (spin-orbit coupling neglected)
+        - `'full-relativistic'`: Complete relativistic treatment (heavy elements, spin-orbit)
+        - `'unavailable'`: Relativistic treatment not specified or unknown
+        """,
+    )
+
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1039,6 +1039,7 @@ class Pseudopotential(NumericalSettings):
     Pseudopotentials approximate the potential of core electrons and the nucleus, enabling
     efficient treatment of valence electrons in codes like VASP, Quantum ESPRESSO, and CASTEP.
     Common types include PAW (Projector Augmented Wave), ultrasoft (US), and norm-conserving (NC).
+    Norm-conserving pseudopotentials are represented by setting `norm_conserving = True` and choosing the appropriate value in `type`.
 
     This class stores high-level metadata (type, cutoff energy, XC functional) that identifies
     which pseudopotential was used. The actual numerical pseudopotential data (radial functions,

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1034,10 +1034,13 @@ class FrozenCore(NumericalSettings):
 
 class Pseudopotential(NumericalSettings):
     """
-    Section containing metadata for pseudopotentials used in plane-wave DFT calculations.
-
+    Section containing high-level metadata (type, cutoff energy, XC functional) that identifies which pseudopotential was used.
     Pseudopotentials approximate the potential of core electrons and the nucleus, enabling
     efficient treatment of valence electrons in codes like VASP, Quantum ESPRESSO, and CASTEP.
+
+    The actual numerical pseudopotential data (radial functions,
+    projectors, augmentation charges) is stored in external files (POTCAR, UPF, etc.) and is
+    typically not included in the archive due to size and licensing constraints.
 
     **Type Classification:**
 
@@ -1062,13 +1065,6 @@ class Pseudopotential(NumericalSettings):
     projectors at higher energies to accurately describe quasiparticle states far above the Fermi
     level. Standard PAW and US pseudopotentials systematically underestimate scattering into
     high-energy unoccupied states, which is critical for GW many-body perturbation theory.
-
-    **Data Storage:**
-
-    This class stores high-level metadata (type, cutoff energy, XC functional) that identifies
-    which pseudopotential was used. The actual numerical pseudopotential data (radial functions,
-    projectors, augmentation charges) is stored in external files (POTCAR, UPF, etc.) and is
-    typically not included in the archive due to size and licensing constraints.
 
     Note: This class is distinct from `EffectiveCorePotential` in basis_set.py, which stores
     analytical ECP representations for quantum chemistry codes with Gaussian basis sets. ECPs

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1152,6 +1152,29 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
+    n_valence_electrons = Quantity(
+        type=np.float64,
+        shape=[],
+        description="""
+        Number of valence electrons explicitly treated by the pseudopotential.
+        This also determines the effective ionic charge seen by the valence electrons.
+
+        Should equal the sum of electrons in `reference_configuration`, though the
+        configuration string may omit deeper semi-core levels that are included in
+        the valence count.
+        """,
+    )
+
+    reference_configuration = Quantity(
+        type=str,
+        shape=[],
+        description="""
+        Electronic configuration used to generate the pseudopotential (e.g., "3s1 3d0.5" or "3p6 3d7 4s1").
+        Documents the valence electron occupations used during generation.
+        The configuration string may only show the outermost valence orbitals explicitly.
+        """,
+    )
+
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1074,88 +1074,6 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
-    norm_conserving = Quantity(
-        type=bool,
-        shape=[],
-        description="""
-        Denotes whether the pseudopotential is norm-conserving.
-        """,
-    )
-
-    cutoff = Quantity(
-        type=np.float64,
-        shape=[],
-        unit='joule',
-        description="""
-        Recommended cutoff energy for the plane-wave basis set using this pseudopotential.
-
-        When multiple cutoff recommendations exist in the source (e.g., coarse/medium/fine
-        or min/max), store the most representative value. Use the medium/standard setting
-        when in doubt. Codes with sophisticated multi-level cutoff systems should extend this at
-        the parser-specific schema level.
-        """,
-    )
-
-    xc_functional_name = Quantity(
-        type=str,
-        shape=['*'],
-        description="""
-        Name of the exchange-correlation functional used to generate the pseudopotential.
-        Follows the libxc naming convention.
-        """,
-    )
-
-    l_max = Quantity(
-        type=np.int32,
-        shape=[],
-        description="""
-        Maximum angular momentum of the pseudopotential projectors.
-        """,
-    )
-
-    lm_max = Quantity(
-        type=np.int32,
-        shape=[],
-        description="""
-        Maximum magnetic momentum of the pseudopotential projectors.
-        """,
-    )
-
-    r_core = Quantity(
-        type=np.float64,
-        shape=[],
-        unit='meter',
-        description="""
-        Core radius defining the pseudopotential smoothing region:
-        - For norm-conserving and ultrasoft pseudopotentials: smaller values require higher
-          cutoff energies but provide better transferability and accuracy
-        - For PAW: augmentation sphere radius; PAW's all-electron reconstruction mitigates
-          the traditional hardness/cutoff tradeoff while maintaining accuracy
-        - Useful for detecting overlapping augmentation spheres in small unit cells
-        """,
-    )
-
-    pseudization_scheme = Quantity(
-        type=MEnum('Troullier-Martins', 'Polynomial', 'Bessel', 'Extra-Soft', 'unavailable'),
-        shape=[],
-        description="""
-        Method used to generate the smooth pseudopotential:
-        - `'Troullier-Martins'`: Standard scheme with continuous derivatives
-        - `'Polynomial'`: Polynomial matching at core radius
-        - `'Bessel'`: Bessel function based construction
-        - `'Extra-Soft'`: Optimized for low cutoff energies
-        - `'unavailable'`: Pseudization scheme not specified or unknown
-        """,
-    )
-
-    relativistic_treatment = SubSection(
-        sub_section=RelativityModel.m_def,
-        description="""
-        Relativistic treatment used during pseudopotential generation.
-        Does not imply anything about how treatment of the valence electrons.
-        """,
-    )
-
     n_valence_electrons = Quantity(
         type=np.float64,
         shape=[],
@@ -1176,6 +1094,101 @@ class Pseudopotential(NumericalSettings):
         Electronic configuration used to generate the pseudopotential (e.g., "3s1 3d0.5" or "3p6 3d7 4s1").
         Documents the valence electron occupations used during generation.
         The configuration string may only show the outermost valence orbitals explicitly.
+        """,
+    )
+
+    norm_conserving = Quantity(
+        type=bool,
+        shape=[],
+        description="""
+        Denotes whether the pseudopotential is norm-conserving.
+        """,
+    )
+
+    gw_optimized = Quantity(
+        type=bool,
+        default=False,
+        description="""
+        Whether this pseudopotential was optimized for GW/excited-state calculations.
+        GW-optimized pseudopotentials are validated for scattering properties far above
+        the Fermi level and typically include more semi-core states. They remain valid
+        for standard DFT calculations but are computationally more expensive.
+        """,
+    )
+
+    cutoff = Quantity(
+        type=np.float64,
+        shape=[],
+        unit='joule',
+        description="""
+        Recommended cutoff energy for the plane-wave basis set using this pseudopotential.
+
+        When multiple cutoff recommendations exist in the source (e.g., coarse/medium/fine
+        or min/max), store the most representative value. Use the medium/standard setting
+        when in doubt. Codes with sophisticated multi-level cutoff systems should extend this at
+        the parser-specific schema level.
+        """,
+    )
+
+    r_core = Quantity(
+        type=np.float64,
+        shape=[],
+        unit='meter',
+        description="""
+        Core radius defining the pseudopotential smoothing region:
+        - For norm-conserving and ultrasoft pseudopotentials: smaller values require higher
+          cutoff energies but provide better transferability and accuracy
+        - For PAW: augmentation sphere radius; PAW's all-electron reconstruction mitigates
+          the traditional hardness/cutoff tradeoff while maintaining accuracy
+        - Useful for detecting overlapping augmentation spheres in small unit cells
+        """,
+    )
+
+    l_max = Quantity(
+        type=np.int32,
+        shape=[],
+        description="""
+        Maximum angular momentum of the pseudopotential projectors.
+        """,
+    )
+
+    lm_max = Quantity(
+        type=np.int32,
+        shape=[],
+        description="""
+        Maximum magnetic momentum of the pseudopotential projectors.
+        """,
+    )
+
+    # generation details
+
+    pseudization_scheme = Quantity(
+        type=MEnum('Troullier-Martins', 'Polynomial', 'Bessel', 'Extra-Soft', 'unavailable'),
+        shape=[],
+        description="""
+        Method used to generate the smooth pseudopotential:
+        - `'Troullier-Martins'`: Standard scheme with continuous derivatives
+        - `'Polynomial'`: Polynomial matching at core radius
+        - `'Bessel'`: Bessel function based construction
+        - `'Extra-Soft'`: Optimized for low cutoff energies
+        - `'unavailable'`: Pseudization scheme not specified or unknown
+        """,
+    )
+
+    xc_functional_name = Quantity(
+        type=str,
+        shape=['*'],
+        description="""
+        Name of the exchange-correlation functional used to generate the pseudopotential.
+        Follows the libxc naming convention.
+        """,
+    )
+
+    relativistic_treatment = SubSection(
+        sub_section=RelativityModel.m_def,
+        description="""
+        Relativistic treatment used during pseudopotential generation.
+        Does not imply anything about how treatment of the valence electrons.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1059,17 +1059,21 @@ class Pseudopotential(NumericalSettings):
     )
 
     type = Quantity(
-        type=MEnum('US V', 'US MBK', 'PAW'),
+        type=MEnum('NC', 'US', 'PAW', 'NC-PAW', 'NC-PAW-GW'),
         shape=[],
         description="""
-        Pseudopotential classification.
+        Pseudopotential formalism classification.
 
-        | abbreviation | description | DOI |
-        | ------------ | ----------- | --------- |
-        | `'US'`       | Ultra-soft  | |
-        | `'PAW'`      | Projector augmented wave | |
-        | `'V'`        | Vanderbilt | https://doi.org/10.1103/PhysRevB.47.6728 |
-        | `'MBK'`      | Morrison-Bylander-Kleinman | https://doi.org/10.1103/PhysRevB.41.7892 |
+        | Type | Description | Key References |
+        |------|-------------|----------------|
+        | `'NC'` | Norm-conserving: Maintains charge norm in pseudized region. Highest transferability but requires higher cutoffs. | Hamann et al., Phys. Rev. Lett. 43, 1494 (1979); Troullier & Martins, Phys. Rev. B 43, 1993 (1991) |
+        | `'US'` | Ultrasoft (Vanderbilt): Relaxes norm-conservation for softer pseudopotentials and lower cutoffs. All ultrasoft pseudopotentials follow Vanderbilt's formalism. | Vanderbilt, Phys. Rev. B 41, 7892 (1990) |
+        | `'PAW'` | Projector Augmented Wave: All-electron frozen-core method with non-norm-conserving partial waves. Most accurate for ground-state DFT. | Blöchl, Phys. Rev. B 50, 17953 (1994); Kresse & Joubert, Phys. Rev. B 59, 1758 (1999) |
+        | `'NC-PAW'` | PAW with norm-conserving partial waves: Better scattering properties at high energies than standard PAW. | Kresse & Joubert, Phys. Rev. B 59, 1758 (1999) |
+        | `'NC-PAW-GW'` | NC-PAW optimized for GW/BSE: Includes extra projectors at higher energies for accurate treatment of unoccupied states far above Fermi level. | VASP _GW potentials; see VASP manual |
+
+        The Morrison-Bylander-Kleinman (MBK) separable form is an implementation
+        technique used across all types, not a distinct pseudopotential formalism.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1149,6 +1149,20 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
+    cutoff_target = Quantity(
+        type=str,
+        default='',
+        description="""
+        Code-native terminology specifying what precision level the cutoff energy refers to.
+
+        Different codes use different names for different cutoff energies within the same pseudopotential file
+        (e.g., ENMAX vs ENMIN in VASP, ecutwfc vs ecutrho in Quantum ESPRESSO). 
+        May be left blank (i.e. an empty string) if no ambiguity is possible. `None` means unset / unevaluated.
+
+        Examples: 'ENMAX' (VASP), 'ecutwfc' (Quantum ESPRESSO), 'cut_off_energy' (CASTEP).
+        """,
+    )
+
     r_core = Quantity(
         type=np.float64,
         shape=[],

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1124,7 +1124,7 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
-    gw_optimized = Quantity(
+    is_gw_optimized = Quantity(
         type=bool,
         default=False,
         description="""

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1038,7 +1038,32 @@ class Pseudopotential(NumericalSettings):
 
     Pseudopotentials approximate the potential of core electrons and the nucleus, enabling
     efficient treatment of valence electrons in codes like VASP, Quantum ESPRESSO, and CASTEP.
-    Common types include PAW (Projector Augmented Wave), ultrasoft (US), and norm-conserving (NC).
+
+    **Type Classification:**
+
+    Norm-conserving (NC): Maintains charge norm within the core region, providing highest
+    transferability between chemical environments. NC pseudopotentials require higher plane-wave
+    cutoffs but guarantee correct scattering properties across all energy ranges.
+
+    Ultrasoft (US): Vanderbilt's formalism relaxes the norm-conservation constraint, producing
+    softer pseudopotentials that converge with lower cutoffs. This reduces computational cost
+    but may sacrifice some transferability. All ultrasoft pseudopotentials follow the same
+    fundamental formalism regardless of generation method.
+
+    Projector Augmented Wave (PAW): Frozen-core all-electron method that reconstructs the full
+    wavefunction within augmentation spheres. Standard PAW uses non-norm-conserving partial
+    waves optimized for ground-state DFT accuracy and computational efficiency.
+
+    NC-PAW: PAW variant with norm-conserving partial waves. While more expensive than standard
+    PAW, NC-PAW provides better scattering properties for high-energy states, making it more
+    suitable for calculations requiring accurate unoccupied states.
+
+    NC-PAW-GW: NC-PAW optimized specifically for GW and BSE calculations. These include additional
+    projectors at higher energies to accurately describe quasiparticle states far above the Fermi
+    level. Standard PAW and US pseudopotentials systematically underestimate scattering into
+    high-energy unoccupied states, which is critical for GW many-body perturbation theory.
+
+    **Data Storage:**
 
     This class stores high-level metadata (type, cutoff energy, XC functional) that identifies
     which pseudopotential was used. The actual numerical pseudopotential data (radial functions,

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1224,6 +1224,13 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+        # Normalize XC functional to expand functional_key into LibXC components
+        if self.xc_functional:
+            self.xc_functional.normalize(archive, logger)
+
 
 class IntegralDecomposition(ArchiveSection):
     """

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1087,8 +1087,12 @@ class Pseudopotential(NumericalSettings):
         shape=[],
         unit='joule',
         description="""
-        Minimum recommended spherical cutoff energy for any plane-wave basis set
-        using the pseudopotential.
+        Recommended cutoff energy for the plane-wave basis set using this pseudopotential.
+
+        When multiple cutoff recommendations exist in the source (e.g., coarse/medium/fine
+        or min/max), store the most representative value. Use the medium/standard setting
+        when in doubt. Codes with sophisticated multi-level cutoff systems should extend this at
+        the parser-specific schema level.
         """,
     )
 
@@ -1174,9 +1178,6 @@ class Pseudopotential(NumericalSettings):
         The configuration string may only show the outermost valence orbitals explicitly.
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class IntegralDecomposition(ArchiveSection):

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1156,7 +1156,7 @@ class Pseudopotential(NumericalSettings):
         type=np.int32,
         shape=[],
         description="""
-        Maximum magnetic momentum of the pseudopotential projectors.
+        Maximum magnetic quantum number of the pseudopotential projectors.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1034,54 +1034,47 @@ class FrozenCore(NumericalSettings):
 
 class PPCutoff(ArchiveSection):
     """
-    Section defining a single cutoff recommendation or setting for a pseudopotential.
-
-    Pseudopotentials often come with multiple cutoff recommendations depending on the
-    physical expansion (wavefunction, charge density, augmentation) and the desired
-    precision level (used, recommended, stringent). This section captures both
-    dimensions, allowing parsers to store all available cutoff information from
-    pseudopotential libraries or calculation files.
+    A single plane-wave cutoff recommendation for a pseudopotential, specifying context metadata
+    such as which physical expansion it controls (wavefunction, charge density, etc.) and its precision
+    (package recommendation, library tier, or range bound).
     """
 
     cutoff_kind = Quantity(
         type=MEnum(
-            'wavefunction',  # e.g. QE ecutwfc, VASP ENCUT
-            'charge_density',  # e.g. QE ecutrho (often ~4x for NC, higher for US)
-            'augmentation',  # PAW augmentation / projector-related cutoffs (if applicable)
-            'response',  # response-function basis cutoffs (e.g. ENCUTGW-like)
-            'other',
+            'wavefunction',
+            'charge_density',
+            'augmentation',
+            'response',
+            'unavailable',
         ),
         description="""
-        The physical expansion this cutoff controls:
-        - `'wavefunction'`: Cutoff for the plane-wave expansion of wavefunctions (e.g., QE ecutwfc, VASP ENCUT).
-        - `'charge_density'`: Cutoff for the charge density expansion (e.g., QE ecutrho, often 4× wavefunction cutoff for norm-conserving, higher for ultrasoft).
-        - `'augmentation'`: Cutoff for PAW augmentation charges or projector-related expansions.
-        - `'response'`: Cutoff for response-function basis sets (e.g., GW calculations).
-        - `'other'`: Any other cutoff type not covered above.
+        Identifies which physical expansion this cutoff controls. Plane-wave DFT codes
+        use different cutoffs for the wavefunction basis, charge density grid, PAW
+        augmentation charges, and response functions (e.g., for GW calculations). This
+        field disambiguates which expansion the cutoff value applies to.
         """,
     )
 
     cutoff_role = Quantity(
         type=MEnum(
-            'used',  # actually used in the run (runtime value)
-            'recommended',  # vendor/library recommended default
-            'recommended_min',  # lower bound recommendation
-            'recommended_max',  # upper bound recommendation
-            'standard',  # library "standard" recommendation (SSSP-like)
-            'stringent',  # library "stringent" recommendation
-            'soft',  # explicitly soft setting
-            'hard',  # explicitly hard setting
+            'recommended',
+            'recommended_min',
+            'recommended_max',
+            'fast',
+            'balanced',
+            'stringent',
         ),
         description="""
-        The role or context of this cutoff value:
-        - `'used'`: Actually used in the run (runtime value from calculation).
-        - `'recommended'`: Vendor or library recommended default.
-        - `'recommended_min'`: Lower bound of recommended range.
-        - `'recommended_max'`: Upper bound of recommended range.
-        - `'standard'`: Library "standard" precision (e.g., SSSP standard).
-        - `'stringent'`: Library "stringent" precision (e.g., SSSP stringent).
-        - `'soft'`: Explicitly soft setting (lower precision).
-        - `'hard'`: Explicitly hard setting (higher precision).
+        Pseudopotential files may provide more than one cutoff recommendation.
+        This field captures the recommendation context for the cutoff value: whether it
+        represents a single simulation package recommendation, bounds in a recommended range (min/max),
+        or a precision tier from a standard library.
+        
+        The precision tiers follow the SSSP (Standard Solid-State Pseudopotentials)
+        protocol nomenclature: `'fast'` for testing and preliminary calculations,
+        `'balanced'` for high-throughput screening and most practical applications,
+        and `'stringent'` for production calculations requiring maximum precision
+        (Beal et al., arXiv:2504.03962, 2025).
         """,
     )
 
@@ -1089,7 +1082,7 @@ class PPCutoff(ArchiveSection):
         type=np.float64,
         unit='joule',
         description="""
-        The cutoff energy value in joules.
+        The cutoff energy.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1036,7 +1036,7 @@ class Pseudopotential(NumericalSettings):
     """
     Section containing high-level metadata (type, cutoff energy, XC functional) that identifies which pseudopotential was used.
     Pseudopotentials approximate the potential of core electrons and the nucleus, enabling
-    efficient treatment of valence electrons in codes like VASP, Quantum ESPRESSO, and CASTEP.
+    efficient treatment of valence electrons in plane-wave codes.
 
     The actual numerical pseudopotential data (radial functions,
     projectors, augmentation charges) is stored in external files (POTCAR, UPF, etc.) and is
@@ -1121,7 +1121,7 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
-    norm_conserving = Quantity(
+    is_norm_conserving = Quantity(
         type=bool,
         shape=[],
         description="""

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1215,7 +1215,9 @@ class Pseudopotential(NumericalSettings):
     )
 
     relativistic_treatment = SubSection(
-        sub_section=SectionProxy('RelativityModel'),
+        sub_section=SectionProxy(
+            'nomad_simulations.schema_packages.model_method.RelativityModel'
+        ),
         description="""
         Relativistic treatment used during pseudopotential generation.
         Does not imply anything about treatment of the valence electrons.

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1032,6 +1032,68 @@ class FrozenCore(NumericalSettings):
     )
 
 
+class PPCutoff(ArchiveSection):
+    """
+    Section defining a single cutoff recommendation or setting for a pseudopotential.
+
+    Pseudopotentials often come with multiple cutoff recommendations depending on the
+    physical expansion (wavefunction, charge density, augmentation) and the desired
+    precision level (used, recommended, stringent). This section captures both
+    dimensions, allowing parsers to store all available cutoff information from
+    pseudopotential libraries or calculation files.
+    """
+
+    cutoff_kind = Quantity(
+        type=MEnum(
+            'wavefunction',  # e.g. QE ecutwfc, VASP ENCUT
+            'charge_density',  # e.g. QE ecutrho (often ~4x for NC, higher for US)
+            'augmentation',  # PAW augmentation / projector-related cutoffs (if applicable)
+            'response',  # response-function basis cutoffs (e.g. ENCUTGW-like)
+            'other',
+        ),
+        description="""
+        The physical expansion this cutoff controls:
+        - `'wavefunction'`: Cutoff for the plane-wave expansion of wavefunctions (e.g., QE ecutwfc, VASP ENCUT).
+        - `'charge_density'`: Cutoff for the charge density expansion (e.g., QE ecutrho, often 4× wavefunction cutoff for norm-conserving, higher for ultrasoft).
+        - `'augmentation'`: Cutoff for PAW augmentation charges or projector-related expansions.
+        - `'response'`: Cutoff for response-function basis sets (e.g., GW calculations).
+        - `'other'`: Any other cutoff type not covered above.
+        """,
+    )
+
+    cutoff_role = Quantity(
+        type=MEnum(
+            'used',  # actually used in the run (runtime value)
+            'recommended',  # vendor/library recommended default
+            'recommended_min',  # lower bound recommendation
+            'recommended_max',  # upper bound recommendation
+            'standard',  # library "standard" recommendation (SSSP-like)
+            'stringent',  # library "stringent" recommendation
+            'soft',  # explicitly soft setting
+            'hard',  # explicitly hard setting
+        ),
+        description="""
+        The role or context of this cutoff value:
+        - `'used'`: Actually used in the run (runtime value from calculation).
+        - `'recommended'`: Vendor or library recommended default.
+        - `'recommended_min'`: Lower bound of recommended range.
+        - `'recommended_max'`: Upper bound of recommended range.
+        - `'standard'`: Library "standard" precision (e.g., SSSP standard).
+        - `'stringent'`: Library "stringent" precision (e.g., SSSP stringent).
+        - `'soft'`: Explicitly soft setting (lower precision).
+        - `'hard'`: Explicitly hard setting (higher precision).
+        """,
+    )
+
+    value = Quantity(
+        type=np.float64,
+        unit='joule',
+        description="""
+        The cutoff energy value in joules.
+        """,
+    )
+
+
 class Pseudopotential(NumericalSettings):
     """
     Section containing high-level metadata (type, cutoff energy, XC functional) that identifies which pseudopotential was used.
@@ -1135,33 +1197,7 @@ class Pseudopotential(NumericalSettings):
         """,
     )
 
-    cutoff = Quantity(
-        type=np.float64,
-        shape=[],
-        unit='joule',
-        description="""
-        Recommended cutoff energy for the plane-wave basis set using this pseudopotential.
-
-        When multiple cutoff recommendations exist in the source (e.g., coarse/medium/fine
-        or min/max), store the most representative value. Use the medium/standard setting
-        when in doubt. Codes with sophisticated multi-level cutoff systems should extend this at
-        the parser-specific schema level.
-        """,
-    )
-
-    cutoff_target = Quantity(
-        type=str,
-        default='',
-        description="""
-        Code-native terminology specifying what precision level the cutoff energy refers to.
-
-        Different codes use different names for different cutoff energies within the same pseudopotential file
-        (e.g., ENMAX vs ENMIN in VASP, ecutwfc vs ecutrho in Quantum ESPRESSO). 
-        May be left blank (i.e. an empty string) if no ambiguity is possible. `None` means unset / unevaluated.
-
-        Examples: 'ENMAX' (VASP), 'ecutwfc' (Quantum ESPRESSO), 'cut_off_energy' (CASTEP).
-        """,
-    )
+    cutoffs = SubSection(sub_section=PPCutoff.m_def, repeats=True)
 
     r_core = Quantity(
         type=np.float64,

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1034,9 +1034,20 @@ class FrozenCore(NumericalSettings):
 
 class Pseudopotential(NumericalSettings):
     """
-    Section containing the parameters for pseudopotentials used in electronic structure calculations.
-    Pseudopotentials are used to approximate the potential of the core electrons and the nucleus,
-    allowing for a more efficient treatment of valence electrons.
+    Section containing metadata for pseudopotentials used in plane-wave DFT calculations.
+
+    Pseudopotentials approximate the potential of core electrons and the nucleus, enabling
+    efficient treatment of valence electrons in codes like VASP, Quantum ESPRESSO, and CASTEP.
+    Common types include PAW (Projector Augmented Wave), ultrasoft (US), and norm-conserving (NC).
+
+    This class stores high-level metadata (type, cutoff energy, XC functional) that identifies
+    which pseudopotential was used. The actual numerical pseudopotential data (radial functions,
+    projectors, augmentation charges) is stored in external files (POTCAR, UPF, etc.) and is
+    typically not included in the archive due to size and licensing constraints.
+
+    Note: This class is distinct from `EffectiveCorePotential` in basis_set.py, which stores
+    analytical ECP representations for quantum chemistry codes with Gaussian basis sets. ECPs
+    cannot represent PAW or ultrasoft pseudopotentials used in plane-wave calculations.
     """
 
     name = Quantity(

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1038,33 +1038,8 @@ class Pseudopotential(NumericalSettings):
     Pseudopotentials approximate the potential of core electrons and the nucleus, enabling
     efficient treatment of valence electrons in plane-wave codes.
 
-    The actual numerical pseudopotential data (radial functions,
-    projectors, augmentation charges) is stored in external files (POTCAR, UPF, etc.) and is
-    typically not included in the archive due to size and licensing constraints.
-
-    **Type Classification:**
-
-    Norm-conserving (NC): Maintains charge norm within the core region, providing highest
-    transferability between chemical environments. NC pseudopotentials require higher plane-wave
-    cutoffs but guarantee correct scattering properties across all energy ranges.
-
-    Ultrasoft (US): Vanderbilt's formalism relaxes the norm-conservation constraint, producing
-    softer pseudopotentials that converge with lower cutoffs. This reduces computational cost
-    but may sacrifice some transferability. All ultrasoft pseudopotentials follow the same
-    fundamental formalism regardless of generation method.
-
-    Projector Augmented Wave (PAW): Frozen-core all-electron method that reconstructs the full
-    wavefunction within augmentation spheres. Standard PAW uses non-norm-conserving partial
-    waves optimized for ground-state DFT accuracy and computational efficiency.
-
-    NC-PAW: PAW variant with norm-conserving partial waves. While more expensive than standard
-    PAW, NC-PAW provides better scattering properties for high-energy states, making it more
-    suitable for calculations requiring accurate unoccupied states.
-
-    NC-PAW-GW: NC-PAW optimized specifically for GW and BSE calculations. These include additional
-    projectors at higher energies to accurately describe quasiparticle states far above the Fermi
-    level. Standard PAW and US pseudopotentials systematically underestimate scattering into
-    high-energy unoccupied states, which is critical for GW many-body perturbation theory.
+    The actual numerical pseudopotential data (radial functions, projectors, augmentation charges)
+    is typically stored in external files which are not parsed into the archive due to size and licensing constraints.
 
     Note: This class is distinct from `EffectiveCorePotential` in basis_set.py, which stores
     analytical ECP representations for quantum chemistry codes with Gaussian basis sets. ECPs
@@ -1085,16 +1060,36 @@ class Pseudopotential(NumericalSettings):
         description="""
         Pseudopotential formalism classification.
 
-        | Type | Description | Key References |
-        |------|-------------|----------------|
-        | `'NC'` | Norm-conserving: Maintains charge norm in pseudized region. Highest transferability but requires higher cutoffs. | Hamann et al., Phys. Rev. Lett. 43, 1494 (1979); Troullier & Martins, Phys. Rev. B 43, 1993 (1991) |
-        | `'US'` | Ultrasoft (Vanderbilt): Relaxes norm-conservation for softer pseudopotentials and lower cutoffs. All ultrasoft pseudopotentials follow Vanderbilt's formalism. | Vanderbilt, Phys. Rev. B 41, 7892 (1990) |
-        | `'PAW'` | Projector Augmented Wave: All-electron frozen-core method with non-norm-conserving partial waves. Most accurate for ground-state DFT. | Blöchl, Phys. Rev. B 50, 17953 (1994); Kresse & Joubert, Phys. Rev. B 59, 1758 (1999) |
-        | `'NC-PAW'` | PAW with norm-conserving partial waves: Better scattering properties at high energies than standard PAW. | Kresse & Joubert, Phys. Rev. B 59, 1758 (1999) |
-        | `'NC-PAW-GW'` | NC-PAW optimized for GW/BSE: Includes extra projectors at higher energies for accurate treatment of unoccupied states far above Fermi level. | VASP _GW potentials; see VASP manual |
+        Norm-conserving (NC) pseudopotentials maintain the charge norm within the core region,
+        providing the highest transferability between chemical environments. They guarantee
+        correct scattering properties across all energy ranges but require higher plane-wave
+        cutoffs than other types. Key references: Hamann et al., Phys. Rev. Lett. 43, 1494 (1979);
+        Troullier & Martins, Phys. Rev. B 43, 1993 (1991).
 
-        The Morrison-Bylander-Kleinman (MBK) separable form is an implementation
-        technique used across all types, not a distinct pseudopotential formalism.
+        Ultrasoft (US) pseudopotentials use Vanderbilt's formalism to relax the norm-conservation
+        constraint, producing softer pseudopotentials that converge with lower cutoffs. This reduces
+        computational cost but may sacrifice some transferability. All ultrasoft pseudopotentials
+        follow the same fundamental formalism regardless of generation method. Reference:
+        Vanderbilt, Phys. Rev. B 41, 7892 (1990).
+
+        Projector Augmented Wave (PAW) is a frozen-core all-electron method that reconstructs the
+        full wavefunction within augmentation spheres. Standard PAW uses non-norm-conserving partial
+        waves optimized for ground-state DFT accuracy and computational efficiency. References:
+        Blöchl, Phys. Rev. B 50, 17953 (1994); Kresse & Joubert, Phys. Rev. B 59, 1758 (1999).
+
+        NC-PAW is a PAW variant with norm-conserving partial waves. While more expensive than
+        standard PAW, NC-PAW provides better scattering properties for high-energy states, making
+        it more suitable for calculations requiring accurate unoccupied states. Reference:
+        Kresse & Joubert, Phys. Rev. B 59, 1758 (1999).
+
+        NC-PAW-GW pseudopotentials are NC-PAW optimized specifically for GW and BSE calculations.
+        They include additional projectors at higher energies to accurately describe quasiparticle
+        states far above the Fermi level. Standard PAW and US pseudopotentials systematically
+        underestimate scattering into high-energy unoccupied states, which is critical for GW
+        many-body perturbation theory. See VASP _GW potentials documentation.
+
+        Note: The Morrison-Bylander-Kleinman (MBK) separable form is an implementation technique
+        used across all types, not a distinct pseudopotential formalism.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1162,7 +1162,9 @@ class Pseudopotential(NumericalSettings):
     # generation details
 
     pseudization_scheme = Quantity(
-        type=MEnum('Troullier-Martins', 'Polynomial', 'Bessel', 'Extra-Soft', 'unavailable'),
+        type=MEnum(
+            'Troullier-Martins', 'Polynomial', 'Bessel', 'Extra-Soft', 'unavailable'
+        ),
         shape=[],
         description="""
         Method used to generate the smooth pseudopotential:

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1206,7 +1206,7 @@ class Pseudopotential(NumericalSettings):
     )
 
     xc_functional = SubSection(
-        sub_section=SectionProxy('XCFunctional'),
+        sub_section=SectionProxy('nomad_simulations.schema_packages.model_method.XCFunctional'),
         description="""
         Exchange-correlation functional used to generate this pseudopotential.
 

--- a/tests/test_numerical_settings.py
+++ b/tests/test_numerical_settings.py
@@ -7,6 +7,7 @@ from nomad_simulations.schema_packages.numerical_settings import (
     KLinePath,
     KMesh,
     KSpaceFunctionalities,
+    Pseudopotential,
 )
 
 from . import logger


### PR DESCRIPTION
Some users have been requesting pseudopotential support. This was available in the runschema and should therefore be ported anyhow. The schema was further extended to include additional metadata with codes like CASTEP and QE in mind.
It also leverages other schema-generic pieces for relativity and DFT annotation.