### PR TITLE
Fix TypeError when model_systems is None in numerical_settings

### DIFF
--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -215,7 +215,9 @@ class KSpaceFunctionalities:
         # Extracting `bravais_lattice` from `ModelSystem.symmetry` section and `ASE.cell` from `ModelSystem.representations`
         lattice = None
         if model_systems is None:
-            logger.warning('Could not find `model_systems` to resolve high symmetry points.')
+            logger.warning(
+                'Could not find `model_systems` to resolve high symmetry points.'
+            )
             return None
         for model_system in model_systems:
             # General checks to proceed with normalization
@@ -825,7 +827,9 @@ class KSpace(NumericalSettings):
             (pint.Quantity | None): The resolved `reciprocal_lattice_vectors` of the `KSpace`.
         """
         if model_systems is None:
-            logger.warning('Could not find `model_systems` to resolve reciprocal lattice vectors.')
+            logger.warning(
+                'Could not find `model_systems` to resolve reciprocal lattice vectors.'
+            )
             return None
         for model_system in model_systems:
             # General checks to proceed with normalization

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -214,6 +214,9 @@ class KSpaceFunctionalities:
         """
         # Extracting `bravais_lattice` from `ModelSystem.symmetry` section and `ASE.cell` from `ModelSystem.representations`
         lattice = None
+        if model_systems is None:
+            logger.warning('Could not find `model_systems` to resolve high symmetry points.')
+            return None
         for model_system in model_systems:
             # General checks to proceed with normalization
             if not model_system.is_representative:
