### PR TITLE
improve queryability of DFT

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -727,7 +727,6 @@ class DFT(ModelMethodElectronic):
             'dispersion',
             'relativistic',
             'range_separated',
-            'double_hybrid',
             'embedding',
             'solvated',
             'noncollinear',
@@ -763,9 +762,6 @@ class DFT(ModelMethodElectronic):
 
         • "range_separated"  - A range-separated hybrid exchange-correlation functional is used, such as
                                 wB97X, CAM-B3LYP, or HSE. Identified by a non-zero range-separation parameter ω.
-
-        • "double_hybrid"    - A double hybrid functional includes post-DFT correlation corrections,
-                                typically MP2 or Laplace-transformed terms, beyond standard hybrid DFT.
 
         • "embedding"        - Subsystem-DFT, frozen-density embedding, or other multi-level partitioning
                                 of the electronic system, where parts are treated with separate DFTs or QM/MM schemes.
@@ -836,6 +832,7 @@ class DFT(ModelMethodElectronic):
                 inferred.add('solvated')
 
             # Dispersion
+            # TODO : Implement implicit dispersion in XCFunctional and adjust this
             if isinstance(term, ExplicitDispersionModel):
                 inferred.add('dispersion')
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -827,7 +827,7 @@ class DFT(ModelMethodElectronic):
         contributions = self.contributions or []
 
         for term in contributions:
-            # Solvation model
+            # Solvation
             if isinstance(term, ImplicitSolvationModel):
                 inferred.add('solvated')
 
@@ -836,26 +836,15 @@ class DFT(ModelMethodElectronic):
             if isinstance(term, ExplicitDispersionModel):
                 inferred.add('dispersion')
 
-            # Relativity and spin-orbit
+            # Relativity
             if isinstance(term, RelativityModel):
                 if term.level and term.level != 'non-relativistic':
                     inferred.add('relativistic')
