### PR TITLE
EmpiricalDispersionModel

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -218,12 +218,11 @@ class ImplicitSolvationModel(BaseModelMethod):
             )
 
 
-class ExplicitDispersionModel(BaseModelMethod):
-    """Explicit dispersion / vdW treatment used together with an ab-initio method.
+class EmpiricalDispersionModel(BaseModelMethod):
+    """Empirical dispersion correction used together with an ab-initio method.
 
     Covers pairwise-additive (D2/D3/D3(BJ)/D4), density-dependent (TS/TS-SCS),
-    many-body dispersion (MBD, e.g. MBD@rsSCS), and non-local correlation
-    functionals (VV10, rVV10, vdW-DF family, XDM).
+    many-body dispersion (MBD, e.g. MBD@rsSCS), and exchange-hole based XDM.
 
     References
     ----------
@@ -232,13 +231,12 @@ class ExplicitDispersionModel(BaseModelMethod):
     • S. Grimme et al., J. Chem. Phys. 136, 154105 (2012) - DFT-D3(BJ)
     • A. Tkatchenko, M. Scheffler, Phys. Rev. Lett. 102, 073005 (2009) - TS
     • A. Tkatchenko et al., Phys. Rev. Lett. 108, 236402 (2012) - MBD
-    • O. A. Vydrov, T. Van Voorhis, J. Chem. Phys. 133, 244103 (2010) - VV10
     • C. Steinmann, WIREs Comput. Mol. Sci. 10, e1438 (2020) - overview
     """
 
     model = Quantity(
         type=MEnum(
-            # Pairwise / density-dependent
+            # Pairwise / density-dependent empirical models
             'D2',
             'D3',
             'D3BJ',
@@ -252,24 +250,10 @@ class ExplicitDispersionModel(BaseModelMethod):
             'MBD@rsSCS',
             # Exchange-hole based
             'XDM',
-            # Non-local correlation functionals
-            'VV10',
-            'rVV10',
-            'vdW-DF',
-            'vdW-DF2',
-            'optB88-vdW',
-            'optB86b-vdW',
-            'SCAN+rVV10',
-            'BEEF-vdW',
         ),
         description="""
-        Identifier of the explicit dispersion / vdW model.
+        Identifier of the empirical dispersion correction model.
         """,
-    )
-
-    is_embedded_in_xc = Quantity(
-        type=bool,
-        description='True if dispersion is part of the XC functional (e.g. SCAN+rVV10).',
     )
 
     damping_function = Quantity(
@@ -281,12 +265,6 @@ class ExplicitDispersionModel(BaseModelMethod):
     xc_partner = Quantity(
         type=str,
         description="Base XC functional used/tuned for (e.g. 'PBE', 'SCAN', 'B3LYP').",
-    )
-
-    # Kernel family choice, when applicable. This is a model identifier, not a numerical knob.
-    nonlocal_kernel = Quantity(
-        type=MEnum('DRSLL', 'LMKLL', 'VV10', 'rVV10'),
-        description='Nonlocal correlation kernel flavor (when applicable).',
     )
 
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -223,6 +223,8 @@ class EmpiricalDispersionModel(BaseModelMethod):
 
     Covers pairwise-additive (D2/D3/D3(BJ)/D4), density-dependent (TS/TS-SCS),
     many-body dispersion (MBD, e.g. MBD@rsSCS), and exchange-hole based XDM.
+    In literature, `DFT-D` is often used as an umbrella label; this schema stores
+    the concrete generation explicitly when available (e.g. D2, D3, D3BJ, D4).
 
     References
     ----------

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1289,7 +1289,7 @@ class SolvationSettings(NumericalSettings):
 
 class DispersionKnob(ArchiveSection):
     """
-    A single typed numerical knob for an explicit dispersion / vdW correction.
+    A single typed numerical knob for an empirical dispersion correction.
 
     This is a "typed physical constraint" record: it stores one scalar value
     together with semantics that disambiguate what the value controls.
@@ -1305,14 +1305,12 @@ class DispersionKnob(ArchiveSection):
             'a1',
             'a2',
             'sR',
