### PR TITLE
add a representation for saddle points

### DIFF
--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-from nomad.metainfo import Quantity
+from nomad.metainfo import MEnum, Quantity
 
 if TYPE_CHECKING:
     from nomad.datamodel.context import Context
@@ -233,5 +233,27 @@ class Hessian(PhysicalProperty):
         type=np.float64,
         unit='joule / m ** 2',
         description="""
+        """,
+    )
+
+    n_negative_eigenvalues = Quantity(
+        type=np.int32,
+        description="""
+        Number of negative Hessian eigenvalues (imaginary vibrational frequencies).
+        A value of 0 indicates a local minimum, 1 a first-order saddle point, and
+        >1 a higher-order saddle point.
+        """,
+    )
+
+    stationary_point_type = Quantity(
+        type=MEnum(
+            'minimum',
+            'saddle_point',
+            'maximum',
+        ),
+        description="""
+        Stationary-point classification inferred from the Hessian eigenvalue sign
+        pattern. Use 'saddle_point' for any stationary point with one or more
+        negative eigenvalues (a transition state corresponds to exactly one).
         """,
     )

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -262,8 +262,8 @@ class Hessian(PhysicalProperty):
         shape=['*'],
         description="""
         Eigenvalues of the Hessian. Sorted during normalization with positive values
-        descending, followed by zeros, then negative values descending (closest to
-        zero first). Very low-magnitude modes in solid-state phonon calculations
+        descending, followed by zeros, then negative values ascending (most negative
+        first). Very low-magnitude modes in solid-state phonon calculations
         (e.g., <100 cm-1) or when using RI/DF approximations often reflect numerical
         artifacts rather than true instabilities.
         """,
@@ -292,8 +292,8 @@ class Hessian(PhysicalProperty):
         super().normalize(archive, logger)
 
         if self.eigenvalues is not None:
-            vals = np.array(self.eigenvalues)
+            vals = np.asarray(self.eigenvalues, dtype=float)
             positives = np.sort(vals[vals > 0])[::-1]
             zeros = vals[np.isclose(vals, 0)]
-            negatives = np.sort(vals[vals < 0])[::-1]
+            negatives = np.sort(vals[vals < 0])
             self.eigenvalues = np.concatenate([positives, zeros, negatives])

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -241,7 +241,8 @@ class Hessian(PhysicalProperty):
         description="""
         Number of negative Hessian eigenvalues (imaginary vibrational frequencies).
         A value of 0 indicates a local minimum, 1 a first-order saddle point, and
-        >1 a higher-order saddle point.
+        >1 a higher-order saddle point. Leave unset if the Hessian was evaluated
+        away from a stationary point.
         """,
     )
 
@@ -250,10 +251,13 @@ class Hessian(PhysicalProperty):
             'minimum',
             'saddle_point',
             'maximum',
+            'non_stationary',
         ),
         description="""
         Stationary-point classification inferred from the Hessian eigenvalue sign
         pattern. Use 'saddle_point' for any stationary point with one or more
         negative eigenvalues (a transition state corresponds to exactly one).
+        Use 'non_stationary' if the Hessian was evaluated where the gradient is
+        non-zero and no stationary point classification applies.
         """,
     )

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -228,11 +228,20 @@ class Hessian(PhysicalProperty):
     describing the local curvature of the energy surface.
     """
 
-    rank = [3, 3]
+    n_hessian_dim = Quantity(
+        type=positive_int(),
+        description="""
+        Matrix dimension (number of degrees of freedom) of the square Hessian in the
+        coordinate basis used by the parser. For Cartesian atomic Hessians this is
+        typically 3 * N_atoms; constrained/filtered coordinates should use the
+        remaining degrees of freedom.
+        """,
+    )
 
     value = Quantity(
         type=np.float64,
         unit='joule / m ** 2',
+        shape=['n_hessian_dim', 'n_hessian_dim'],
         description="""
         """,
     )
@@ -247,21 +256,44 @@ class Hessian(PhysicalProperty):
         """,
     )
 
+    eigenvalues = Quantity(
+        type=np.float64,
+        unit='joule / m ** 2',
+        shape=['*'],
+        description="""
+        Eigenvalues of the Hessian. Sorted during normalization with positive values
+        descending, followed by zeros, then negative values descending (closest to
+        zero first). Very low-magnitude modes in solid-state phonon calculations
+        (e.g., <100 cm-1) or when using RI/DF approximations often reflect numerical
+        artifacts rather than true instabilities.
+        """,
+    )
+
     stationary_point_type = Quantity(
         type=MEnum(
             'minimum',
-            'saddle_point',
             'maximum',
+            'saddle_point',
             'non_stationary',
             'unavailable',
         ),
         description="""
         Stationary-point classification (requires zero gradient) based on Hessian
-        eigenvalue signs. 
-        - Use 'saddle_point' for any stationary point with one or
+        eigenvalue signs. Use 'saddle_point' for any stationary point with one or
         more negative eigenvalues (a transition state corresponds to exactly one).
-        - Use 'maximum' when all eigenvalues are negative (negative-definite Hessian).
-        - Use 'non_stationary' if the Hessian was evaluated where the gradient is non-zero
-        and no stationary point classification applies.
+        Use 'maximum' when all eigenvalues are negative (negative-definite Hessian).
+        Use 'non_stationary' if the Hessian was evaluated where the gradient is
+        non-zero and no stationary point classification applies. Use 'unavailable'
+        when no classification could be determined from the data.
         """,
     )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+        if self.eigenvalues is not None:
+            vals = np.array(self.eigenvalues)
+            positives = np.sort(vals[vals > 0])[::-1]
+            zeros = vals[np.isclose(vals, 0)]
+            negatives = np.sort(vals[vals < 0])[::-1]
+            self.eigenvalues = np.concatenate([positives, zeros, negatives])

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -253,6 +253,7 @@ class Hessian(PhysicalProperty):
             'saddle_point',
             'maximum',
             'non_stationary',
+            'unavailable',
         ),
         description="""
         Stationary-point classification (requires zero gradient) based on Hessian

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -292,7 +292,7 @@ class Hessian(PhysicalProperty):
         super().normalize(archive, logger)
 
         if self.eigenvalues is not None:
-            vals = np.asarray(self.eigenvalues, dtype=float)
+            vals = np.array(self.eigenvalues)
             positives = np.sort(vals[vals > 0])[::-1]
             zeros = vals[np.isclose(vals, 0)]
             negatives = np.sort(vals[vals < 0])

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from nomad.metainfo import Section
     from structlog.stdlib import BoundLogger
 
+from nomad_simulations.schema_packages.data_types import positive_int
 from nomad_simulations.schema_packages.physical_property import PhysicalProperty
 from nomad_simulations.schema_packages.properties.energies import BaseEnergy
 
@@ -237,7 +238,7 @@ class Hessian(PhysicalProperty):
     )
 
     n_negative_eigenvalues = Quantity(
-        type=np.int32,
+        type=positive_int(),
         description="""
         Number of negative Hessian eigenvalues (imaginary vibrational frequencies).
         A value of 0 indicates a local minimum, 1 a first-order saddle point, and
@@ -254,10 +255,12 @@ class Hessian(PhysicalProperty):
             'non_stationary',
         ),
         description="""
-        Stationary-point classification inferred from the Hessian eigenvalue sign
-        pattern. Use 'saddle_point' for any stationary point with one or more
-        negative eigenvalues (a transition state corresponds to exactly one).
-        Use 'non_stationary' if the Hessian was evaluated where the gradient is
-        non-zero and no stationary point classification applies.
+        Stationary-point classification (requires zero gradient) based on Hessian
+        eigenvalue signs. 
+        - Use 'saddle_point' for any stationary point with one or
+        more negative eigenvalues (a transition state corresponds to exactly one).
+        - Use 'maximum' when all eigenvalues are negative (negative-definite Hessian).
+        - Use 'non_stationary' if the Hessian was evaluated where the gradient is non-zero
+        and no stationary point classification applies.
         """,
     )


### PR DESCRIPTION
## Purpose 
Add structured stationary-point metadata to Hessian so users can filter minima vs. saddle/non-stationary points directly, improving discoverability of transition-state-like structures.

## Scope

**Included** (_What is intentionally part of this PR?_)

- Extend Hessian schema with `n_negative_eigenvalues` guidance and `stationary_point_type` enum (minimum/saddle_point/maximum/non_stationary).

**Out of scope** (_What is explicitly not included (to avoid scope creep)?_)

- A dedicated `TransitionState` implementation is currently out of scope. This PR only adds additional metadata to classify Hessians.

## Status 

_Select one_

- [ ] Draft / In progress (not ready for full review)
- [x] Ready for review
- [ ] Blocked (explain below)

## Dependencies / Blockers 

_List anything that may block progress or review_

- [x] None.
- [ ] Related PRs:
- [ ] Open design questions:
- [ ] External dependencies (people, decisions, data, releases):

## Testing / Validation 

Not applicable: schema-only change; no runtime behavior to exercise yet.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (brief description):
- [x] Not applicable (explain why):

quantity-only change; no runtime behavior to exercise yet.

## Linked Issues / Context

- Fixes #
- Related to #287 
- Follow-up issues (if known):
add normalizer/parser mappings to populate stationary_point_type from eigenvalues/gradients.

## Reviewer Notes 

If you prefer keeping a separate “transition_state” label, we can reintroduce it; current approach folds all negative-eigenvalue cases into `saddle_point`. Once we have a dedicated TransitionState schema, we can deal with it on that PR.

FYI: I am aware of the NEB schemas in heterogenous catalysis app.