-                if term.approximation in (
-                    'SOMF',
-                    'ZORA',
-                    'DKH',
-                    'X2C',
-                    'BSS',
-                    'NESC',
-                    'FORA',
-                    'IORA',
-                    'Pauli',
-                ):
-                    if (
-                        term.level in ('two-component', 'four-component')
-                        or term.approximation == 'SOMF'
-                    ):
-                        inferred.add('spin_orbit')
+
+                if term.level in ('two-component', 'four-component'):
+                    inferred.add('spin_orbit')
+                elif term.approximation == 'SOMF':
+                    inferred.add('spin_orbit')
 
         # Range-separated hybrid (ω present, ω ≠ 0)
         for comp in self.xc.components or []:

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -680,6 +680,27 @@ class DFT(ModelMethodElectronic):
     A base section used to define the parameters used in a density functional theory (DFT) calculation.
     """
 
+    type = Quantity(
+        type=MEnum(
+            'KS',
+            'BSDFT',
+            'OFDFT',
+            'ADFT',
+            'cDFT',
+            'DFT+U',
+        ),
+        default='KS',
+        description="""
+        NOMAD-style identifier for the DFT flavour:
+        - KS    : conventional (generalized) Kohn-Sham DFT
+        - BSDFT : broken-symmetry DFT
+        - OFDFT : orbital-free DFT
+        - ADFT  : analytic/integral-direct DFT formulations
+        - cDFT  : constrained DFT with explicit density/charge/spin constraints
+        - DFT+U : Hubbard-corrected DFT (DFT+U)
+        """,
+    )
+
     # TODO : improve and rename this classification
     jacobs_ladder = Quantity(
         type=MEnum(

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -860,9 +860,12 @@ class DFT(ModelMethodElectronic):
                     ):
                         inferred.add('spin_orbit')
 
-        # Range-separated hybrid (ω present)
+        # Range-separated hybrid (ω present, ω ≠ 0)
         for comp in self.xc.components or []:
-            if comp.range_separation_parameter is not None:
+            if (
+                comp.range_separation_parameter is not None
+                and not np.isclose(comp.range_separation_parameter, 0.0)
+            ):
                 inferred.add('range_separated')
                 break
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -691,23 +691,23 @@ class DFT(ModelMethodElectronic):
 
         Allowed values:
 
-        • "KS" — **Kohn-Sham DFT**, the standard formulation where the interacting 
-                electron system is mapped to a system of non-interacting particles 
-                with orbitals. The total energy includes a non-interacting kinetic energy
-                and an exchange-correlation potential. Most DFT calculations fall under
-                this category, including hybrids and spin-polarized setups.
+        • "KS" -    **Kohn-Sham DFT**, the standard formulation where the interacting 
+                        electron system is mapped to a system of non-interacting particles 
+                        with orbitals. The total energy includes a non-interacting kinetic energy
+                        and an exchange-correlation potential. Most DFT calculations fall under
+                        this category, including hybrids and spin-polarized setups.
 
-        • "OFDFT" — **Orbital-Free DFT**, a simplified variant where the kinetic energy 
-                    of electrons is modeled directly as a functional of the density,
-                    without introducing Kohn-Sham orbitals. Used in large-scale or 
-                    warm-dense systems where orbital scaling is prohibitive.
+        • "OFDFT" - **Orbital-Free DFT**, a simplified variant where the kinetic energy 
+                        of electrons is modeled directly as a functional of the density,
+                        without introducing Kohn-Sham orbitals. Used in large-scale or 
+                        warm-dense systems where orbital scaling is prohibitive.
 
-        • "Ensemble" — **Ensemble DFT**, where the system is described as a weighted 
+        • "Ensemble" - **Ensemble DFT**, where the system is described as a weighted 
                         ensemble of quantum states (pure or mixed) to handle excited-state 
                         properties or fractional occupation phenomena. This includes 
                         approaches like ensemble Kohn-Sham or EDFT.
 
-        • "Finite-T" — **Finite-temperature DFT**, an extension of Kohn-Sham DFT 
+        • "Finite-T" - **Finite-temperature DFT**, an extension of Kohn-Sham DFT 
                         to non-zero electronic temperatures, following the Mermin 
                         formulation. This includes explicit Fermi-Dirac smearing in 
                         orbital occupations, important for metals, warm-dense matter, 
@@ -758,8 +758,8 @@ class DFT(ModelMethodElectronic):
                                 standard DFT energy, such as D3, D4, VV10, or MBD. This flag is used only
                                 when dispersion is modeled separately from the XC functional.
 
-        • "relativistic"     - Scalar or spin-orbit relativistic corrections are applied to the valence
-                                Hamiltonian, typically via ZORA, DKH, X2C, or four-component Dirac schemes.
+        • "relativistic"     - Scalar-relativistic or four-component relativistic treatment of
+                                the valence Hamiltonian (e.g., ZORA, DKH, X2C), *excluding* spin-orbit coupling.
 
         • "range_separated"  - A range-separated hybrid exchange-correlation functional is used, such as
                                 wB97X, CAM-B3LYP, or HSE. Identified by a non-zero range-separation parameter ω.
@@ -776,13 +776,13 @@ class DFT(ModelMethodElectronic):
         • "noncollinear"     - The spin density is treated as a vector field (noncollinear spin),
                                 often used for spin-orbit coupled or topological materials.
 
-        • "spin_orbit"       - Spin-orbit coupling (SOC) is included either explicitly in the Hamiltonian
-                                or via mean-field corrections (e.g., SOMF). Used when SOC affects electronic states.
+        • "spin_orbit"       - Spin-orbit coupling (SOC) included explicitly in the Hamiltonian or
+                                via mean-field corrections (e.g., SOMF).
 
         Note: these extensions are not mutually exclusive and can coexist within the same calculation.
         
         For example, a calculation with ZORA-wB97X-D3-CPCM in broken-symmetry formulation
-        would include multiple extensions simultaneously, ("relativistic", "range_separated", "dispersion",
+        would include multiple extension flags simultaneously, ("relativistic", "range_separated", "dispersion",
         "solvated", "broken_symmetry").
         """,
     )
