### PR TITLE
Extend forcefield parameters

### DIFF
--- a/src/nomad_simulations/schema_packages/atoms_state.py
+++ b/src/nomad_simulations/schema_packages/atoms_state.py
@@ -620,10 +620,10 @@ class ElectronicState(Entity):
         section_def=BaseSpinOrbitalState.m_def,
         description="""
         The actual quantum state descriptor at this level of the hierarchy.
-        This `BaseSpinOrbitalState` (typically `SphericalSymmetryState`) defines the 
+        This `BaseSpinOrbitalState` (typically `SphericalSymmetryState`) defines the
         quantum numbers and properties of the state in a modular fashion.
         Child states in `sub_states` may inherit quantum numbers from this parent descriptor.
-        
+
         For example, if parent has `spin_orbit_state=SphericalSymmetryState(n=3, l=2)`,
         a child might only specify `spin_orbit_state=SphericalSymmetryState(ml=-2)`,
         with n=3, l=2 implied from the parent.
@@ -637,7 +637,7 @@ class ElectronicState(Entity):
         - For single orbitals: typically 1 (if ml, ms specified) or 2*l+1 (orbital only)
         - For manifolds: sum of constituent state degeneracies
         - For symmetry-adapted states: dimension of irreducible representation
-        
+
         Can be computed from `spin_orbit_state` or summed from `sub_states`.
         For correlated systems, represents the many-body state degeneracy.
         """,
@@ -647,11 +647,11 @@ class ElectronicState(Entity):
         type=positive_float(),
         description="""
         Electronic occupation of this state or manifold.
-        
+
         - For decomposable states: sum of occupations in `sub_states`
         - For correlated systems: effective occupation from many-body calculation (can be fractional)
         - For non-interacting: integer or follows Fermi-Dirac distribution
-        
+
         Note: For correlated electrons, fractional occupation does NOT mean partial occupancy
         of individual orbitals, but rather reflects the many-body quantum state.
         """,
@@ -674,17 +674,17 @@ class ElectronicState(Entity):
         repeats=True,
         description="""
         Hierarchical decomposition of this electronic state into finer-grained components.
-        
+
         The decomposition can follow different schemes depending on physics context:
         - **Orbital decomposition**: Split by ml quantum number (e.g., p → px, py, pz)
         - **Spin decomposition**: Split by ms quantum number (e.g., orbital → spin up/down)
         - **Symmetry decomposition**: Split by crystal field irreps (e.g., d → t2g, eg)
         - **Coupling scheme**: Split by j,mj for j-j coupling vs. ml,ms for L-S coupling
-        
+
         Multiple decomposition schemes can coexist for the same electrons - choose the one
         appropriate for your analysis. For strongly correlated systems where electrons cannot
         be assigned to individual orbitals, this may be empty or contain only a reference basis.
-        
+
         Child states inherit quantum number information from parent's `spin_orbit_state`,
         only specifying additional refinements (e.g., parent has l=2, child adds ml=-1).
         """,