-            # Nonlocal kernel parameter
-            'b',
             # Many-body screening / range separation
             'beta',
         ),
         description="""
         Identifies the dispersion parameter using standard notation.
-        (e.g. s6, a1, beta, b).
+        (e.g. s6, a1, beta).
 
         All dispersion knobs are dimensionless.
         """,
@@ -1323,7 +1321,6 @@ class DispersionKnob(ArchiveSection):
             'pairwise',
             'three_body_atm',
             'many_body',
-            'nonlocal_kernel',
             'density_partitioning',
         ),
         description="""
@@ -1341,7 +1338,7 @@ class DispersionKnob(ArchiveSection):
 
 class DispersionSettings(NumericalSettings):
     """
-    Numerical and evaluation settings for an explicit dispersion / vdW correction.
+    Numerical and evaluation settings for an empirical dispersion correction.
 
     This section contains discrete switches and environment choices (e.g. whether
     to include higher-order dispersion terms, which density partitioning is used),
@@ -1412,7 +1409,7 @@ class DispersionSettings(NumericalSettings):
 
         Examples:
           • D3BJ:  s6/s8 (pairwise), a1/a2 (pairwise), optionally s9 (three_body_atm)
-          • rVV10: b (nonlocal_kernel)
+          • MBD@rsSCS: beta (many_body)
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1287,7 +1287,7 @@ class SolvationSettings(NumericalSettings):
     )
 
 
-class DispersionKnob(ArchiveSection):
+class EmpiricalDispersionKnob(ArchiveSection):
     """
     A single typed numerical knob for an empirical dispersion correction.
 
@@ -1336,13 +1336,13 @@ class DispersionKnob(ArchiveSection):
     )
 
 
-class DispersionSettings(NumericalSettings):
+class EmpiricalDispersionSettings(NumericalSettings):
     """
     Numerical and evaluation settings for an empirical dispersion correction.
 
     This section contains discrete switches and environment choices (e.g. whether
     to include higher-order dispersion terms, which density partitioning is used),
-    as well as typed scalar parameters stored as `DispersionKnob`.
+    as well as typed scalar parameters stored as `EmpiricalDispersionKnob`.
     """
 
     # switches for term inclusion / order
@@ -1402,7 +1402,7 @@ class DispersionSettings(NumericalSettings):
 
     # typed scalar parameters
     knobs = SubSection(
-        sub_section=DispersionKnob.m_def,
+        sub_section=EmpiricalDispersionKnob.m_def,
         repeats=True,
         description="""
         Typed scalar parameters (knobs) for the dispersion correction.

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -10,7 +10,7 @@ from nomad_simulations.schema_packages.model_method import (
     DFT,
     TB,
     ActiveSpace,
-    ExplicitDispersionModel,
+    EmpiricalDispersionModel,
     ImplicitSolvationModel,
     MultireferencePT,
     MultireferenceSCF,
@@ -630,7 +630,7 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
         refractive_index=1.33,
     )
 