@@ -825,6 +825,50 @@ class DFT(ModelMethodElectronic):
             self.jacobs_ladder = max(families, key=lambda f: rank.get(f, -1))
         else:
             self.jacobs_ladder = self.jacobs_ladder or 'unavailable'
+
+        # --- Inferred extensions ---
+        inferred = set()
+        contributions = self.contributions or []
+
+        for term in contributions:
+            # Solvation model
+            if isinstance(term, ImplicitSolvationModel):
+                inferred.add('solvated')
+
+            # Dispersion
+            if isinstance(term, ExplicitDispersionModel):
+                inferred.add('dispersion')
+
+            # Relativity and spin-orbit
+            if isinstance(term, RelativityModel):
+                if term.level and term.level != 'non-relativistic':
+                    inferred.add('relativistic')
+                if term.approximation in (
+                    'SOMF',
+                    'ZORA',
+                    'DKH',
+                    'X2C',
+                    'BSS',
+                    'NESC',
+                    'FORA',
+                    'IORA',
+                    'Pauli',
+                ):
+                    if (
+                        term.level in ('two-component', 'four-component')
+                        or term.approximation == 'SOMF'
+                    ):
+                        inferred.add('spin_orbit')
+
+        # Range-separated hybrid (ω present)
+        for comp in self.xc.components or []:
+            if comp.range_separation_parameter is not None:
+                inferred.add('range_separated')
+                break
+
+        # --- Merge with any existing extensions ---
+        existing = set(self.extensions or [])
+        self.extensions = sorted(existing.union(inferred))
 
 
 class TB(ModelMethodElectronic):

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -680,7 +680,7 @@ class DFT(ModelMethodElectronic):
     A base section used to define the parameters used in a density functional theory (DFT) calculation.
     """
 
-    type = Quantity(
+    formulation = Quantity(
         type=MEnum('KS', 'OFDFT', 'Ensemble', 'Finite-T'),
         default='KS',
         description="""

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -681,23 +681,109 @@ class DFT(ModelMethodElectronic):
     """
 
     type = Quantity(
-        type=MEnum(
-            'KS',
-            'BSDFT',
-            'OFDFT',
-            'ADFT',
-            'cDFT',
-            'DFT+U',
-        ),
+        type=MEnum('KS', 'OFDFT', 'Ensemble', 'Finite-T'),
         default='KS',
         description="""
