### PR TITLE
Use fully qualified SectionProxy for MO basis_set_ref

### DIFF
--- a/src/nomad_simulations/schema_packages/properties/molecular_orbitals.py
+++ b/src/nomad_simulations/schema_packages/properties/molecular_orbitals.py
@@ -27,7 +27,11 @@ class MolecularOrbitals(ElectronicEigenvalues):
 
     # References
     basis_set_ref = Quantity(
-        type=Reference(SectionProxy('AtomCenteredBasisSet')),
+        type=Reference(
+            SectionProxy(
+                'nomad_simulations.schema_packages.basis_set.AtomCenteredBasisSet'
+            )
+        ),
         description="""
         Reference to the atom-centered basis set in which these molecular
         orbitals are expanded.


### PR DESCRIPTION
## Purpose
This PR fixes `MolecularOrbitals.basis_set_ref` by replacing a local `SectionProxy` target with a fully-qualified section path.


## Scope

**Included**

-  In `src/nomad_simulations/schema_packages/properties/molecular_orbitals.py`:
  - from:
    - `SectionProxy('AtomCenteredBasisSet')`
  - to:
    - `SectionProxy('nomad_simulations.schema_packages.basis_set.AtomCenteredBasisSet')`

## Context & Links

_Reminder: Link related issues or PRs (in the sidebar or below). Add short description for any needed context._

- 

## Reviewer Notes

_Anything reviewers should pay special attention to? Trade-offs, known limitations, or areas of uncertainty._

## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] None
- [ ] (explain):

## Dependencies / Blockers

- [x] None
- [ ] Open design questions (explain):
- [ ] External dependencies (explain):

## Testing / Validation

_How was this change validated?_

- [x] None (explain):
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (explain):


