### PR TITLE
Remove empty normalize functions

### DIFF
--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1286,5 +1286,3 @@ class CGBeadState(ParticleState):
 
         return symbol
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1285,4 +1285,3 @@ class CGBeadState(ParticleState):
             symbol = alts[0] if alts else None
 
         return symbol
-

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -967,10 +967,7 @@ class MuffinTinRegion(BasisSetComponent, Mesh):
         super().__init__(*args, **kwargs)
         self.mt_r_min = None
 
-    @check_normalized
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-        # TODO: add spherical specification, once supported in `Grid`
+    # TODO: add spherical specification in normalization, once supported in `Grid`
 
 
 class BasisSetContainer(NumericalSettings):

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -967,7 +967,10 @@ class MuffinTinRegion(BasisSetComponent, Mesh):
         super().__init__(*args, **kwargs)
         self.mt_r_min = None
 
-    # TODO: add spherical specification in normalization, once supported in `Grid`
+    @check_normalized
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+        # TODO: add spherical specification, once supported in `Grid`
 
 
 class BasisSetContainer(NumericalSettings):

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -241,8 +241,8 @@ class AtomCenteredFunction(ArchiveSection):
     shell_normalization = Quantity(
         type=np.float64,
         description="""
-            Unitless normalization factor applied to each contracted atomic orbital 
-            (or shell) to satisfy the chosen normalization convention. 
+            Unitless normalization factor applied to each contracted atomic orbital
+            (or shell) to satisfy the chosen normalization convention.
             It defines how normalized primitives are scaled when forming the final AO.
             """,
     )
@@ -527,7 +527,7 @@ class AtomCenteredBasisSet(BasisSetComponent):
           - 'NAO': Numerical atomic orbitals
           - 'PC': Point charges (or ghost basis centers)
 
-        If a code uses a mixture (e.g., GTO + ECP), store them as separate `AtomCenteredBasisSet` sections, 
+        If a code uses a mixture (e.g., GTO + ECP), store them as separate `AtomCenteredBasisSet` sections,
         while referring to the relevant AtomsState.
         """,
     )
@@ -543,7 +543,7 @@ class AtomCenteredBasisSet(BasisSetComponent):
         The role of this basis set in the calculation:
           - 'orbital': main orbital basis for the SCF
           - 'auxiliary_scf': used for RI-J or density fitting in SCF
-          - 'auxiliary_post_hf': used in MP2, CC, etc. 
+          - 'auxiliary_post_hf': used in MP2, CC, etc.
           - 'cabs': complementary auxiliary basis for explicitly correlated (F12) methods.
         """,
     )
@@ -597,7 +597,7 @@ class AtomCenteredBasisSet(BasisSetComponent):
     n_total_basis_functions = Quantity(
         type=np.int32,
         description="""
-        The **total** number of contracted basis functions in this entire set. 
+        The **total** number of contracted basis functions in this entire set.
         This is typically the sum of all `(2l+1)` or cartesian expansions across
         all shells on all relevant atoms (within the scope of this section).
         """,

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -1109,20 +1109,12 @@ class SlaterKoster(TB):
 
     overlaps = SubSection(sub_section=SlaterKosterBond.m_def, repeats=True)
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class xTB(TB):
     """
     A base section used to define the parameters used in an extended tight-binding (xTB) calculation.
     """
 
     # ? Deprecate this
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class Photon(ArchiveSection):
     """

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -1109,12 +1109,14 @@ class SlaterKoster(TB):
 
     overlaps = SubSection(sub_section=SlaterKosterBond.m_def, repeats=True)
 
+
 class xTB(TB):
     """
     A base section used to define the parameters used in an extended tight-binding (xTB) calculation.
     """
 
     # ? Deprecate this
+
 
 class Photon(ArchiveSection):
     """

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -142,9 +142,6 @@ class Mesh(ArchiveSection):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class KSpaceFunctionalities:
     """
@@ -912,9 +909,6 @@ class SelfConsistency(NumericalSettings):
         super().__init__(m_def, m_context, **kwargs)
         # Set the name of the section
         self.name = self.m_def.name
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
 
 
 class FrozenCore(NumericalSettings):

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -370,4 +370,3 @@ class TrajectoryOutputs(WorkflowOutputs):
         The elapsed simulated physical time since the start of the trajectory.
         """,
     )