-        NOMAD-style identifier for the DFT flavour:
-        - KS    : conventional (generalized) Kohn-Sham DFT
-        - BSDFT : broken-symmetry DFT
-        - OFDFT : orbital-free DFT
-        - ADFT  : analytic/integral-direct DFT formulations
-        - cDFT  : constrained DFT with explicit density/charge/spin constraints
-        - DFT+U : Hubbard-corrected DFT (DFT+U)
+        Identifies the fundamental formulation of density functional theory (DFT) used
+        in the simulation, based on the variational structure and degrees of freedom.
+        This classification distinguishes between major theoretical frameworks that 
+        define how the electron density is treated and how the total energy is computed.
+
+        Allowed values:
+
+        • "KS" — **Kohn-Sham DFT**, the standard formulation where the interacting 
+                electron system is mapped to a system of non-interacting particles 
+                with orbitals. The total energy includes a non-interacting kinetic energy
+                and an exchange-correlation potential. Most DFT calculations fall under
+                this category, including hybrids and spin-polarized setups.
+
+        • "OFDFT" — **Orbital-Free DFT**, a simplified variant where the kinetic energy 
+                    of electrons is modeled directly as a functional of the density,
+                    without introducing Kohn-Sham orbitals. Used in large-scale or 
+                    warm-dense systems where orbital scaling is prohibitive.
+
+        • "Ensemble" — **Ensemble DFT**, where the system is described as a weighted 
+                        ensemble of quantum states (pure or mixed) to handle excited-state 
+                        properties or fractional occupation phenomena. This includes 
+                        approaches like ensemble Kohn-Sham or EDFT.
+
+        • "Finite-T" — **Finite-temperature DFT**, an extension of Kohn-Sham DFT 
+                        to non-zero electronic temperatures, following the Mermin 
+                        formulation. This includes explicit Fermi-Dirac smearing in 
+                        orbital occupations, important for metals, warm-dense matter, 
+                        and plasma simulations.
+
+        This field defines the baseline variational structure. Additional methodological
+        features (e.g., dispersion corrections, spin-orbit coupling, solvation models)
+        are recorded separately under the `extensions` field.
+        """,
+    )
+
+    extensions = Quantity(
+        type=MEnum(
+            'DFT+U',
+            'constrained',
+            'broken_symmetry',
+            'dispersion',
+            'relativistic',
+            'range_separated',
+            'double_hybrid',
+            'embedding',
+            'solvated',
+            'noncollinear',
+            'spin_orbit',
+        ),
+        shape=['*'],
+        description="""
+        High-level methodological extensions or modifications applied to the core DFT formalism.
+        These flags provide a semantically meaningful summary of key physical or algorithmic
+        modifications to the standard Kohn-Sham or orbital-free DFT setup. They are automatically
+        inferred from the presence of corresponding model sections and parameters.
+
+        Each extension represents a conceptually orthogonal feature that affects the physical model,
+        variational structure, or solution symmetry:
+
+        • "DFT+U"            - On-site Hubbard U correction applied to localized orbitals
+                                (e.g., transition metal d or f states), often used in solid-state systems.
+                                Typically modeled via a +U energy correction term.
+
+        • "constrained"      - Constrained DFT (cDFT), where additional variational constraints are
+                                imposed on quantities like charge, spin, or density to enforce target values.
+
+        • "broken_symmetry"  - Self-consistent field solution intentionally breaks symmetry (e.g., spin or
+                                spatial), often via an unrestricted determinant, to access magnetically ordered
+                                or electronically degenerate states (e.g., AFM, open-shell singlet).
+
+        • "dispersion"       - An explicit dispersion or van der Waals model is applied on top of the
+                                standard DFT energy, such as D3, D4, VV10, or MBD. This flag is used only
+                                when dispersion is modeled separately from the XC functional.
+
+        • "relativistic"     - Scalar or spin-orbit relativistic corrections are applied to the valence
+                                Hamiltonian, typically via ZORA, DKH, X2C, or four-component Dirac schemes.
+
+        • "range_separated"  - A range-separated hybrid exchange-correlation functional is used, such as
+                                wB97X, CAM-B3LYP, or HSE. Identified by a non-zero range-separation parameter ω.
+
+        • "double_hybrid"    - A double hybrid functional includes post-DFT correlation corrections,
+                                typically MP2 or Laplace-transformed terms, beyond standard hybrid DFT.
+
+        • "embedding"        - Subsystem-DFT, frozen-density embedding, or other multi-level partitioning
+                                of the electronic system, where parts are treated with separate DFTs or QM/MM schemes.
+
+        • "solvated"         - Implicit solvation or polarizable continuum model (e.g., PCM, SMD, COSMO)
+                                is used to simulate solvent effects on the electronic structure.
+
+        • "noncollinear"     - The spin density is treated as a vector field (noncollinear spin),
+                                often used for spin-orbit coupled or topological materials.
+
+        • "spin_orbit"       - Spin-orbit coupling (SOC) is included either explicitly in the Hamiltonian
+                                or via mean-field corrections (e.g., SOMF). Used when SOC affects electronic states.
+
+        Note: these extensions are not mutually exclusive and can coexist within the same calculation.
+        
+        For example, a calculation with ZORA-wB97X-D3-CPCM in broken-symmetry formulation
+        would include multiple extensions simultaneously, ("relativistic", "range_separated", "dispersion",
+        "solvated", "broken_symmetry").
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -862,9 +862,8 @@ class DFT(ModelMethodElectronic):
 
         # Range-separated hybrid (ω present, ω ≠ 0)
         for comp in self.xc.components or []:
-            if (
-                comp.range_separation_parameter is not None
-                and not np.isclose(comp.range_separation_parameter, 0.0)
+            if comp.range_separation_parameter is not None and not np.isclose(
+                comp.range_separation_parameter, 0.0
             ):
                 inferred.add('range_separated')
                 break

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -715,11 +715,11 @@ class DFT(ModelMethodElectronic):
 
         This field defines the baseline variational structure. Additional methodological
         features (e.g., dispersion corrections, spin-orbit coupling, solvation models)
-        are recorded separately under the `extensions` field.
+        are recorded separately under the `treatments` field.
         """,
     )
 
-    extensions = Quantity(
+    treatments = Quantity(
         type=MEnum(
             'DFT+U',
             'constrained',
@@ -734,12 +734,12 @@ class DFT(ModelMethodElectronic):
         ),
         shape=['*'],
         description="""
-        High-level methodological extensions or modifications applied to the core DFT formalism.
+        High-level methodological treatments or modifications applied to the core DFT formalism.
         These flags provide a semantically meaningful summary of key physical or algorithmic
         modifications to the standard Kohn-Sham or orbital-free DFT setup. They are automatically
         inferred from the presence of corresponding model sections and parameters.
 
-        Each extension represents a conceptually orthogonal feature that affects the physical model,
+        Each treatment represents a conceptually orthogonal feature that affects the physical model,
         variational structure, or solution symmetry:
 
         • "DFT+U"            - On-site Hubbard U correction applied to localized orbitals
@@ -775,10 +775,10 @@ class DFT(ModelMethodElectronic):
         • "spin_orbit"       - Spin-orbit coupling (SOC) included explicitly in the Hamiltonian or
                                 via mean-field corrections (e.g., SOMF).
 
-        Note: these extensions are not mutually exclusive and can coexist within the same calculation.
-        
+        Note: these treatments are not mutually exclusive and can coexist within the same calculation.
+
         For example, a calculation with ZORA-wB97X-D3-CPCM in broken-symmetry formulation
-        would include multiple extension flags simultaneously, ("relativistic", "range_separated", "dispersion",
+        would include multiple treatment flags simultaneously, ("relativistic", "range_separated", "dispersion",
         "solvated", "broken_symmetry").
         """,
     )
@@ -822,7 +822,7 @@ class DFT(ModelMethodElectronic):
         else:
             self.jacobs_ladder = self.jacobs_ladder or 'unavailable'
 
-        # --- Inferred extensions ---
+        # --- Inferred treatments ---
         inferred = set()
         contributions = self.contributions or []
 
@@ -854,9 +854,9 @@ class DFT(ModelMethodElectronic):
                 inferred.add('range_separated')
                 break
 
-        # --- Merge with any existing extensions ---
-        existing = set(self.extensions or [])
-        self.extensions = sorted(existing.union(inferred))
+        # --- Merge with any existing treatments ---
+        existing = set(self.treatments or [])
+        self.treatments = sorted(existing.union(inferred))
 
 
 class TB(ModelMethodElectronic):

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -735,13 +735,15 @@ class KLinePath(ArchiveSection):
         # Generate point segments using `map` and `linspace_segments`
         points_segments = list(
             map(
-                lambda i, value: linspace_segments(
-                    self.high_symmetry_path_values[i - 1],
-                    value,
-                    closest_indices[i] - closest_indices[i - 1],
-                )
-                if i > 0
-                else np.array([]),
+                lambda i, value: (
+                    linspace_segments(
+                        self.high_symmetry_path_values[i - 1],
+                        value,
+                        closest_indices[i] - closest_indices[i - 1],
+                    )
+                    if i > 0
+                    else np.array([])
+                ),
                 range(len(self.high_symmetry_path_values)),
                 self.high_symmetry_path_values,
             )

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -706,7 +706,7 @@ def test_dft_normalize_infers_solvated():
     dft.m_add_sub_section(type(dft).contributions, ImplicitSolvationModel(model='PCM'))
 
     dft.normalize(EntryArchive(), logger=logger)
-    assert 'solvated' in dft.extensions
+    assert 'solvated' in dft.treatments
 
 
 def test_dft_normalize_infers_dispersion():
@@ -716,7 +716,7 @@ def test_dft_normalize_infers_dispersion():
     )
 
     dft.normalize(EntryArchive(), logger=logger)
-    assert 'dispersion' in dft.extensions
+    assert 'dispersion' in dft.treatments
 
 
 def test_dft_normalize_infers_relativistic():
@@ -725,7 +725,7 @@ def test_dft_normalize_infers_relativistic():
     dft.m_add_sub_section(type(dft).contributions, rel)
 
     dft.normalize(EntryArchive(), logger=logger)
-    assert 'relativistic' in dft.extensions
+    assert 'relativistic' in dft.treatments
 
 
 def test_dft_normalize_infers_spin_orbit():
@@ -734,7 +734,7 @@ def test_dft_normalize_infers_spin_orbit():
     dft.m_add_sub_section(type(dft).contributions, rel)
 
     dft.normalize(EntryArchive(), logger=logger)
-    assert 'spin_orbit' in dft.extensions
+    assert 'spin_orbit' in dft.treatments
 
 
 def test_dft_normalize_infers_range_separated():
@@ -745,7 +745,7 @@ def test_dft_normalize_infers_range_separated():
     dft.xc = XCFunctional(components=[xc_comp])
 
     dft.normalize(EntryArchive(), logger=logger)
-    assert 'range_separated' in dft.extensions
+    assert 'range_separated' in dft.treatments
 
 
 def test_dft_normalize_zero_range_separation_does_not_infer():
@@ -753,7 +753,7 @@ def test_dft_normalize_zero_range_separation_does_not_infer():
     dft.xc = XCFunctional(components=[XCComponent(range_separation_parameter=0.0)])
     dft.normalize(EntryArchive(), logger=logger)
 
-    assert 'range_separated' not in dft.extensions
+    assert 'range_separated' not in dft.treatments
 
 
 def test_dft_normalize_four_component_relativistic_infers_spin_orbit():
@@ -763,16 +763,16 @@ def test_dft_normalize_four_component_relativistic_infers_spin_orbit():
 
     dft.normalize(EntryArchive(), logger=logger)
 
-    assert 'relativistic' in dft.extensions
-    assert 'spin_orbit' in dft.extensions
+    assert 'relativistic' in dft.treatments
+    assert 'spin_orbit' in dft.treatments
 
 
-def test_dft_normalize_merges_with_existing_extensions():
-    dft = DFT(extensions=['solvated'])
+def test_dft_normalize_merges_with_existing_treatments():
+    dft = DFT(treatments=['solvated'])
     dft.m_add_sub_section(type(dft).contributions, ExplicitDispersionModel(model='D3'))
 
     dft.normalize(EntryArchive(), logger=logger)
-    assert sorted(dft.extensions) == sorted(['solvated', 'dispersion'])
+    assert sorted(dft.treatments) == sorted(['solvated', 'dispersion'])
 
 
 _COMMON_XC_CASES = [

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -701,6 +701,61 @@ def test_dft_functional_key_population_is_idempotent():
     assert len(dft.xc.components or []) == n1
 
 
+def test_dft_normalize_infers_solvated():
+    dft = DFT()
+    dft.m_add_sub_section(type(dft).contributions, ImplicitSolvationModel(model='PCM'))
+
+    dft.normalize(EntryArchive(), logger=logger)
+    assert 'solvated' in dft.extensions
+
+
+def test_dft_normalize_infers_dispersion():
+    dft = DFT()
+    dft.m_add_sub_section(
+        type(dft).contributions, ExplicitDispersionModel(model='D3BJ')
+    )
+
+    dft.normalize(EntryArchive(), logger=logger)
+    assert 'dispersion' in dft.extensions
+
+
+def test_dft_normalize_infers_relativistic():
+    dft = DFT()
+    rel = RelativityModel(level='two-component')
+    dft.m_add_sub_section(type(dft).contributions, rel)
+
+    dft.normalize(EntryArchive(), logger=logger)
+    assert 'relativistic' in dft.extensions
+
+
+def test_dft_normalize_infers_spin_orbit():
+    dft = DFT()
+    rel = RelativityModel(level='two-component', approximation='SOMF')
+    dft.m_add_sub_section(type(dft).contributions, rel)
+
+    dft.normalize(EntryArchive(), logger=logger)
+    assert 'spin_orbit' in dft.extensions
+
+
+def test_dft_normalize_infers_range_separated():
+    dft = DFT()
+    xc_comp = XCComponent(
+        canonical_label='XC_HYB_GGA_XC_CAM_B3LYP', range_separation_parameter=0.33
+    )
+    dft.xc = XCFunctional(components=[xc_comp])
+
+    dft.normalize(EntryArchive(), logger=logger)
+    assert 'range_separated' in dft.extensions
+
+
+def test_dft_normalize_merges_with_existing_extensions():
+    dft = DFT(extensions=['solvated'])
+    dft.m_add_sub_section(type(dft).contributions, ExplicitDispersionModel(model='D3'))
+
+    dft.normalize(EntryArchive(), logger=logger)
+    assert sorted(dft.extensions) == sorted(['solvated', 'dispersion'])
+
+
 _COMMON_XC_CASES = [
     # ---------------- LDA ----------------
     ('LDA', 'LDA', ['XC_LDA_X', 'XC_LDA_C_PW', 'XC_LDA_C_PZ']),

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -748,6 +748,25 @@ def test_dft_normalize_infers_range_separated():
     assert 'range_separated' in dft.extensions
 
 
+def test_dft_normalize_zero_range_separation_does_not_infer():
+    dft = DFT()
+    dft.xc = XCFunctional(components=[XCComponent(range_separation_parameter=0.0)])
+    dft.normalize(EntryArchive(), logger=logger)
+
+    assert 'range_separated' not in dft.extensions
+
+
+def test_dft_normalize_four_component_relativistic_infers_spin_orbit():
+    dft = DFT()
+    rel = RelativityModel(level='four-component')  # No approximation set
+    dft.m_add_sub_section(type(dft).contributions, rel)
+
+    dft.normalize(EntryArchive(), logger=logger)
+
+    assert 'relativistic' in dft.extensions
+    assert 'spin_orbit' in dft.extensions
+
+
 def test_dft_normalize_merges_with_existing_extensions():
     dft = DFT(extensions=['solvated'])
     dft.m_add_sub_section(type(dft).contributions, ExplicitDispersionModel(model='D3'))


### PR DESCRIPTION
## Purpose

This PR introduces a normalized representation of DFT formulations and associated treatments, with an intention to improve semantic clarity and queryability. It flags important physical or mathematical phenomena based on whether the corresponding treatment is applied.

For example, a ZORA-wB97X-D3-CPCM calculation in a broken-symmetry DFT ansatz (extremely popular calculation settings nowadays) would carry multiple treatment flags simultaneously: `("relativistic", "range_separated", "solvated", "dispersion", "broken_symmetry")`.

**_User: "Hmm, what is the level of theory for relativistic effects?"_** 
Then they can navigate to the relevant archive sections for the full, method-specific details.

## Scope 

**Included**

- `DFT.formulation`
- `DFT.treatments`
- Relevant unit tests. 

The treatments list should not store independent information, but act as a **normalized semantic summary derived from structured subsections.**

**Out of scope**

- Method related parameters for niche DFT variants, e.g. OF-DFT numerical settings, are out of scope.
- `ImplicitDispersion` has not been implemented yet. 

## Reviewer Notes

It may semantically not be consistent. One MEnum is `solvated`, the other is `dispersion`. Maybe it should be `dispersion-corrected`. I did not put into a lot of effort before seeing whether this idea is liked, and whether different sub communities would like to call these phenomena entirely differently.

I can expand normalization to accommodate other types, if agreed.
I can also cleanup and organize the current DFT tests, if agreed.

## Status

- [ ] Draft / In progress
- [x] Ready for review

## Breaking Changes

It doesn't break anything, it adds to the current metainfo.

## Testing / Validation
_How was this change validated?_

- [x] Unit tests