-    edm = ExplicitDispersionModel(
+    edm = EmpiricalDispersionModel(
         model='D3BJ',
         damping_function='BJ',
     )
@@ -650,7 +650,7 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
 
     assert len(dft.contributions) == 3
     assert isinstance(dft.contributions[0], ImplicitSolvationModel)
-    assert isinstance(dft.contributions[1], ExplicitDispersionModel)
+    assert isinstance(dft.contributions[1], EmpiricalDispersionModel)
     assert isinstance(dft.contributions[2], RelativityModel)
 
     # Solvation

--- a/tests/test_numerical_settings.py
+++ b/tests/test_numerical_settings.py
@@ -4,8 +4,8 @@ from nomad.datamodel import EntryArchive
 from nomad.units import ureg
 
 from nomad_simulations.schema_packages.numerical_settings import (
-    DispersionKnob,
-    DispersionSettings,
+    EmpiricalDispersionKnob,
+    EmpiricalDispersionSettings,
     KLinePath,
     KMesh,
     KSpaceFunctionalities,
@@ -491,11 +491,11 @@ class TestKLinePath:
         assert np.allclose(k_line_path.points, points)
 
 
-class TestDispersionSettings:
+class TestEmpiricalDispersionSettings:
     """
     Tests for dispersion numerical settings schema:
-      - typed physical constraints via DispersionKnob
-      - container section DispersionSettings
+      - typed physical constraints via EmpiricalDispersionKnob
+      - container section EmpiricalDispersionSettings
     """
 
     def test_knobs_roundtrip_and_normalize_noop(self):
@@ -503,15 +503,15 @@ class TestDispersionSettings:
         Knobs should be storable and survive normalize() unchanged
         (no special normalization is defined currently).
         """
-        dns = DispersionSettings(
+        dns = EmpiricalDispersionSettings(
             include_c8=True,
             include_three_body_atm=False,
             partition_scheme='Hirshfeld',
             density_source='valence-only',
             knobs=[
-                DispersionKnob(kind='s6', applies_to='pairwise', value=1.0),
-                DispersionKnob(kind='a1', applies_to='pairwise', value=0.40),
-                DispersionKnob(kind='a2', applies_to='pairwise', value=4.00),
+                EmpiricalDispersionKnob(kind='s6', applies_to='pairwise', value=1.0),
+                EmpiricalDispersionKnob(kind='a1', applies_to='pairwise', value=0.40),
+                EmpiricalDispersionKnob(kind='a2', applies_to='pairwise', value=4.00),
             ],
         )
 
@@ -543,7 +543,7 @@ class TestDispersionSettings:
         """
         Basic storage test for the inclusion switches and max_dispersion_order.
         """
-        dns = DispersionSettings(
+        dns = EmpiricalDispersionSettings(
             include_three_body_atm=include_three_body_atm,
             include_c8=include_c8,
             include_c10=include_c10,
@@ -570,7 +570,7 @@ class TestDispersionSettings:
         """
         Storage test for environment/charge/density-source categorical fields.
         """
-        dns = DispersionSettings(
+        dns = EmpiricalDispersionSettings(
             partition_scheme=partition_scheme,
             charge_model=charge_model,
             density_source=density_source,
@@ -586,10 +586,12 @@ class TestDispersionSettings:
         It should be allowed to store multiple knobs of the same kind if they
         apply to different contributions (or even if not, schema-wise).
         """
-        dns = DispersionSettings(
+        dns = EmpiricalDispersionSettings(
             knobs=[
-                DispersionKnob(kind='s9', applies_to='three_body_atm', value=1.0),
-                DispersionKnob(kind='s9', applies_to='pairwise', value=0.0),
+                EmpiricalDispersionKnob(
+                    kind='s9', applies_to='three_body_atm', value=1.0
+                ),
+                EmpiricalDispersionKnob(kind='s9', applies_to='pairwise', value=0.0),
             ]
         )
         dns.normalize(EntryArchive(), logger=logger)


### PR DESCRIPTION
## Purpose

This PR refines the dispersion schema to cover empirical dispersion models only and removes non-empirical/nonlocal correlation entries from this path.

After some parsing and discussions with Denis, we realized that `EmpiricalDispersionModel` would be a better fit here

## Scope

**Included**

- Renamed the dispersion contribution class to `EmpiricalDispersionModel` for consistency with existing semantics.
- Restricted supported dispersion model types to empirical families (e.g. D2/D3/D3BJ/D4/TS/TS-SCS/MBD/MBD@rsSCS/XDM).
- Removed nonlocal-correlation-specific options from this branch of the schema.
- Updated related dispersion numerical settings and tests to match the empirical-only scope.

**Out of scope**

- Nonlocal correlation will be implemented separately as `NonlocalCorrelation` in another branch/PR #328 


## Context & Links

_Reminder: Link related issues or PRs (in the sidebar or below). Add short description for any needed context._

- NonlocalCorrelation #328 

## Reviewer Notes

I renamed the related numerical settings to `EmpiricalDispersionKnob` and `EmpiricalDispersionSettings` to match `EmpiricalDispersionModel` and to keep this branch empirical-only. Do you prefer these explicit names, or shorter `DispersionKnob`/`DispersionSettings` with the empirical scope implied by context?

## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] (explain):
It renames sections, but these have not yet been used in any of the merged parsers

## Dependencies / Blockers

- [x] None
- [ ] Open design questions (explain):
- [ ] External dependencies (explain):

## Testing / Validation

_How was this change validated?_

- [ ] None (explain):
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (explain):