-

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -371,5 +371,3 @@ class TrajectoryOutputs(WorkflowOutputs):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/properties/fermi_surface.py
+++ b/src/nomad_simulations/schema_packages/properties/fermi_surface.py
@@ -29,5 +29,3 @@ class FermiSurface(PhysicalProperty):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/properties/fermi_surface.py
+++ b/src/nomad_simulations/schema_packages/properties/fermi_surface.py
@@ -28,4 +28,3 @@ class FermiSurface(PhysicalProperty):
         Number of bands / eigenvalues.
         """,
     )
-

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -38,6 +38,7 @@ class SpectralProfile(PhysicalProperty):
 
     frequencies = SubSection(sub_section=Energy.m_def)
 
+
 class DOSProfile(SpectralProfile):
     """
     A base section used to define the `value` of the `ElectronicDensityOfState` property. This is useful when containing

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -38,10 +38,6 @@ class SpectralProfile(PhysicalProperty):
 
     frequencies = SubSection(sub_section=Energy.m_def)
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class DOSProfile(SpectralProfile):
     """
     A base section used to define the `value` of the `ElectronicDensityOfState` property. This is useful when containing

--- a/src/nomad_simulations/schema_packages/variables.py
+++ b/src/nomad_simulations/schema_packages/variables.py
@@ -109,10 +109,6 @@ class Energy2(Variables):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class WignerSeitz(Variables):
     """
     Wigner-Seitz points in which the real space is discretized. This variable is used to define `HoppingMatrix(PhysicalProperty)` and
@@ -127,10 +123,6 @@ class WignerSeitz(Variables):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class Frequency(Variables):
     """ """
 
@@ -142,10 +134,6 @@ class Frequency(Variables):
         Points in which the frequency is discretized, in joules.
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class MatsubaraFrequency(Variables):
     """ """
@@ -159,10 +147,6 @@ class MatsubaraFrequency(Variables):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class Time(Variables):
     """ """
 
@@ -175,10 +159,6 @@ class Time(Variables):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class ImaginaryTime(Variables):
     """ """
 
@@ -190,10 +170,6 @@ class ImaginaryTime(Variables):
         Points in which the imaginary time is discretized, in seconds.
         """,
     )
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
 
 class KMesh(Variables):
     """
@@ -208,10 +184,6 @@ class KMesh(Variables):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)
-
-
 class KLinePath(Variables):
     """ """
 
@@ -222,5 +194,3 @@ class KLinePath(Variables):
         """,
     )
 
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/variables.py
+++ b/src/nomad_simulations/schema_packages/variables.py
@@ -109,6 +109,7 @@ class Energy2(Variables):
         """,
     )
 
+
 class WignerSeitz(Variables):
     """
     Wigner-Seitz points in which the real space is discretized. This variable is used to define `HoppingMatrix(PhysicalProperty)` and
@@ -123,6 +124,7 @@ class WignerSeitz(Variables):
         """,
     )
 
+
 class Frequency(Variables):
     """ """
 
@@ -134,6 +136,7 @@ class Frequency(Variables):
         Points in which the frequency is discretized, in joules.
         """,
     )
+
 
 class MatsubaraFrequency(Variables):
     """ """
@@ -147,6 +150,7 @@ class MatsubaraFrequency(Variables):
         """,
     )
 
+
 class Time(Variables):
     """ """
 
@@ -159,6 +163,7 @@ class Time(Variables):
         """,
     )
 
+
 class ImaginaryTime(Variables):
     """ """
 
@@ -170,6 +175,7 @@ class ImaginaryTime(Variables):
         Points in which the imaginary time is discretized, in seconds.
         """,
     )
+
 
 class KMesh(Variables):
     """
@@ -184,6 +190,7 @@ class KMesh(Variables):
         """,
     )
 
+
 class KLinePath(Variables):
     """ """
 
@@ -193,4 +200,3 @@ class KLinePath(Variables):
         Reference to the `KLinePath.points` in which the physical property is calculated. These are 3D arrays stored in fractional coordinates.
         """,
     )
-


### PR DESCRIPTION
**Remove empty `normalize()` functions that only call `super().normalize()`**

Removes 17 boilerplate `normalize()` functions across 8 files that contained only `super().normalize()` calls without additional logic. Retains the `normalize()` function in `MuffinTinRegion` (basis_set.py) which has the `@check_normalized` decorator that enforces specific execution order. Includes formatting fixes for trailing whitespace and blank lines.