@@ -694,26 +694,26 @@ class ElectronicState(Entity):
         section_def=BaseSpinOrbitalState.m_def,  # @EBB2675: do you see numerical_settings.basis_set also fit here?
         repeats=True,
         description="""
-        References to basis orbitals (as `BaseSpinOrbitalState` instances) used to construct 
+        References to basis orbitals (as `BaseSpinOrbitalState` instances) used to construct
         this state as a linear combination.
-        
+
         Used when this electronic state cannot be described by a single quantum state but rather
         as a superposition of simpler orbital states:
         - Hybrid orbitals: sp³ = linear combination of s, px, py, pz orbitals
         - Molecular orbitals: LCAO construction from atomic orbitals
         - Wannier functions: linear combination of Bloch states
         - Symmetry-adapted linear combinations (SALC)
-        
+
         Each entry is a simple quantum state (e.g., `SphericalSymmetryState(n=2, l=0)` for 2s,
-        `SphericalSymmetryState(n=2, l=1, ml=1)` for 2px, etc.) without the navigation 
+        `SphericalSymmetryState(n=2, l=1, ml=1)` for 2px, etc.) without the navigation
         structure of `ElectronicState`.
-        
+
         The actual expansion coefficients should be stored in the relevant electronic eigenvalue
         sections (e.g., `BandStructure.eigenvectors`, `DOSElectronicNew.value_projection`, etc.)
-        rather than duplicated here. This field provides the ordered basis set definition that 
+        rather than duplicated here. This field provides the ordered basis set definition that
         those coefficients correspond to.
-        
-        If this state has a simple symmetry description (`spin_orbit_state`), this field 
+
+        If this state has a simple symmetry description (`spin_orbit_state`), this field
         is typically empty. It's primarily for composite states that lack simple quantum number labels.
         """,
     )

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1271,6 +1271,30 @@ class ForceField(ModelMethod):
         """,
     )
 
+    partial_charges = Quantity(
+        type=np.float64,
+        unit='elementary_charge',
+        shape=['*'],
+        description="""
+        List of partial charges for each particle in the system, as force field
+        parameters. Adjusted from partial atomic charges to model interactions
+        within the context of the force field.
+        Different from the formal integer charges in AtomsState.charge!
+        """,
+    )
+
+    effective_masses = Quantity(
+        type=np.float64,
+        unit='kg',
+        shape=['*'],
+        description="""
+        List of masses for each particle in the system, as force field parameters.
+        Adjusted from atomic masses to model interactions within the context of the
+        force field.
+        Can be different from the elemental atomic masses from ParticleState.mass!
+        """,
+    )
+
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from itertools import chain
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import ase
 import numpy as np
 from scipy import sparse
 from scipy.stats import linregress
@@ -400,44 +401,133 @@ def archive_to_universe(
     if not _check_package_dependency('MDAnalysis', 'archive_to_universe', 'md'):
         return None
 
-    # TODO explicit return until we convert to data
-    if not archive.run:
-        return None
+    # TODO: legacy archive.run - remove this branch when migration to archive.data is complete
+    _using_new_schema = False
+    if archive.run:
+        try:
+            sec_run = archive.run[-1]
+            sec_system = sec_run.system
+            sec_system_top = sec_run.system[system_index]
+            sec_atoms = sec_system_top.atoms
+            sec_atoms_group = sec_system_top.atoms_group
+            n_atoms = sec_atoms.get('n_atoms')
+            atom_names = sec_atoms.get('labels')
+            system_times = [
+                calc.time for calc in sec_run.calculation if calc.system_ref
+            ]
+            sec_method = (
+                sec_run.method[method_index]
+                if sec_run.get('method') is not None
+                else {}
+            )
+            atom_parameters = (
+                sec_method.get('atom_parameters') if sec_method is not None else []
+            )
+            # get the atom masses and charges
+            masses = np.empty(n_atoms)
+            charges = np.empty(n_atoms)
 
-    try:
-        sec_run = archive.run[-1]
-        sec_system = sec_run.system
-        sec_system_top = sec_run.system[system_index]
-        sec_atoms = sec_system_top.atoms
-        sec_atoms_group = sec_system_top.atoms_group
-        sec_calculation = sec_run.calculation
-        sec_method = (
-            sec_run.method[method_index] if sec_run.get('method') is not None else {}
-        )
-    except IndexError:
+            for atom_ind, atom in enumerate(atom_parameters):
+                if atom.get('mass'):
+                    masses[atom_ind] = ureg.convert(
+                        atom.mass.magnitude, atom.mass.units, ureg.amu
+                    )
+                if atom.get('charge'):
+                    charges[atom_ind] = ureg.convert(
+                        atom.charge.magnitude, atom.charge.units, ureg.e
+                    )
+            atom_types = (
+                [atom.label for atom in atom_parameters]
+                if atom_parameters
+                else atom_names
+            )
+        except IndexError:
+            LOGGER.warning(
+                'Supplied indices or necessary sections do not exist in archive. Cannot build the MDA universe.'
+            )
+            return None
+    elif archive.data:
+        try:
+            sec_system = archive.data.model_system[system_index]
+            # sec_system_top = archive.data.system[system_index]
+            # sec_atoms = sec_system_top.atoms
+            sec_atoms_group = sec_system.sub_systems if sec_system is not None else None
+            n_atoms = sec_system.get('n_particles') if sec_system is not None else None
+            particle_states = (
+                sec_system.particle_states if sec_system is not None else None
+            )
+            atom_names = (
+                [ps.label or ps.chemical_symbol for ps in particle_states]
+                if particle_states
+                else None
+            )
+            atom_types = [ps.chemical_symbol for ps in particle_states]
+            masses = [
+                ureg.convert(ps.mass.magnitude, ps.mass.units, ureg.amu)
+                if ps.mass is not None
+                else ase.data.atomic_masses[
+                    ase.data.atomic_numbers.get(ps.chemical_symbol, 0)
+                ]
+                for ps in particle_states
+            ]
+            charges = [
+                ureg.convert(
+                    ps.partial_charge.magnitude, ps.partial_charge.units, ureg.e
+                )
+                if ps.partial_charge is not None
+                else 0.0
+                for ps in particle_states
+            ]
+            system_times = [
+                out.time for out in archive.data.outputs if out.time is not None
+            ]
+        except Exception:
+            LOGGER.warning('Archive can not be read.')
+            return None
+    else:
         LOGGER.warning(
-            'Supplied indices or necessary sections do not exist in archive. Cannot build the MDA universe.'
+            'No run or data section found in archive. Cannot build the MDA universe.'
         )
         return None
 
-    n_atoms = sec_atoms.get('n_atoms')
     if n_atoms is None:
         LOGGER.warning('No atoms found in the archive. Cannot build the MDA universe.')
         return None
 
     n_frames = len(sec_system) if sec_system is not None else 1
-    atom_names = sec_atoms.get('labels')
-    model_atom_parameters = sec_method.get('atom_parameters')
-    atom_types = (
-        [atom.label for atom in model_atom_parameters]
-        if model_atom_parameters
-        else atom_names
-    )
+
     atom_resindex = np.arange(n_atoms)
     atoms_segindices = np.empty(n_atoms)
     atom_segids = np.array(range(n_atoms), dtype='object')
     molecule_groups = sec_atoms_group
     n_segments = len(molecule_groups)
+
+    # Attribute accessors for archive.run / archive.data backward compatibility.
+    # TODO: legacy archive.run - remove else branch and _using_new_schema flag
+    # when migration to archive.data is complete.
+    if _using_new_schema:
+
+        def _atom_idx(obj):
+            return obj.particle_indices
+
+        def _label(obj):
+            return obj.branch_label
+
+        def _sub_objs(obj):
+            subs = obj.sub_systems
+            return subs if subs is not None else []
+
+    else:
+
+        def _atom_idx(obj):
+            return obj.atom_indices
+
+        def _label(obj):
+            return obj.label
+
+        def _sub_objs(obj):
+            subs = obj.atoms_group
+            return subs if subs is not None else []
 
     n_residues = 0
     n_molecules = 0
@@ -448,29 +538,29 @@ def archive_to_universe(
     residue_n_atoms = []
     molecule_n_res = []
     for mol_group_ind, mol_group in enumerate(molecule_groups):
-        atoms_segindices[mol_group.atom_indices] = mol_group_ind
-        atom_segids[mol_group.atom_indices] = mol_group.label
-        molecules = mol_group.atoms_group if mol_group.atoms_group is not None else []
+        atoms_segindices[_atom_idx(mol_group)] = mol_group_ind
+        atom_segids[_atom_idx(mol_group)] = _label(mol_group)
+        molecules = _sub_objs(mol_group)
         for mol in molecules:
-            monomer_groups = mol.atoms_group
+            monomer_groups = _sub_objs(mol)
             mol_res_counter = 0
             if monomer_groups:
                 for mon_group in monomer_groups:
-                    monomers = mon_group.atoms_group
+                    monomers = _sub_objs(mon_group)
                     for mon in monomers:
-                        resnames.append(mon.label)
+                        resnames.append(_label(mon))
                         residue_segindex.append(mol_group_ind)
-                        residue_moltypes.append(mol.label)
-                        residue_min_atom_index.append(np.min(mon.atom_indices))
-                        residue_n_atoms.append(len(mon.atom_indices))
+                        residue_moltypes.append(_label(mol))
+                        residue_min_atom_index.append(np.min(_atom_idx(mon)))
+                        residue_n_atoms.append(len(_atom_idx(mon)))
                         n_residues += 1
                         mol_res_counter += 1
-            else:  # no monomers => whole molecule is it's own residue
-                resnames.append(mol.label)
+            else:  # no monomers => whole molecule is its own residue
+                resnames.append(_label(mol))
                 residue_segindex.append(mol_group_ind)
-                residue_moltypes.append(mol.label)
-                residue_min_atom_index.append(np.min(mol.atom_indices))
-                residue_n_atoms.append(len(mol.atom_indices))
+                residue_moltypes.append(_label(mol))
+                residue_min_atom_index.append(np.min(_atom_idx(mol)))
+                residue_n_atoms.append(len(_atom_idx(mol)))
                 n_residues += 1
                 mol_res_counter += 1
             molecule_n_res.append(mol_res_counter)
@@ -505,66 +595,47 @@ def archive_to_universe(
         residue_molnums[mol_index_counter : mol_index_counter + n_res] = i_molecule
         mol_index_counter += n_res
 
-    # get the atom masses and charges
-
-    masses = np.empty(n_atoms)
-    charges = np.empty(n_atoms)
-    atom_parameters = (
-        sec_method.get('atom_parameters') if sec_method is not None else []
-    )
-    atom_parameters = atom_parameters if atom_parameters is not None else []
-
-    for atom_ind, atom in enumerate(atom_parameters):
-        if atom.get('mass'):
-            masses[atom_ind] = ureg.convert(
-                atom.mass.magnitude, atom.mass.units, ureg.amu
-            )
-        if atom.get('charge'):
-            charges[atom_ind] = ureg.convert(
-                atom.charge.magnitude, atom.charge.units, ureg.e
-            )
-
     # get the atom positions, velocities, and box dimensions
     positions = np.empty(shape=(n_frames, n_atoms, 3))
     velocities = np.empty(shape=(n_frames, n_atoms, 3))
     dimensions = np.empty(shape=(n_frames, 6))
     for frame_ind, frame in enumerate(sec_system):
-        sec_atoms_fr = frame.get('atoms')
-        if sec_atoms_fr is not None:
+        # TODO: legacy archive.run - remove else branch when migration is complete
+        if _using_new_schema:
+            positions_frame = frame.positions
+            velocities_frame = frame.velocities
+            latt_vec_tmp = frame.lattice_vectors
+        else:
+            sec_atoms_fr = frame.get('atoms')
+            if sec_atoms_fr is None:
+                continue
             positions_frame = sec_atoms_fr.positions
-            positions[frame_ind] = (
-                ureg.convert(
-                    positions_frame.magnitude, positions_frame.units, ureg.angstrom
-                )
-                if positions_frame is not None
-                else None
-            )
             velocities_frame = sec_atoms_fr.velocities
-            velocities[frame_ind] = (
-                ureg.convert(
-                    velocities_frame.magnitude,
-                    velocities_frame.units,
-                    ureg.angstrom / ureg.picosecond,
-                )
-                if velocities_frame is not None
-                else None
-            )
             latt_vec_tmp = sec_atoms_fr.get('lattice_vectors')
-            if latt_vec_tmp is not None:
-                length_conversion = ureg.convert(
-                    1.0, sec_atoms_fr.lattice_vectors.units, ureg.angstrom
-                )
-                dimensions[frame_ind] = [
-                    sec_atoms_fr.lattice_vectors.magnitude[0][0] * length_conversion,
-                    sec_atoms_fr.lattice_vectors.magnitude[1][1] * length_conversion,
-                    sec_atoms_fr.lattice_vectors.magnitude[2][2] * length_conversion,
-                    90,
-                    90,
-                    90,
-                ]  # TODO: extend to non-cubic boxes
+        if positions_frame is not None:
+            positions[frame_ind] = ureg.convert(
+                positions_frame.magnitude, positions_frame.units, ureg.angstrom
+            )
+        if velocities_frame is not None:
+            velocities[frame_ind] = ureg.convert(
+                velocities_frame.magnitude,
+                velocities_frame.units,
+                ureg.angstrom / ureg.picosecond,
+            )
+        if latt_vec_tmp is not None:
+            length_conversion = ureg.convert(1.0, latt_vec_tmp.units, ureg.angstrom)
+            dimensions[frame_ind] = [
+                latt_vec_tmp.magnitude[0][0] * length_conversion,
+                latt_vec_tmp.magnitude[1][1] * length_conversion,
+                latt_vec_tmp.magnitude[2][2] * length_conversion,
+                90,
+                90,
+                90,
+            ]  # TODO: extend to non-cubic boxes
 
     # get the bonds  # TODO extend to multiple storage options for interactions
-    bonds = sec_atoms.bond_list
+    # TODO: legacy archive.run - remove else branch when migration is complete
+    bonds = sec_system_top.bond_list if _using_new_schema else sec_atoms.bond_list
     # TODO add back in once get_bond_list_from_model_contributions is updated
     # if bonds is None:
     #     bonds = get_bond_list_from_model_contributions(
@@ -577,7 +648,6 @@ def archive_to_universe(
     def approx(a, b, rel_tol=1e-09, abs_tol=0.0):
         return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
-    system_times = [calc.time for calc in sec_calculation if calc.system_ref]
     if system_times:
         try:
             method = archive.workflow2.method

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -401,100 +401,50 @@ def archive_to_universe(
     if not _check_package_dependency('MDAnalysis', 'archive_to_universe', 'md'):
         return None
 
-    # TODO: legacy archive.run - remove this branch when migration to archive.data is complete
-    _using_new_schema = False
-    if archive.run:
+    if archive.data:
         try:
-            sec_run = archive.run[-1]
-            sec_system = sec_run.system
-            sec_system_top = sec_run.system[system_index]
-            sec_atoms = sec_system_top.atoms
-            sec_atoms_group = sec_system_top.atoms_group
-            n_atoms = sec_atoms.get('n_atoms')
-            atom_names = sec_atoms.get('labels')
-            system_times = [
-                calc.time for calc in sec_run.calculation if calc.system_ref
-            ]
-            sec_method = (
-                sec_run.method[method_index]
-                if sec_run.get('method') is not None
-                else {}
+            data = archive.data
+            sec_system = data.model_system
+            sec_system_top = sec_system[system_index]
+            sec_atoms_group = (
+                sec_system_top.sub_systems if sec_system_top is not None else None
             )
-            atom_parameters = (
-                sec_method.get('atom_parameters') if sec_method is not None else []
-            )
-            # get the atom masses and charges
-            masses = np.empty(n_atoms)
-            charges = np.empty(n_atoms)
+            sec_method = data.model_method[method_index] if data.model_method else None
 
-            for atom_ind, atom in enumerate(atom_parameters):
-                if atom.get('mass'):
-                    masses[atom_ind] = ureg.convert(
-                        atom.mass.magnitude, atom.mass.units, ureg.amu
-                    )
-                if atom.get('charge'):
-                    charges[atom_ind] = ureg.convert(
-                        atom.charge.magnitude, atom.charge.units, ureg.e
-                    )
-            atom_types = (
-                [atom.label for atom in atom_parameters]
-                if atom_parameters
-                else atom_names
-            )
-        except IndexError:
-            LOGGER.warning(
-                'Supplied indices or necessary sections do not exist in archive. Cannot build the MDA universe.'
-            )
-            return None
-    elif archive.data:
-        try:
-            sec_system = archive.data.model_system[system_index]
-            # sec_system_top = archive.data.system[system_index]
-            # sec_atoms = sec_system_top.atoms
-            sec_atoms_group = sec_system.sub_systems if sec_system is not None else None
-            n_atoms = sec_system.get('n_particles') if sec_system is not None else None
-            particle_states = (
-                sec_system.particle_states if sec_system is not None else None
-            )
-            atom_names = (
-                [ps.label or ps.chemical_symbol for ps in particle_states]
-                if particle_states
-                else None
-            )
-            atom_types = [ps.chemical_symbol for ps in particle_states]
-            masses = [
-                ureg.convert(ps.mass.magnitude, ps.mass.units, ureg.amu)
-                if ps.mass is not None
-                else ase.data.atomic_masses[
-                    ase.data.atomic_numbers.get(ps.chemical_symbol, 0)
-                ]
-                for ps in particle_states
-            ]
-            charges = [
-                ureg.convert(
-                    ps.partial_charge.magnitude, ps.partial_charge.units, ureg.e
-                )
-                if ps.partial_charge is not None
-                else 0.0
-                for ps in particle_states
-            ]
-            system_times = [
-                out.time for out in archive.data.outputs if out.time is not None
-            ]
         except Exception:
             LOGGER.warning('Archive can not be read.')
             return None
     else:
         LOGGER.warning(
-            'No run or data section found in archive. Cannot build the MDA universe.'
+            'No data section found in archive. Cannot build the MDA universe.'
         )
         return None
 
+    n_atoms = sec_system_top.get('n_particles') if sec_system is not None else None
     if n_atoms is None:
         LOGGER.warning('No atoms found in the archive. Cannot build the MDA universe.')
         return None
-
-    n_frames = len(sec_system) if sec_system is not None else 1
+    particle_states = sec_system_top.particle_states if sec_system is not None else None
+    atom_names = [ps.label for ps in particle_states] if particle_states else None
+    atom_types = [ps.chemical_symbol for ps in particle_states]
+    masses = [
+        ureg.convert(ps.mass.magnitude, ps.mass.units, ureg.amu)
+        if ps.mass is not None
+        else ase.data.atomic_masses[ase.data.atomic_numbers.get(ps.chemical_symbol, 0)]
+        for ps in particle_states
+    ]
+    charges = [
+        ureg.convert(ps.partial_charge.magnitude, ps.partial_charge.units, ureg.e)
+        if ps.partial_charge is not None
+        else 0.0
+        for ps in particle_states
+    ]
+    system_times = [
+        t
+        for out in archive.data.outputs
+        if (t := getattr(out, 'time', None)) is not None
+    ]
+    n_frames = len(sec_system)
 
     atom_resindex = np.arange(n_atoms)
     atoms_segindices = np.empty(n_atoms)
@@ -505,29 +455,15 @@ def archive_to_universe(
     # Attribute accessors for archive.run / archive.data backward compatibility.
     # TODO: legacy archive.run - remove else branch and _using_new_schema flag
     # when migration to archive.data is complete.
-    if _using_new_schema:
+    def _atom_idx(obj):
+        return obj.particle_indices
 
-        def _atom_idx(obj):
-            return obj.particle_indices
+    def _label(obj):
+        return obj.name if obj.name is not None else obj.branch_label
 
-        def _label(obj):
-            return obj.branch_label
-
-        def _sub_objs(obj):
-            subs = obj.sub_systems
-            return subs if subs is not None else []
-
-    else:
-
-        def _atom_idx(obj):
-            return obj.atom_indices
-
-        def _label(obj):
-            return obj.label
-
-        def _sub_objs(obj):
-            subs = obj.atoms_group
-            return subs if subs is not None else []
+    def _sub_objs(obj):
+        subs = obj.sub_systems
+        return subs if subs is not None else []
 
     n_residues = 0
     n_molecules = 0
@@ -597,26 +533,18 @@ def archive_to_universe(
 
     # get the atom positions, velocities, and box dimensions
     positions = np.empty(shape=(n_frames, n_atoms, 3))
-    velocities = np.empty(shape=(n_frames, n_atoms, 3))
     dimensions = np.empty(shape=(n_frames, 6))
+    has_velocities = any(frame.velocities is not None for frame in sec_system)
+    velocities = np.zeros(shape=(n_frames, n_atoms, 3)) if has_velocities else None
     for frame_ind, frame in enumerate(sec_system):
-        # TODO: legacy archive.run - remove else branch when migration is complete
-        if _using_new_schema:
-            positions_frame = frame.positions
-            velocities_frame = frame.velocities
-            latt_vec_tmp = frame.lattice_vectors
-        else:
-            sec_atoms_fr = frame.get('atoms')
-            if sec_atoms_fr is None:
-                continue
-            positions_frame = sec_atoms_fr.positions
-            velocities_frame = sec_atoms_fr.velocities
-            latt_vec_tmp = sec_atoms_fr.get('lattice_vectors')
+        positions_frame = frame.positions
+        velocities_frame = frame.velocities
+        latt_vec_tmp = frame.lattice_vectors
         if positions_frame is not None:
             positions[frame_ind] = ureg.convert(
                 positions_frame.magnitude, positions_frame.units, ureg.angstrom
             )
-        if velocities_frame is not None:
+        if has_velocities and velocities_frame is not None:
             velocities[frame_ind] = ureg.convert(
                 velocities_frame.magnitude,
                 velocities_frame.units,
@@ -635,7 +563,7 @@ def archive_to_universe(
 
     # get the bonds  # TODO extend to multiple storage options for interactions
     # TODO: legacy archive.run - remove else branch when migration is complete
-    bonds = sec_system_top.bond_list if _using_new_schema else sec_atoms.bond_list
+    bonds = sec_system_top.bond_list
     # TODO add back in once get_bond_list_from_model_contributions is updated
     # if bonds is None:
     #     bonds = get_bond_list_from_model_contributions(
@@ -649,33 +577,40 @@ def archive_to_universe(
         return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
     if system_times:
-        try:
-            method = archive.workflow2.method
-            system_timestep = (
-                method.integration_timestep * method.coordinate_save_frequency
-            )
-        except Exception:
-            LOGGER.warning(
-                'Cannot find the system times. MDA universe will contain non-physical times and timestep.'
-            )
-    else:
         time_steps = [
             system_times[i_time] - system_times[i_time - 1]
             for i_time in range(1, len(system_times))
         ]
         if all(approx(time_steps[0], time_step) for time_step in time_steps):
-            system_timestep = ureg.convert(
-                time_steps[0].magnitude, ureg.second, ureg.picosecond
+            system_timestep = (
+                ureg.convert(
+                    time_steps[0].magnitude, time_steps[0].units, ureg.picosecond
+                )
+                * ureg.picosecond
             )
         else:
             LOGGER.warning(
                 'System times are not equally spaced. Cannot set system times in MDA universe.'
                 ' MDA universe will contain non-physical times and timestep.'
             )
+    else:
+        try:
+            method = archive.workflow2.method
+            dt = method.integration_timestep
+            freq = method.coordinate_save_frequency
+            if dt is not None:
+                system_timestep = dt * freq if freq is not None else dt
+            else:
+                raise ValueError('integration_timestep is None')
+        except Exception:
+            LOGGER.warning(
+                'Cannot find the system times. MDA universe will contain non-physical times and timestep.'
+            )
 
-    system_timestep = ureg.convert(
-        system_timestep, system_timestep._units, ureg.picoseconds
-    )
+    if not hasattr(system_timestep, 'to'):
+        system_timestep = system_timestep * ureg.picosecond
+    else:
+        system_timestep = system_timestep.to(ureg.picosecond)
 
     # create the Universe
     metainfo_universe = create_empty_universe(
@@ -686,14 +621,15 @@ def archive_to_universe(
         atom_resindex=np.array(atom_resindex),
         residue_segindex=np.array(residue_segindex),
         flag_trajectory=True,
-        flag_velocities=True,
+        flag_velocities=has_velocities,
         timestep=system_timestep.magnitude,
     )
 
     # set the positions and velocities
     for frame_ind, frame in enumerate(metainfo_universe.trajectory):
         metainfo_universe.atoms.positions = positions[frame_ind]
-        metainfo_universe.atoms.velocities = velocities[frame_ind]
+        if has_velocities:
+            metainfo_universe.atoms.velocities = velocities[frame_ind]
 
     # add the atom attributes
     metainfo_universe.add_TopologyAttr('name', atom_names)
@@ -701,11 +637,12 @@ def archive_to_universe(
     metainfo_universe.add_TopologyAttr('mass', masses)
     metainfo_universe.add_TopologyAttr('charge', charges)
     if n_segments != 0:
-        metainfo_universe.add_TopologyAttr('segids', np.unique(atom_segids))
+        segids = [_label(mol_group) for mol_group in molecule_groups]
+        metainfo_universe.add_TopologyAttr('segids', segids)
     if n_residues != 0:
         metainfo_universe.add_TopologyAttr('resnames', resnames)
-        metainfo_universe.add_TopologyAttr('resids', np.unique(atom_resindex) + 1)
-        metainfo_universe.add_TopologyAttr('resnums', np.unique(atom_resindex) + 1)
+        metainfo_universe.add_TopologyAttr('resids', np.arange(n_residues) + 1)
+        metainfo_universe.add_TopologyAttr('resnums', np.arange(n_residues) + 1)
     if len(residue_molnums) > 0:
         metainfo_universe.add_TopologyAttr('molnums', residue_molnums)
     if len(residue_moltypes) > 0:
@@ -1350,8 +1287,8 @@ def calc_molecular_rg(
 
     rg_results: list[dict[str, Any]] = []
     for molgroup in system_hierarchy:
-        for i_mol, molecule in enumerate(molgroup.subsystems):
-            sec_monomer_groups = molecule.subsystems
+        for i_mol, molecule in enumerate(molgroup.sub_systems or []):
+            sec_monomer_groups = molecule.sub_systems
             group_type = (
                 sec_monomer_groups[0].branch_label if sec_monomer_groups else None
             )
@@ -1362,7 +1299,11 @@ def calc_molecular_rg(
             rg_result = calc_radius_of_gyration(universe, molecule.particle_indices)
             # Convert TypedDict to regular dict and add metadata
             result_dict: dict[str, Any] = dict(rg_result)
-            result_dict['label'] = molecule.label + '-index_' + str(i_mol)
+            result_dict['label'] = (
+                (molecule.name if molecule.name is not None else molecule.branch_label)
+                + '-index_'
+                + str(i_mol)
+            )
             result_dict['system_ref'] = molecule
             rg_results.append(result_dict)
 

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -409,7 +409,6 @@ def archive_to_universe(
             sec_atoms_group = (
                 sec_system_top.sub_systems if sec_system_top is not None else None
             )
-            sec_method = data.model_method[method_index] if data.model_method else None
 
         except Exception:
             LOGGER.warning('Archive can not be read.')

--- a/src/nomad_simulations/schema_packages/workflow/geometry_optimization.py
+++ b/src/nomad_simulations/schema_packages/workflow/geometry_optimization.py
@@ -168,7 +168,7 @@ class GeometryOptimizationResults(SimulationWorkflowResults):
         if not self.n_steps:
             self.n_steps = len(archive.data.outputs)
 
-        if not self.energies:
+        if self.energies is None:
             energies_l = []
             for outputs in archive.data.outputs:
                 try:

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -28,6 +28,7 @@ from nomad.datamodel.metainfo.workflow import Link
 from nomad.metainfo import MEnum, MSection, Quantity, Reference, Section, SubSection
 from nomad.units import ureg
 
+from nomad_simulations.schema_packages.errors import ErrorEstimate
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
 from nomad_simulations.schema_packages.physical_property import PhysicalProperty
@@ -1093,10 +1094,11 @@ class MolecularDynamicsResults(SerialWorkflowResults):
             return None
         try:
             universe = archive_to_universe(archive)
-        except Exception:
+        except Exception as exc:
             universe = None
             logger.warning(
-                'Could not convert archive to MDAnalysis Universe, skipping MD results normalization.'
+                'Could not convert archive to MDAnalysis Universe, skipping MD results normalization.',
+                exc_info=str(exc),
             )
         return universe
 
@@ -1105,7 +1107,7 @@ class MolecularDynamicsResults(SerialWorkflowResults):
         self, archive: EntryArchive
     ) -> list[RadialDistributionFunction]:
         # logger = self._get_molecular_rdfs.__annotations__['logger']
-        if not self.radial_distribution_functions:
+        if self.radial_distribution_functions:
             return self.radial_distribution_functions
 
         n_traj_split = 10  # number of intervals to split trajectory into for averaging
@@ -1147,7 +1149,6 @@ class MolecularDynamicsResults(SerialWorkflowResults):
                 rdf.n_variables = 1
                 rdf.variables_name = ['distance']
 
-                rdf.label = str(pair_type)
                 bins_list = rdf_results.get('bins', [])
                 value_list = rdf_results.get('value', [])
                 frame_start_list = rdf_results.get('frame_start', [])
@@ -1166,6 +1167,7 @@ class MolecularDynamicsResults(SerialWorkflowResults):
                 rdf.frame_end = (
                     frame_end_list[i_pair] if i_pair < len(frame_end_list) else 0
                 )
+                rdf.label = f'{pair_type}_frames_{rdf.frame_start}-{rdf.frame_end}'
                 sec_rdfs.append(rdf)
 
         return sec_rdfs
@@ -1177,6 +1179,7 @@ class MolecularDynamicsResults(SerialWorkflowResults):
         # logger = self._get_molecular_msds.__annotations__['logger']
         if (
             self.mean_squared_displacements is not None
+            and len(self.mean_squared_displacements) > 0
         ):  # TODO add check for diffusion_constants too?
             return self.mean_squared_displacements, self.diffusion_constants or []
 
@@ -1207,18 +1210,15 @@ class MolecularDynamicsResults(SerialWorkflowResults):
                     else []
                 )
                 if diffusion_constant.value is not None:
-                    diffusion_constant.error_type = (
-                        'Pearson correlation coefficient'  # TODO Update treatment!
-                    )
                     if msd_results.get('error_diffusion_constant') is not None:
-                        errors = msd_results['error_diffusion_constant'][i_type]
-                        diffusion_constant.errors = (
-                            list(errors)
-                            if isinstance(errors, list | np.ndarray)
-                            else [errors]
+                        error_val = msd_results['error_diffusion_constant'][i_type]
+                        error_estimate = ErrorEstimate(
+                            metric='other',
+                            value=[float(error_val)],
+                            notes='Pearson correlation coefficient of the linear MSD fit',
                         )
+                        diffusion_constant.errors = [error_estimate]
                     diffusion_constant.is_derived = True
-                    diffusion_constant.physical_property_ref = [msd]
                     sec_diffusion_constants.append(diffusion_constant)
                 sec_msds.append(msd)
 
@@ -1233,7 +1233,7 @@ class MolecularDynamicsResults(SerialWorkflowResults):
         """
         try:
             data = archive.data
