### PR TITLE
add `AtomsState.partial_charge` for atom-centered fractional charges

### DIFF
--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1114,6 +1114,16 @@ class AtomsState(ParticleState):
         """,
     )
 
+    partial_charge = Quantity(
+        type=np.float64,
+        unit='elementary_charge',
+        description="""
+        Atom-centered partial charge used in force fields or population analyses
+        (e.g., Mulliken, Hirshfeld, CM5, NPA, RESP). This quantity is distinct from
+        the formal integer oxidation-like `charge`.
+        """,
+    )
+
     spin = Quantity(
         type=np.int32,
         default=0,

--- a/tests/test_atoms_state.py
+++ b/tests/test_atoms_state.py
@@ -488,6 +488,10 @@ class TestAtomsState:
         assert atom_state.chemical_symbol == chemical_symbol
 
     def test_partial_charge_is_independent_of_formal_charge(self):
+        """
+        Test that `partial_charge` is preserved independently from the formal
+        integer `charge` after normalization.
+        """
         atom_state = AtomsState(
             chemical_symbol='O',
             charge=-1,

--- a/tests/test_atoms_state.py
+++ b/tests/test_atoms_state.py
@@ -487,6 +487,21 @@ class TestAtomsState:
         atom_state.normalize(EntryArchive(), logger)
         assert atom_state.chemical_symbol == chemical_symbol
 
+    def test_partial_charge_is_independent_of_formal_charge(self):
+        atom_state = AtomsState(
+            chemical_symbol='O',
+            charge=-1,
+            partial_charge=-0.42 * ureg.elementary_charge,
+        )
+        atom_state.normalize(EntryArchive(), logger)
+
+        assert atom_state.charge == -1
+        assert atom_state.partial_charge is not None
+        assert (
+            pytest.approx(atom_state.partial_charge.to('elementary_charge').magnitude)
+            == -0.42
+        )
+
 
 class TestCGBeadState:
     """


### PR DESCRIPTION
## Purpose

This PR adds a dedicated `partial_charge` field to `AtomsState` so parsers can store atom-centered fractional charges without overloading the existing formal integer `charge`.

## Scope

**Included**

- `AtomsState.charge` is intentionally formal/integer and defines the elemental charge. For MD and population-related runs, we also need a place for fractional per-atom charges (e.g., Mulliken, Hirshfeld, CM5, NPA, RESP).

## Context & Links

- discussed 10 mins ago with @JFRudzinski and @Bernadette-Mohr 

## Reviewer Notes

_Anything reviewers should pay special attention to? Trade-offs, known limitations, or areas of uncertainty._

## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

_How was this change validated?_

- [ ] None (explain):
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (explain):