@@ -821,6 +824,9 @@ class KSpace(NumericalSettings):
         Returns:
             (pint.Quantity | None): The resolved `reciprocal_lattice_vectors` of the `KSpace`.
         """
+        if model_systems is None:
+            logger.warning('Could not find `model_systems` to resolve reciprocal lattice vectors.')
+            return None
         for model_system in model_systems:
             # General checks to proceed with normalization
             if not model_system.is_representative:

--- a/tests/test_numerical_settings.py
+++ b/tests/test_numerical_settings.py
@@ -19,16 +19,19 @@ class TestKSpace:
     """
 
     @pytest.mark.parametrize(
-        'system_type, is_representative, reciprocal_lattice_vectors, result',
+        'system_type, is_representative, reciprocal_lattice_vectors, model_systems, result',
         [
-            ('bulk', False, None, None),
-            ('atom', True, None, None),
+            ('bulk', False, None, 'default', None),
+            ('atom', True, None, 'default', None),
             (
                 'bulk',
                 True,
                 [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                'default',
                 [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
             ),
+            # Test None model_systems case
+            ('bulk', True, None, None, None),
         ],
     )
     def test_normalize(
@@ -36,6 +39,7 @@ class TestKSpace:
         system_type: str | None,
         is_representative: bool,
         reciprocal_lattice_vectors: list[list[float]] | None,
+        model_systems: str | None,
         result: list[list[float]],
     ):
         """
@@ -48,6 +52,15 @@ class TestKSpace:
         )
         k_space = simulation.model_method[0].numerical_settings[0]
         assert k_space.name == 'KSpace'
+
+        # Mock m_xpath to return None if model_systems parameter is None
+        if model_systems is None:
+
+            def mock_xpath(path, dict=False):
+                return None
+
+            k_space.m_xpath = mock_xpath
+
         k_space.normalize(EntryArchive(), logger)
         if k_space.reciprocal_lattice_vectors is not None:
             value = k_space.reciprocal_lattice_vectors.to('1/angstrom').magnitude / (
@@ -98,29 +111,48 @@ class TestKSpaceFunctionalities:
         )
         assert check == result
 
-    def test_resolve_high_symmetry_points(self):
+    @pytest.mark.parametrize(
+        'model_systems_input, expected_result',
+        [
+            # Valid case: model_systems with proper symmetry
+            (
+                'valid',
+                {
+                    'Gamma': [0, 0, 0],
+                    'M': [0.5, 0.5, 0],
+                    'R': [0.5, 0.5, 0.5],
+                    'X': [0, 0.5, 0],
+                },
+            ),
+            # None case: model_systems is None
+            (None, None),
+        ],
+    )
+    def test_resolve_high_symmetry_points(self, model_systems_input, expected_result):
         """
-        Test the `resolve_high_symmetry_points` method. Only testing the valid situation in which the `ModelSystem` normalization worked.
+        Test the `resolve_high_symmetry_points` method with valid and None model_systems.
         """
-        # `ModelSystem.normalize()` need to extract `bulk` as a type.
-        simulation = generate_k_space_simulation(
-            pbc=[True, True, True],
-        )
-        model_systems = simulation.model_system
-        # normalize to extract symmetry
-        simulation.model_system[0].normalize(EntryArchive(), logger)
+        if model_systems_input == 'valid':
+            # `ModelSystem.normalize()` need to extract `bulk` as a type.
+            simulation = generate_k_space_simulation(
+                pbc=[True, True, True],
+            )
+            model_systems = simulation.model_system
+            # normalize to extract symmetry
+            simulation.model_system[0].normalize(EntryArchive(), logger)
+        else:
+            model_systems = model_systems_input
 
         # Testing the functionality method
         high_symmetry_points = KSpaceFunctionalities().resolve_high_symmetry_points(
             model_systems=model_systems, logger=logger
         )
-        assert len(high_symmetry_points) == 4
-        assert high_symmetry_points == {
-            'Gamma': [0, 0, 0],
-            'M': [0.5, 0.5, 0],
-            'R': [0.5, 0.5, 0.5],
-            'X': [0, 0.5, 0],
-        }
+
+        if expected_result is None:
+            assert high_symmetry_points is None
+        else:
+            assert len(high_symmetry_points) == 4
+            assert high_symmetry_points == expected_result
 
 
 class TestKMesh:
@@ -390,34 +422,3 @@ class TestKLinePath:
             ]
         )
         assert np.allclose(k_line_path.points, points)
-
-    def test_resolve_high_symmetry_points_with_none_model_systems(self):
-        """
-        Test that resolve_high_symmetry_points handles None model_systems gracefully.
-        """
-        k_space_functionalities = KSpaceFunctionalities()
-        result = k_space_functionalities.resolve_high_symmetry_points(
-            model_systems=None, logger=logger
-        )
-        assert result is None
-
-    def test_resolve_reciprocal_lattice_vectors_with_none_model_systems(self):
-        """
-        Test that KSpace.normalize handles None model_systems gracefully when
-        resolving reciprocal_lattice_vectors.
-        """
-        from nomad_simulations.schema_packages.numerical_settings import KSpace
-
-        k_space = KSpace()
-
-        # Mock m_xpath to return None (simulating missing model_systems)
-        def mock_xpath(path, dict=False):
-            return None
-
-        k_space.m_xpath = mock_xpath
-
-        # This should not raise TypeError, should return None gracefully
-        result = k_space.resolve_reciprocal_lattice_vectors(
-            model_systems=None, logger=logger
-        )
-        assert result is None

--- a/tests/test_numerical_settings.py
+++ b/tests/test_numerical_settings.py
@@ -390,3 +390,34 @@ class TestKLinePath:
             ]
         )
         assert np.allclose(k_line_path.points, points)
+
+    def test_resolve_high_symmetry_points_with_none_model_systems(self):
+        """
+        Test that resolve_high_symmetry_points handles None model_systems gracefully.
+        """
+        k_space_functionalities = KSpaceFunctionalities()
+        result = k_space_functionalities.resolve_high_symmetry_points(
+            model_systems=None, logger=logger
+        )
+        assert result is None
+
+    def test_resolve_reciprocal_lattice_vectors_with_none_model_systems(self):
+        """
+        Test that KSpace.normalize handles None model_systems gracefully when
+        resolving reciprocal_lattice_vectors.
+        """
+        from nomad_simulations.schema_packages.numerical_settings import KSpace
+
+        k_space = KSpace()
+
+        # Mock m_xpath to return None (simulating missing model_systems)
+        def mock_xpath(path, dict=False):
+            return None
+
+        k_space.m_xpath = mock_xpath
+
+        # This should not raise TypeError, should return None gracefully
+        result = k_space.resolve_reciprocal_lattice_vectors(
+            model_systems=None, logger=logger
+        )
+        assert result is None


### PR DESCRIPTION
Add None checks before iterating over model_systems in:
- KSpaceFunctionalities.resolve_high_symmetry_points()
- KSpace.resolve_reciprocal_lattice_vectors()

This prevents TypeError: 'NoneType' object is not iterable when m_xpath returns None for model_systems.