-            sec_systems = data.system
+            sec_systems = data.model_system
             sec_outputs = data.outputs
         except Exception:
             logger.warning('Could not access archive data for populating output RGs')
@@ -1287,11 +1287,22 @@ class MolecularDynamicsResults(SerialWorkflowResults):
 
         try:
             data = archive.data
-            sec_systems = data.system
-            sec_system = sec_systems[data.representative_system_index]
+            # Use the first system that has sub_systems (topology frame),
+            # since representative_system_index may point to a trajectory frame
+            # with no sub_systems.
+            sec_system = next(
+                (s for s in data.model_system if s.sub_systems),
+                None,
+            )
             sec_outputs = data.outputs
         except Exception:
             logger.warning('Could not access archive data for RG calculation')
+            return []
+
+        if sec_system is None:
+            logger.warning(
+                'Could not find a system with sub_systems for RG calculation'
+            )
             return []
 
         # Check if RGs are already present in outputs

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -1350,15 +1350,17 @@ class MolecularDynamics(SerialWorkflow):
 
     results = SubSection(sub_section=MolecularDynamicsResults)
 
-    def map_inputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
-        super().map_inputs(archive, logger)
+    @log
+    def map_inputs(self, archive: EntryArchive) -> None:
+        super().map_inputs(archive)
         if not self.method:
             self.method = MolecularDynamicsMethod()
 
