### PR TITLE
add a generic `ParticleState.mass` quantity

### DIFF
--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1269,14 +1269,6 @@ class CGBeadState(ParticleState):
         """,
     )
 
-    mass = Quantity(
-        type=positive_float(),
-        unit='kg',
-        description="""
-        Total mass of the particle.
-        """,
-    )
-
     charge = Quantity(
         type=np.float64,
         unit='coulomb',

--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -1065,8 +1065,8 @@ class ParticleState(Entity):
     """
     Generic base section for particle-level entities in a simulation.
 
-    `ParticleState` defines only metadata that can be shared across particle
-    representations. Domain-specific quantities should be introduced in
+    `ParticleState` defines representation-agnostic quantities that can be shared
+    across particle kinds. Domain-specific quantities should be introduced in
     specialized subclasses (for example `AtomsState` and `CGBeadState`).
     """
 
@@ -1074,6 +1074,21 @@ class ParticleState(Entity):
         type=str,
         description="""
         User- or program-package-defined identifier for this particle.
+        """,
+    )
+
+    mass = Quantity(
+        type=positive_float(),
+        unit='kg',
+        description="""
+        Mass associated with this particle/site, in kilograms.
+
+        This is an immutable per-particle descriptor intended for downstream
+        analyses that require per-particle masses.
+        For `AtomsState`, it is the mass of the modeled atomic site (including
+        isotope/effective choices provided by the source data). For `CGBeadState`,
+        it is the bead mass.
+        Method-related mass assignments belong in method-specific sections.
         """,
     )
 
@@ -1089,7 +1104,7 @@ class AtomsState(ParticleState):
     A base section to define each atom's state information.
 
     This section stores intrinsic atom/site-level descriptors (element identity,
-    atomic number, formal integer charge, spin, site label) and an optional
+    atomic number, mass, formal integer charge, spin, site label) and an optional
     `electronic_state` container for orbital-state metadata.
 
     Method-dependent observables that are not intrinsic atom descriptors (for example,
@@ -1255,7 +1270,7 @@ class CGBeadState(ParticleState):
     )
 
     mass = Quantity(
-        type=np.float64,
+        type=positive_float(),
         unit='kg',
         description="""
         Total mass of the particle.


### PR DESCRIPTION
## Purpose

Following our meeting on 27.02 and the PR #338 , this PR adds a shared mass quantity to `ParticleState` for downstream use, and clarifies its semantics as an immutable particle descriptor

## Scope

**Included**

- Added theory-agnostic `ParticleState.mass` with SI unit and type `positive_float()` for **immutable** per-particle mass description.
- Downstream use of mass is clarified in the docstring.
- Removed the child `CGBeadState.mass`.
- Already existing mass tests on `CGBeadState` passes


## Context & Links

_Reminder: Link related issues or PRs (in the sidebar or below). Add short description for any needed context._

- #338 , #337 

## Reviewer Notes

Please let me know if there is any ambiguity about what makes a mass immutable or method-dependent

## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] None
- [ ] (explain):

## Dependencies / Blockers

- [x] None
- [ ] Open design questions (explain):
- [ ] External dependencies (explain):

## Testing / Validation

_How was this change validated?_

- [ ] None (explain):
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (explain):


