### PR TITLE
tighten `ParticleState` and `AtomsState` definition

### DIFF
--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1063,8 +1063,11 @@ class HubbardInteractions(ElectronicState):
 
 class ParticleState(Entity):
     """
-    Generic base section representing the state of a particle in a simulation.
-    This can be extended to include any common quantities in the future.
+    Generic base section for particle-level entities in a simulation.
+
+    `ParticleState` defines only metadata that can be shared across particle
+    representations. Domain-specific quantities should be introduced in
+    specialized subclasses (for example `AtomsState` and `CGBeadState`).
     """
 
     label = Quantity(
@@ -1083,7 +1086,15 @@ class ParticleState(Entity):
 
 class AtomsState(ParticleState):
     """
-    A base section to define each atom state information.
+    A base section to define each atom's state information.
+
+    This section stores intrinsic atom/site-level descriptors (element identity,
+    atomic number, formal integer charge, spin, site label) and an optional
+    `electronic_state` container for orbital-state metadata.
+
+    Method-dependent observables that are not intrinsic atom descriptors (for example,
+    atom-in-molecule partial charges from Mulliken/Hirshfeld/RESP analyses) are
+    out of scope for `AtomsState` and should be stored in method-specific sections.
     """
 
     chemical_symbol = Quantity(
@@ -1104,23 +1115,12 @@ class AtomsState(ParticleState):
         type=np.int32,
         default=0,
         description="""
-        Charge of the atom. It is defined as the number of extra electrons or holes in the
-        atom. If the atom is neutral, charge = 0 and the summation of all (if available) the`ElectronicState.occupation`
-        coincides with the `atomic_number`. Otherwise, charge can be any positive integer (+1, +2...)
-        for cations or any negative integer (-1, -2...) for anions.
+        Formal integer charge of the atom, defined as the number of extra
+        electrons (negative) or holes (positive) relative to the neutral atom.
+        For neutral atoms `charge = 0`.
 
         Note: for `CoreHole` systems we do not consider the charge of the atom even if
         we do not store the final `ElectronicState` where the electron was excited to.
-        """,
-    )
-
-    partial_charge = Quantity(
-        type=np.float64,
-        unit='elementary_charge',
-        description="""
-        Atom-centered partial charge used in force fields or population analyses
-        (e.g., Mulliken, Hirshfeld, CM5, NPA, RESP). This quantity is distinct from
-        the formal integer oxidation-like `charge`.
         """,
     )
 

--- a/tests/test_atoms_state.py
+++ b/tests/test_atoms_state.py
@@ -487,25 +487,6 @@ class TestAtomsState:
         atom_state.normalize(EntryArchive(), logger)
         assert atom_state.chemical_symbol == chemical_symbol
 
-    def test_partial_charge_is_independent_of_formal_charge(self):
-        """
-        Test that `partial_charge` is preserved independently from the formal
-        integer `charge` after normalization.
-        """
-        atom_state = AtomsState(
-            chemical_symbol='O',
-            charge=-1,
-            partial_charge=-0.42 * ureg.elementary_charge,
-        )
-        atom_state.normalize(EntryArchive(), logger)
-
-        assert atom_state.charge == -1
-        assert atom_state.partial_charge is not None
-        assert (
-            pytest.approx(atom_state.partial_charge.to('elementary_charge').magnitude)
-            == -0.42
-        )
-
 
 class TestCGBeadState:
     """


### PR DESCRIPTION
## Purpose

Following our team meeting on 27.02 and issue #337 , this PR aims to clarify `AtomsState` and `ParticleState` terminology.

## Scope

**Included**

- Removed `AtomsState.partial_charge` from the schema.
- Tightened `AtomsState` class docstring to make scope explicit (atomic/site-level descriptors only).
- Clarified `AtomsState.charge` as a **formal integer** charge.
- Strengthened `ParticleState` docstring to clarify base-vs-specialized responsibilities.
- Removed the obsolete `partial_charge` test.

## Context & Links


- #337 

## Reviewer Notes

- Such method-dependent quantities should be stored in method-specific/property sections instead of `AtomsState`.


## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] None
- [ ] (explain):

## Dependencies / Blockers

- [x] None
- [ ] Open design questions (explain):
- [ ] External dependencies (explain):

## Testing / Validation

_How was this change validated?_

- [x] None (explain):
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (explain):