-    def map_outputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
-        super().map_outputs(archive, logger)
+    @log
+    def map_outputs(self, archive: EntryArchive) -> None:
         if not self.results:
             self.results = MolecularDynamicsResults()
+        super().map_outputs(archive)
 
     def normalize(self, archive, logger):
         super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -789,7 +789,7 @@ class MolecularDynamicsMethod(SimulationWorkflowMethod):
     integrator_type = Quantity(
         type=MEnum(
             'brownian',
-            'conjugant_gradient',
+            'conjugate_gradient',
             'langevin_goga',
             'langevin_schneider',
             'leap_frog',


### PR DESCRIPTION
## Purpose
`partial_charge` and `effective_mass` are method-dependent FF parameters, not invariant particle properties. This PR adds corresponding quantities for them on `ForceField`, enabling downstream code to read FF-assigned values separately from physical elemental masses.

## Scope

**Included**

- Added `partial_charges` (float64, unit `elementary_charge`, shape `['*']`) to `ForceField`
- Added `effective_masses` (float64, unit `kg`, shape `['*']`) to `ForceField`

**Out of scope**

- Removing `mass`/`partial_charge` from `AtomsState`/`CGBeadState`
- Updating parsers to write to the new fields
- Updating `archive_to_universe` to read from the new fields

## Context & Links

- Companion PR (archive_data_update): https://github.com/FAIRmat-NFDI/nomad-simulations/pull/338, https://github.com/FAIRmat-NFDI/nomad-simulations/pull/342, https://github.com/FAIRmat-NFDI/nomad-simulations/pull/343

## Reviewer Notes

- `effective_masses` is intentionally named to distinguish from `ParticleState.mass` (physical/elemental): FF mass assignments can deviate (virtual sites → 0, united-atom beads → summed mass, TIP4P dummy site → 0).
- `partial_charges` has no direct equivalent remaining on `ParticlesState`/`AtomsState`/`CGBeadState`, this is the sole charge storage for FF simulations.

## Status

- [ ] Draft / In progress
- [x] Ready for review
- [ ] Blocked (explain):

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [ ] None
- [ ] Open design questions (explain):
- [x] External dependencies: downstream parsers (`nomad-parser-plugins-simulation`) and `archive_to_universe` in `nomad-simulations` must be updated to populate/read these fields.

## Testing / Validation

- [x] None (explain): quantities are schema additions only; functional validation will occur as part of the parser integration tests.