### PR TITLE
Added partial_charges and effective_masses to class ForceField

### DIFF
--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -10,6 +10,7 @@ from nomad.metainfo import JSON, URL, MEnum, Quantity, Section, SubSection
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
+from nomad_simulations.schema_packages.data_types import positive_float
 from nomad_simulations.schema_packages.model_method import BaseModelMethod, ModelMethod
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
 
@@ -1271,10 +1272,18 @@ class ForceField(ModelMethod):
         """,
     )
 
+    n_particles = Quantity(
+        type=np.int32,
+        description="""
+        Number of particles in the system described by this force field.
+        Used as the shared dimension for per-particle arrays (partial_charges, effective_masses).
+        """,
+    )
+
     partial_charges = Quantity(
         type=np.float64,
         unit='elementary_charge',
-        shape=['*'],
+        shape=['n_particles'],
         description="""
         List of partial charges for each particle in the system, as force field
         parameters. Adjusted from partial atomic charges to model interactions
@@ -1284,9 +1293,9 @@ class ForceField(ModelMethod):
     )
 
     effective_masses = Quantity(
-        type=np.float64,
+        type=positive_float(),
         unit='kg',
-        shape=['*'],
+        shape=['n_particles'],
         description="""
         List of masses for each particle in the system, as force field parameters.
         Adjusted from atomic masses to model interactions within the context of the
@@ -1299,7 +1308,22 @@ class ForceField(ModelMethod):
         super().normalize(archive, logger)
 
         self.name = 'ForceField'
-        logger.warning('in force field')
+
+        # Infer n_particles from whichever per-particle array is present
+        if not self.n_particles:
+            if self.partial_charges is not None:
+                self.n_particles = len(self.partial_charges)
+            elif self.effective_masses is not None:
+                self.n_particles = len(self.effective_masses)
+
+        # Validate consistency when both arrays are present
+        if self.partial_charges is not None and self.effective_masses is not None:
+            if len(self.partial_charges) != len(self.effective_masses):
+                logger.warning(
+                    'partial_charges and effective_masses have different lengths: %s vs %s',
+                    len(self.partial_charges),
+                    len(self.effective_masses),
+                )
 
 
 # TODO Need to survey Lammps and maybe openmm and check for other common potential types

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1239,10 +1239,9 @@ class PeriodicImproper(ImproperDihedralPotential):
 
 class AtomParameters(ArchiveSection):
     """
-    Force field parameters for one atom type. `species_scope` holds direct
-    references to every `AtomsState` instance assigned this type, mirroring
-    the pattern of `BasisSetComponent.species_scope`. The references allow
-    navigation from an `AtomsState` back to its `AtomParameters` entry.
+    Force field parameters for one atom type. `species_scope` holds forward
+    references from this entry to every `AtomsState` instance assigned this
+    type, mirroring the pattern of `BasisSetComponent.species_scope`.
     `species_scope` is resolved automatically by `AtomParametersContainer.normalize()`
     by matching `atom_type` against `AtomsState.label`.
     """

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -17,6 +17,7 @@ from nomad.metainfo import (
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
+from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.data_types import positive_float
 from nomad_simulations.schema_packages.model_method import BaseModelMethod, ModelMethod
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
@@ -1240,23 +1241,21 @@ class PeriodicImproper(ImproperDihedralPotential):
 
 class AtomParameters(ArchiveSection):
     """
-    Force field parameters for one atom type. `particle_indices` lists the
-    positions in `ModelSystem.particle_states` of all atoms assigned this
-    type. All indexed atoms share the same scalar parameters (`partial_charge`,
-    `effective_mass`), avoiding per-instance duplication.
-
-    Semantically equivalent to `ModelSystem.particle_indices` for subsystems:
-    indices are counted from the representative top-level `ModelSystem`.
+    Force field parameters for one atom type. `species_scope` holds direct
+    references to every `AtomsState` instance assigned this type, mirroring
+    the pattern of `BasisSetComponent.species_scope`. The references allow
+    navigation from an `AtomsState` back to its `AtomParameters` entry.
+    `species_scope` is resolved automatically by `AtomParametersContainer.normalize()`
+    by matching `atom_type` against `AtomsState.label`.
     """
 
-    particle_indices = Quantity(
-        type=np.int32,
+    species_scope = Quantity(
+        type=AtomsState,
         shape=['*'],
         description="""
-        Indices into the parent `ModelSystem.particle_states` list for all
-        atoms assigned this atom type. Counted from the representative
-        (top-level) `ModelSystem`, consistent with
-        `ModelSystem.particle_indices` used for subsystems.
+        References to the `AtomsState` instances assigned this atom type.
+        Resolved by `AtomParametersContainer.normalize()` from `atom_type`
+        matching against `AtomsState.label` in the representative `ModelSystem`.
         """,
     )
 
@@ -1298,7 +1297,7 @@ class AtomParametersContainer(NumericalSettings):
     """
     Numerical-settings container for per-atom force field parameters grouped
     by atom type. Each `AtomParameters` subsection covers all atoms of one
-    FF atom type via `particle_indices`.
+    FF atom type via `species_scope` (references to `AtomsState` instances).
     """
 
     atom_parameters = SubSection(
@@ -1306,20 +1305,36 @@ class AtomParametersContainer(NumericalSettings):
         repeats=True,
         description="""
         Per-atom-type force field parameters (partial charge, effective mass,
-        atom type label). Each entry covers all atoms of one FF type via
-        `particle_indices`.
+        atom type label). Each entry references its atoms via `species_scope`.
         """,
     )
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
-        all_indices = [
-            int(i)
+        try:
+            particle_states = archive.data.model_system[0].particle_states
+        except (AttributeError, IndexError, TypeError):
+            particle_states = None
+
+        if particle_states is not None:
+            for ap in self.atom_parameters or []:
+                if ap.species_scope is not None and len(ap.species_scope) > 0:
+                    continue
+                if ap.atom_type is None:
+                    continue
+                ap.species_scope = [
+                    ps
+                    for ps in particle_states
+                    if getattr(ps, 'label', None) == ap.atom_type
+                ]
+
+        all_refs = [
+            id(ps)
             for ap in self.atom_parameters or []
-            for i in (ap.particle_indices if ap.particle_indices is not None else [])
+            for ps in (ap.species_scope if ap.species_scope is not None else [])
         ]
-        assert len(all_indices) == len(set(all_indices)), (
-            'Overlapping particle_indices across AtomParameters entries.'
+        assert len(all_refs) == len(set(all_refs)), (
+            'Overlapping species_scope references across AtomParameters entries.'
         )
 
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -15,7 +15,7 @@ from nomad.metainfo import (
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
-from nomad_simulations.schema_packages.atoms_state import AtomsState
+from nomad_simulations.schema_packages.atoms_state import ParticleState
 from nomad_simulations.schema_packages.data_types import positive_float
 from nomad_simulations.schema_packages.model_method import BaseModelMethod, ModelMethod
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
@@ -867,7 +867,8 @@ class PolynomialAngle(PolynomialPotential, AnglePotential):
         if match:
             extracted_text = match.group().strip()  # .group(1).strip()
         self.__doc__ = rf"""{self.__doc__} {extracted_text}.
-            Here the dependent variable of the potential, $x$, corresponds to the angle between three particles."""
+            Here the dependent variable of the potential, $x$, corresponds to the angle
+            between three particles."""
 
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
@@ -877,7 +878,8 @@ class PolynomialAngle(PolynomialPotential, AnglePotential):
 
 class TabulatedAngle(AnglePotential, TabulatedPotential):
     """
-    Section containing information about a tabulated bond potential. The value of the potential and/or force
+    Section containing information about a tabulated bond potential. The value of the
+    potential and/or force
     is stored for a set of corresponding bin distances.
     """
 
@@ -1249,22 +1251,22 @@ class PeriodicImproper(ImproperDihedralPotential):
             self.functional_form = 'periodic'
 
 
-class AtomParameters(ArchiveSection):
+class ParticleParameters(ArchiveSection):
     """
     Force field parameters for one atom type. `species_scope` holds forward
-    references from this entry to every `AtomsState` instance assigned this
+    references from this entry to every `ParticleState` instance assigned this
     type, mirroring the pattern of `BasisSetComponent.species_scope`.
-    `species_scope` is resolved automatically by `AtomParametersContainer.normalize()`
-    by matching `atom_type` against `AtomsState.label`.
+    `species_scope` is resolved automatically by `ParticleParametersContainer.normalize()`
+    by matching `atom_type` against `ParticleState.label`.
     """
 
     species_scope = Quantity(
-        type=AtomsState,
+        type=ParticleState,
         shape=['*'],
         description="""
-        References to the `AtomsState` instances assigned this atom type.
-        Resolved by `AtomParametersContainer.normalize()` from `atom_type`
-        matching against `AtomsState.label` in the representative `ModelSystem`.
+        References to the `ParticleState` instances assigned this atom type.
+        Resolved by `ParticleParametersContainer.normalize()` from `atom_type`
+        matching against `ParticleState.label` in the representative `ModelSystem`.
         """,
     )
 
@@ -1284,7 +1286,7 @@ class AtomParameters(ArchiveSection):
         unit='elementary_charge',
         description="""
         Partial charge assigned in this `AtomParameters` entry for the referenced
-        `AtomsState` instance, as a force field parameter. Adjusted from formal/
+        `ParticleState` instance, as a force field parameter. Adjusted from formal/
         oxidation charges to model electrostatic interactions within the context
         of the force field. Distinct from formal or oxidation-state style charges.
         """,
@@ -1295,22 +1297,22 @@ class AtomParameters(ArchiveSection):
         unit='kg',
         description="""
         Effective mass assigned in this `AtomParameters` entry for the referenced
-        `AtomsState` instance, as a force field parameter. May differ from the
+        `ParticleState` instance, as a force field parameter. May differ from the
         standard atomic mass when force-field parameterization adjusts masses for
         numerical stability or coarse-grained representations.
         """,
     )
 
 
-class AtomParametersContainer(NumericalSettings):
+class ParticleParametersContainer(NumericalSettings):
     """
     Numerical-settings container for per-atom force field parameters grouped
-    by atom type. Each `AtomParameters` subsection covers all atoms of one
-    FF atom type via `species_scope` (references to `AtomsState` instances).
+    by atom type. Each `ParticleParameters` subsection covers all atoms of one
+    FF atom type via `species_scope` (references to `ParticleState` instances).
     """
 
     atom_parameters = SubSection(
-        sub_section=AtomParameters.m_def,
+        sub_section=ParticleParameters.m_def,
         repeats=True,
         description="""
         Per-atom-type force field parameters (partial charge, effective mass,
@@ -1324,7 +1326,7 @@ class AtomParametersContainer(NumericalSettings):
             particle_states = archive.data.model_system[-1].particle_states
         except (AttributeError, IndexError, TypeError):
             logger.error(
-                'Unable to resolve AtomParameters.species_scope references, '
+                'Unable to resolve ParticleParameters.species_scope references, '
                 'model_system or particle_states not accessible.'
             )
             particle_states = None
@@ -1352,7 +1354,7 @@ class AtomParametersContainer(NumericalSettings):
                 seen.add(ps_id)
         if duplicates:
             logger.error(
-                'Overlapping species_scope references across AtomParameters entries.'
+                'Overlapping species_scope references across ParticleParameters entries.'
                 '(conflicting atom_type(s): %s)',
                 ', '.join(sorted(duplicates)),
             )
@@ -1361,8 +1363,9 @@ class AtomParametersContainer(NumericalSettings):
 class ForceField(ModelMethod):
     """
     Section containing the parameters of a (classical, particle-based) force field model.
-    Typical `numerical_settings` are ForceCalculations and AtomParametersContainer.
-    Lists of interactions by type and, if available, corresponding parameters can be given within `interactions`.
+    Typical `numerical_settings` are ForceCalculations and ParticleParametersContainer.
+    Lists of interactions by type and, if available, corresponding parameters can be given
+    within `interactions`.
     Additionally, a published model can be referenced with `reference`.
     """
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1329,13 +1329,22 @@ class AtomParametersContainer(NumericalSettings):
                 ]
 
         all_refs = [
-            id(ps)
+            (id(ps), getattr(ap, 'atom_type', None))
             for ap in self.atom_parameters or []
             for ps in (ap.species_scope if ap.species_scope is not None else [])
         ]
-        assert len(all_refs) == len(set(all_refs)), (
-            'Overlapping species_scope references across AtomParameters entries.'
-        )
+        ref_ids = [ref_id for ref_id, _ in all_refs]
+        seen: set[int] = set()
+        duplicates: set[str] = set()
+        for ref_id, atom_type in all_refs:
+            if ref_id in seen:
+                duplicates.add(str(atom_type))
+            seen.add(ref_id)
+        if len(duplicates) > 0:
+            raise ValueError(
+                'Overlapping species_scope references across AtomParameters entries'
+                ' (conflicting atom_type(s): %s).' % ', '.join(sorted(duplicates))
+            )
 
 
 class ForceField(ModelMethod):

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1271,6 +1271,30 @@ class ForceField(ModelMethod):
         """,
     )
 
+    partial_charges = Quantity(
+        type=np.float64,
+        unit='elementary_charge',
+        shape=['*'],
+        description="""
+        List of partial charges for each particle in the system, as force field
+        parameters. Adjusted from partial atomic charges to model interactions
+        within the context of the force field.
+        Different from the formal integer charges in AtomsState.charge!
+        """,
+    )
+
+    effective_masses = Quantity(
+        type=np.float64,
+        unit='kg',
+        shape=['*'],
+        description="""
+        List of masses for each particle in the system, as force field parameters.
+        Adjusted from atomic masses to model interactions within the context of the
+        force field.
+        Can be different from the elemental atomic masses from ParticleState.mass!
+        """,
+    )
+
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1037,7 +1037,7 @@ class PeriodicDihedral(DihedralPotential):
         type=np.float64,
         unit='radian',
         shape=[],
-        description="""
+        description=r"""
         Phase shift $\delta$.
         """,
     )
@@ -1144,7 +1144,7 @@ class AngleDihedralCouplingPotential(Potential):
 
 
 class HarmonicAngleDihedralCoupling(AngleDihedralCouplingPotential):
-    """
+    r"""
     Harmonic form of an angle–dihedral coupling potential:
     $V = k_1(\theta - \theta_0)^2 + k_2(\phi - \phi_0)^2 + k_3(\theta - \theta_0)(\phi - \phi_0)$
     """
@@ -1187,7 +1187,7 @@ class HarmonicImproper(ImproperDihedralPotential):
         type=np.float64,
         unit='radian',
         shape=[],
-        description="""
+        description=r"""
         Equilibrium improper angle $\omega_0$.
         """,
     )
@@ -1227,7 +1227,7 @@ class PeriodicImproper(ImproperDihedralPotential):
         type=np.float64,
         unit='radian',
         shape=[],
-        description="""
+        description=r"""
         Phase shift $\delta$.
         """,
     )

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1279,7 +1279,7 @@ class ForceField(ModelMethod):
         List of partial charges for each particle in the system, as force field
         parameters. Adjusted from partial atomic charges to model interactions
         within the context of the force field.
-        Different from the formal integer charges in AtomsState.charge!
+        Different from any formal/oxidation-state style charges stored on the system/particle state.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -6,7 +6,16 @@ import numpy as np
 from ase.dft.kpoints import get_monkhorst_pack_size_and_offset, monkhorst_pack
 from nomad.datamodel.context import Context
 from nomad.datamodel.data import ArchiveSection
-from nomad.metainfo import JSON, URL, MEnum, Quantity, Section, SubSection
+from nomad.metainfo import (
+    JSON,
+    URL,
+    MEnum,
+    Quantity,
+    Reference,
+    Section,
+    SectionProxy,
+    SubSection,
+)
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
@@ -1231,6 +1240,60 @@ class PeriodicImproper(ImproperDihedralPotential):
             self.functional_form = 'periodic'
 
 
+class AtomParameters(NumericalSettings):
+    """
+    Per-species force field parameters. Stores method-level atom descriptors
+    (partial charge, effective mass, atom type label) and references the
+    corresponding `AtomsState` entries via `species_scope`.
+
+    One `AtomParameters` instance covers all atoms sharing the same force field
+    type (e.g. AMBER `CT`, CHARMM `HT`). The `species_scope` list points to
+    every `AtomsState` section that carries that type.
+    """
+
+    species_scope = Quantity(
+        type=Reference(
+            SectionProxy('nomad_simulations.schema_packages.atoms_state.AtomsState')
+        ),
+        shape=['*'],
+        description="""
+        References to the `AtomsState` sections to which these force field
+        parameters apply. Mirrors the `BasisSetComponent.species_scope` pattern:
+        the method section references the system sections, not vice versa.
+        """,
+    )
+
+    atom_type = Quantity(
+        type=str,
+        description="""
+        Force field atom type label as defined by the force field (e.g. `'CT'`,
+        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple atoms in `species_scope` share
+        this label.
+        """,
+    )
+
+    partial_charge = Quantity(
+        type=np.float64,
+        unit='elementary_charge',
+        description="""
+        Partial charge for this force field atom type, as a force field parameter.
+        Adjusted from formal/oxidation charges to model electrostatic interactions
+        within the context of the force field. Distinct from the formal integer
+        charge stored on `AtomsState.charge`.
+        """,
+    )
+
+    effective_mass = Quantity(
+        type=positive_float(),
+        unit='kg',
+        description="""
+        Effective mass for this force field atom type, as a force field parameter.
+        May differ from the standard atomic mass when a force field adjusts masses
+        for numerical stability or coarse-graining purposes.
+        """,
+    )
+
+
 class ForceField(ModelMethod):
     """
     Section containing the parameters of a (classical, particle-based) force field model.
@@ -1272,35 +1335,13 @@ class ForceField(ModelMethod):
         """,
     )
 
-    n_particles = Quantity(
-        type=np.int32,
+    atom_parameters = SubSection(
+        sub_section=AtomParameters.m_def,
+        repeats=True,
         description="""
-        Number of particles in the system described by this force field.
-        Used as the shared dimension for per-particle arrays (partial_charges, effective_masses).
-        """,
-    )
-
-    partial_charges = Quantity(
-        type=np.float64,
-        unit='elementary_charge',
-        shape=['n_particles'],
-        description="""
-        List of partial charges for each particle in the system, as force field
-        parameters. Adjusted from partial atomic charges to model interactions
-        within the context of the force field.
-        Different from any formal/oxidation-state style charges stored on the system/particle state.
-        """,
-    )
-
-    effective_masses = Quantity(
-        type=positive_float(),
-        unit='kg',
-        shape=['n_particles'],
-        description="""
-        List of masses for each particle in the system, as force field parameters.
-        Adjusted from atomic masses to model interactions within the context of the
-        force field.
-        Can differ from the standard atomic masses.
+        Per-species force field parameters (partial charge, effective mass, atom
+        type label). Each subsection covers one force field atom type and
+        references the corresponding `AtomsState` entries via `species_scope`.
         """,
     )
 
@@ -1308,22 +1349,7 @@ class ForceField(ModelMethod):
         super().normalize(archive, logger)
 
         self.name = 'ForceField'
-
-        # Infer n_particles from whichever per-particle array is present
-        if not self.n_particles:
-            if self.partial_charges is not None:
-                self.n_particles = len(self.partial_charges)
-            elif self.effective_masses is not None:
-                self.n_particles = len(self.effective_masses)
-
-        # Validate consistency when both arrays are present
-        if self.partial_charges is not None and self.effective_masses is not None:
-            if len(self.partial_charges) != len(self.effective_masses):
-                logger.warning(
-                    'partial_charges and effective_masses have different lengths: %s vs %s',
-                    len(self.partial_charges),
-                    len(self.effective_masses),
-                )
+        logger.warning('in force field')
 
 
 # TODO Need to survey Lammps and maybe openmm and check for other common potential types

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1291,7 +1291,7 @@ class ForceField(ModelMethod):
         List of masses for each particle in the system, as force field parameters.
         Adjusted from atomic masses to model interactions within the context of the
         force field.
-        Can be different from the elemental atomic masses from ParticleState.mass!
+        Can differ from the standard atomic masses.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1310,7 +1310,10 @@ class AtomParametersContainer(NumericalSettings):
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
         try:
-            particle_states = archive.data.model_system[0].particle_states
+            model_systems = archive.data.model_system
+            rep_idx = getattr(archive.data, 'representative_system_index', None)
+            idx = rep_idx if rep_idx is not None else 0
+            particle_states = model_systems[idx].particle_states
         except (AttributeError, IndexError, TypeError):
             particle_states = None
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -7,11 +7,9 @@ from ase.dft.kpoints import get_monkhorst_pack_size_and_offset, monkhorst_pack
 from nomad.datamodel.context import Context
 from nomad.datamodel.data import ArchiveSection
 from nomad.metainfo import (
-    JSON,
     URL,
     MEnum,
     Quantity,
-    Section,
     SubSection,
 )
 from nomad.units import ureg

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1263,7 +1263,7 @@ class AtomParameters(ArchiveSection):
         type=str,
         description="""
         Force field atom type label as defined by the force field (e.g. `'CT'`,
-        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple `AtomParameters` entries may
+        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple particles in `species_scope` may
         share this label.
         This identifier is part of the force-field parameterization, not chemical
         element/species identity.

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -298,16 +298,16 @@ class TabulatedPotential(Potential):
         if not self.functional_form:
             self.functional_form = 'tabulated'
         elif self.functional_form != 'tabulated':
-            logger.warning(f'Incorrect functional form set for {self.name}.')
+            logger.warning('Incorrect functional form set for %s.', self.name)
 
         if self.bins is not None and self.energies is not None:
             if len(self.bins) != len(self.energies):
                 logger.error(
-                    f'bins and energies values have different length in {self.name}'
+                    'bins and energies values have different length in %s', self.name
                 )
         if self.bins is not None and self.forces is not None:
             if len(self.bins) != len(self.forces):
-                logger.error(f'bins and forces have different length in {self.name}')
+                logger.error('bins and forces have different length in %s', self.name)
 
         if self.bins is not None:
             smoothing_factor = len(self.bins) - np.sqrt(2 * len(self.bins))
@@ -348,19 +348,25 @@ class TabulatedPotential(Potential):
                     )
                     if np.all([np.abs(x) < FF_TOL for x in energies_diff]):
                         logger.warning(
-                            f'Tabulated forces were generated from energies in {self.name},'
-                            f'with consistency errors less than tol={FF_TOL}. '
+                            'Tabulated forces were generated from energies in %s,'
+                            'with consistency errors less than tol=%s. ',
+                            self.name,
+                            FF_TOL,
                         )
                     else:
                         logger.warning(
-                            f'Unable to derive tabulated forces from energies in {self.name},'
-                            f'consistency errors were greater than tol={FF_TOL}.'
+                            'Unable to derive tabulated forces from energies in %s,'
+                            'consistency errors were greater than tol=%s.',
+                            self.name,
+                            FF_TOL,
                         )
                         self.forces = None
                 except ValueError as e:
                     logger.warning(
-                        f'Unable to derive tabulated forces from energies in {self.name},'
-                        f'Unknown error occurred in derivation: {e}'
+                        'Unable to derive tabulated forces from energies in %s,'
+                        'Unknown error occurred in derivation: %s',
+                        self.name,
+                        e,
                     )
 
             if self.forces is not None and self.energies is None:
@@ -394,19 +400,25 @@ class TabulatedPotential(Potential):
                     )
                     if np.all([np.abs(x) < FF_TOL for x in forces_diff]):
                         logger.warning(
-                            f'Tabulated energies were generated from forces in {self.name},'
-                            f'with consistency errors less than tol={FF_TOL}. '
+                            'Tabulated energies were generated from forces in %s,'
+                            'with consistency errors less than tol=%s. ',
+                            self.name,
+                            FF_TOL,
                         )
                     else:
                         logger.warning(
-                            f'Unable to derive tabulated energies from forces in {self.name},'
-                            f'consistency errors were greater than tol={FF_TOL}.'
+                            'Unable to derive tabulated energies from forces in %s,'
+                            'consistency errors were greater than tol=%s.',
+                            self.name,
+                            FF_TOL,
                         )
                         self.energies = None
                 except ValueError as e:
                     logger.warning(
-                        f'Unable to derive tabulated energies from forces in {self.name},'
-                        f'Unknown error occurred in derivation: {e}'
+                        'Unable to derive tabulated energies from forces in %s,'
+                        'Unknown error occurred in derivation: %s',
+                        self.name,
+                        e,
                     )
 
 
@@ -1309,40 +1321,40 @@ class AtomParametersContainer(NumericalSettings):
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
         try:
-            model_systems = archive.data.model_system
-            rep_idx = getattr(archive.data, 'representative_system_index', None)
-            idx = rep_idx if rep_idx is not None else 0
-            particle_states = model_systems[idx].particle_states
+            particle_states = archive.data.model_system[-1].particle_states
         except (AttributeError, IndexError, TypeError):
+            logger.error(
+                'Unable to resolve AtomParameters.species_scope references, '
+                'model_system or particle_states not accessible.'
+            )
             particle_states = None
 
         if particle_states is not None:
+            label_index: dict[str, list] = {}
+            for ps in particle_states:
+                lbl = getattr(ps, 'label', None)
+                if lbl is not None:
+                    label_index.setdefault(lbl, []).append(ps)
             for ap in self.atom_parameters or []:
                 if ap.species_scope is not None and len(ap.species_scope) > 0:
                     continue
                 if ap.atom_type is None:
                     continue
-                ap.species_scope = [
-                    ps
-                    for ps in particle_states
-                    if getattr(ps, 'label', None) == ap.atom_type
-                ]
+                ap.species_scope = label_index.get(ap.atom_type, [])
 
-        all_refs = [
-            (id(ps), getattr(ap, 'atom_type', None))
-            for ap in self.atom_parameters or []
-            for ps in (ap.species_scope if ap.species_scope is not None else [])
-        ]
         seen: set[int] = set()
         duplicates: set[str] = set()
-        for ref_id, atom_type in all_refs:
-            if ref_id in seen:
-                duplicates.add(str(atom_type))
-            seen.add(ref_id)
-        if len(duplicates) > 0:
-            raise ValueError(
-                f'Overlapping species_scope references across AtomParameters entries'
-                f' (conflicting atom_type(s): {", ".join(sorted(duplicates))}).'
+        for ap in self.atom_parameters or []:
+            for ps in ap.species_scope or []:
+                ps_id = id(ps)
+                if ps_id in seen:
+                    duplicates.add(str(getattr(ap, 'atom_type', None)))
+                seen.add(ps_id)
+        if duplicates:
+            logger.error(
+                'Overlapping species_scope references across AtomParameters entries.'
+                '(conflicting atom_type(s): %s)',
+                ', '.join(sorted(duplicates)),
             )
 
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1257,23 +1257,23 @@ class ParticleParameters(ArchiveSection):
     references from this entry to every `ParticleState` instance assigned this
     type, mirroring the pattern of `BasisSetComponent.species_scope`.
     `species_scope` is resolved automatically by `ParticleParametersContainer.normalize()`
-    by matching `atom_type` against `ParticleState.label`.
+    by matching `particle_type` against `ParticleState.label`.
     """
 
     species_scope = Quantity(
         type=ParticleState,
         shape=['*'],
         description="""
-        References to the `ParticleState` instances assigned this atom type.
-        Resolved by `ParticleParametersContainer.normalize()` from `atom_type`
+        References to the `ParticleState` instances assigned this particle type.
+        Resolved by `ParticleParametersContainer.normalize()` from `particle_type`
         matching against `ParticleState.label` in the representative `ModelSystem`.
         """,
     )
 
-    atom_type = Quantity(
+    particle_type = Quantity(
         type=str,
         description="""
-        Force field atom type label as defined by the force field (e.g. `'CT'`,
+        Force field particle type label as defined by the force field (e.g. `'CT'`,
         `'OW'`, `'HW'` in AMBER/CHARMM). Multiple particles in `species_scope` may
         share this label.
         This identifier is part of the force-field parameterization, not chemical
@@ -1306,17 +1306,17 @@ class ParticleParameters(ArchiveSection):
 
 class ParticleParametersContainer(NumericalSettings):
     """
-    Numerical-settings container for per-atom force field parameters grouped
-    by atom type. Each `ParticleParameters` subsection covers all atoms of one
-    FF atom type via `species_scope` (references to `ParticleState` instances).
+    Numerical-settings container for per-particle force field parameters grouped
+    by particle type. Each `ParticleParameters` subsection covers all particles of one
+    FF particle type via `species_scope` (references to `ParticleState` instances).
     """
 
-    atom_parameters = SubSection(
+    particle_parameters = SubSection(
         sub_section=ParticleParameters.m_def,
         repeats=True,
         description="""
-        Per-atom-type force field parameters (partial charge, effective mass,
-        atom type label). Each entry references its atoms via `species_scope`.
+        Per-particle-type force field parameters (partial charge, effective mass,
+        particle type label). Each entry references its particles via `species_scope`.
         """,
     )
 
@@ -1337,25 +1337,25 @@ class ParticleParametersContainer(NumericalSettings):
                 lbl = getattr(ps, 'label', None)
                 if lbl is not None:
                     label_index.setdefault(lbl, []).append(ps)
-            for ap in self.atom_parameters or []:
+            for ap in self.particle_parameters or []:
                 if ap.species_scope is not None and len(ap.species_scope) > 0:
                     continue
-                if ap.atom_type is None:
+                if ap.particle_type is None:
                     continue
-                ap.species_scope = label_index.get(ap.atom_type, [])
+                ap.species_scope = label_index.get(ap.particle_type, [])
 
         seen: set[int] = set()
         duplicates: set[str] = set()
-        for ap in self.atom_parameters or []:
+        for ap in self.particle_parameters or []:
             for ps in ap.species_scope or []:
                 ps_id = id(ps)
                 if ps_id in seen:
-                    duplicates.add(str(getattr(ap, 'atom_type', None)))
+                    duplicates.add(str(getattr(ap, 'particle_type', None)))
                 seen.add(ps_id)
         if duplicates:
             logger.error(
                 'Overlapping species_scope references across ParticleParameters entries.'
-                '(conflicting atom_type(s): %s)',
+                '(conflicting particle_type(s): %s)',
                 ', '.join(sorted(duplicates)),
             )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -11,9 +11,7 @@ from nomad.metainfo import (
     URL,
     MEnum,
     Quantity,
-    Reference,
     Section,
-    SectionProxy,
     SubSection,
 )
 from nomad.units import ureg
@@ -1240,26 +1238,25 @@ class PeriodicImproper(ImproperDihedralPotential):
             self.functional_form = 'periodic'
 
 
-class AtomParameters(NumericalSettings):
+class AtomParameters(ArchiveSection):
     """
-    Per-species force field parameters. Stores method-level atom descriptors
-    (partial charge, effective mass, atom type label) and references the
-    corresponding `AtomsState` entries via `species_scope`.
+    Force field parameters for one atom type. `particle_indices` lists the
+    positions in `ModelSystem.particle_states` of all atoms assigned this
+    type. All indexed atoms share the same scalar parameters (`partial_charge`,
+    `effective_mass`), avoiding per-instance duplication.
 
-    One `AtomParameters` instance covers all atoms sharing the same force field
-    type (e.g. AMBER `CT`, CHARMM `HT`). The `species_scope` list points to
-    every `AtomsState` section that carries that type.
+    Semantically equivalent to `ModelSystem.particle_indices` for subsystems:
+    indices are counted from the representative top-level `ModelSystem`.
     """
 
-    species_scope = Quantity(
-        type=Reference(
-            SectionProxy('nomad_simulations.schema_packages.atoms_state.AtomsState')
-        ),
+    particle_indices = Quantity(
+        type=np.int32,
         shape=['*'],
         description="""
-        References to the `AtomsState` sections to which these force field
-        parameters apply. Mirrors the `BasisSetComponent.species_scope` pattern:
-        the method section references the system sections, not vice versa.
+        Indices into the parent `ModelSystem.particle_states` list for all
+        atoms assigned this atom type. Counted from the representative
+        (top-level) `ModelSystem`, consistent with
+        `ModelSystem.particle_indices` used for subsystems.
         """,
     )
 
@@ -1267,8 +1264,10 @@ class AtomParameters(NumericalSettings):
         type=str,
         description="""
         Force field atom type label as defined by the force field (e.g. `'CT'`,
-        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple atoms in `species_scope` share
-        this label.
+        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple `AtomParameters` entries may
+        share this label.
+        This identifier is part of the force-field parameterization, not chemical
+        element/species identity.
         """,
     )
 
@@ -1276,10 +1275,10 @@ class AtomParameters(NumericalSettings):
         type=np.float64,
         unit='elementary_charge',
         description="""
-        Partial charge for this force field atom type, as a force field parameter.
-        Adjusted from formal/oxidation charges to model electrostatic interactions
-        within the context of the force field. Distinct from the formal integer
-        charge stored on `AtomsState.charge`.
+        Partial charge assigned in this `AtomParameters` entry for the referenced
+        `AtomsState` instance, as a force field parameter. Adjusted from formal/
+        oxidation charges to model electrostatic interactions within the context
+        of the force field. Distinct from formal or oxidation-state style charges.
         """,
     )
 
@@ -1287,17 +1286,47 @@ class AtomParameters(NumericalSettings):
         type=positive_float(),
         unit='kg',
         description="""
-        Effective mass for this force field atom type, as a force field parameter.
-        May differ from the standard atomic mass when a force field adjusts masses
-        for numerical stability or coarse-graining purposes.
+        Effective mass assigned in this `AtomParameters` entry for the referenced
+        `AtomsState` instance, as a force field parameter. May differ from the
+        standard atomic mass when force-field parameterization adjusts masses for
+        numerical stability or coarse-grained representations.
         """,
     )
+
+
+class AtomParametersContainer(NumericalSettings):
+    """
+    Numerical-settings container for per-atom force field parameters grouped
+    by atom type. Each `AtomParameters` subsection covers all atoms of one
+    FF atom type via `particle_indices`.
+    """
+
+    atom_parameters = SubSection(
+        sub_section=AtomParameters.m_def,
+        repeats=True,
+        description="""
+        Per-atom-type force field parameters (partial charge, effective mass,
+        atom type label). Each entry covers all atoms of one FF type via
+        `particle_indices`.
+        """,
+    )
+
+    def normalize(self, archive, logger) -> None:
+        super().normalize(archive, logger)
+        all_indices = [
+            int(i)
+            for ap in self.atom_parameters or []
+            for i in (ap.particle_indices if ap.particle_indices is not None else [])
+        ]
+        assert len(all_indices) == len(set(all_indices)), (
+            'Overlapping particle_indices across AtomParameters entries.'
+        )
 
 
 class ForceField(ModelMethod):
     """
     Section containing the parameters of a (classical, particle-based) force field model.
-    Typical `numerical_settings` are ForceCalculations.
+    Typical `numerical_settings` are ForceCalculations and AtomParametersContainer.
     Lists of interactions by type and, if available, corresponding parameters can be given within `interactions`.
     Additionally, a published model can be referenced with `reference`.
     """
@@ -1335,21 +1364,10 @@ class ForceField(ModelMethod):
         """,
     )
 
-    atom_parameters = SubSection(
-        sub_section=AtomParameters.m_def,
-        repeats=True,
-        description="""
-        Per-species force field parameters (partial charge, effective mass, atom
-        type label). Each subsection covers one force field atom type and
-        references the corresponding `AtomsState` entries via `species_scope`.
-        """,
-    )
-
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 
         self.name = 'ForceField'
-        logger.warning('in force field')
 
 
 # TODO Need to survey Lammps and maybe openmm and check for other common potential types

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1333,7 +1333,6 @@ class AtomParametersContainer(NumericalSettings):
             for ap in self.atom_parameters or []
             for ps in (ap.species_scope if ap.species_scope is not None else [])
         ]
-        ref_ids = [ref_id for ref_id, _ in all_refs]
         seen: set[int] = set()
         duplicates: set[str] = set()
         for ref_id, atom_type in all_refs:
@@ -1342,8 +1341,8 @@ class AtomParametersContainer(NumericalSettings):
             seen.add(ref_id)
         if len(duplicates) > 0:
             raise ValueError(
-                'Overlapping species_scope references across AtomParameters entries'
-                ' (conflicting atom_type(s): %s).' % ', '.join(sorted(duplicates))
+                f'Overlapping species_scope references across AtomParameters entries'
+                f' (conflicting atom_type(s): {", ".join(sorted(duplicates))}).'
             )
 
 

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -1356,9 +1356,9 @@ class MolecularDynamics(SerialWorkflow):
             self.method = MolecularDynamicsMethod()
 
     def map_outputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
-        super().map_outputs(archive, logger)
         if not self.results:
             self.results = MolecularDynamicsResults()
+        super().map_outputs(archive, logger=logger)
 
     def normalize(self, archive, logger):
         super().normalize(archive, logger)

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -1350,14 +1350,16 @@ class MolecularDynamics(SerialWorkflow):
 
     results = SubSection(sub_section=MolecularDynamicsResults)
 
-    def map_inputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
-        super().map_inputs(archive, logger)
+    def map_inputs(self, archive: EntryArchive) -> None:
+        logger = self.map_inputs.__annotations__['logger']
+        super().map_inputs(archive, logger=logger)
         if not self.method:
             self.method = MolecularDynamicsMethod()
 
-    def map_outputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
+    def map_outputs(self, archive: EntryArchive) -> None:
         if not self.results:
             self.results = MolecularDynamicsResults()
+        logger = self.map_outputs.__annotations__['logger']
         super().map_outputs(archive, logger=logger)
 
     def normalize(self, archive, logger):

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -1350,16 +1350,14 @@ class MolecularDynamics(SerialWorkflow):
 
     results = SubSection(sub_section=MolecularDynamicsResults)
 
-    def map_inputs(self, archive: EntryArchive) -> None:
-        logger = self.map_inputs.__annotations__['logger']
-        super().map_inputs(archive, logger=logger)
+    def map_inputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
         if not self.method:
             self.method = MolecularDynamicsMethod()
+        super().map_inputs(archive, logger=logger)
 
-    def map_outputs(self, archive: EntryArchive) -> None:
+    def map_outputs(self, archive: EntryArchive, logger: BoundLogger = None) -> None:
         if not self.results:
             self.results = MolecularDynamicsResults()
-        logger = self.map_outputs.__annotations__['logger']
         super().map_outputs(archive, logger=logger)
 
     def normalize(self, archive, logger):

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -38,6 +38,7 @@ from nomad_simulations.schema_packages.force_field import (
     UreyBradleyAngle,
 )
 from nomad_simulations.schema_packages.general import Simulation
+from nomad_simulations.schema_packages.model_system import ModelSystem
 
 # from structlog.stdlib import BoundLogger
 from . import logger
@@ -1107,6 +1108,49 @@ class TestAtomParametersContainer:
 
         with pytest.raises(AssertionError):
             apc.normalize(EntryArchive(), logger)
+
+    def test_normalize_resolves_species_scope_from_archive(self):
+        """species_scope is populated by matching atom_type against AtomsState.label."""
+        ps_o = AtomsState(label='OW')
+        ps_h1 = AtomsState(label='HW')
+        ps_h2 = AtomsState(label='HW')
+        ms = ModelSystem()
+        ms.particle_states = [ps_o, ps_h1, ps_h2]
+        simulation = Simulation()
+        simulation.model_system.append(ms)
+        archive = EntryArchive()
+        archive.data = simulation
+
+        apc = AtomParametersContainer()
+        ap_o = AtomParameters()
+        ap_o.atom_type = 'OW'
+        ap_h = AtomParameters()
+        ap_h.atom_type = 'HW'
+        apc.atom_parameters = [ap_o, ap_h]
+        apc.normalize(archive, logger)
+
+        assert len(ap_o.species_scope) == 1
+        assert ap_o.species_scope[0] is ps_o
+        assert len(ap_h.species_scope) == 2
+        assert set(ap_h.species_scope) == {ps_h1, ps_h2}
+
+    def test_normalize_species_scope_empty_when_no_match(self):
+        """species_scope stays empty when atom_type matches no AtomsState.label."""
+        ps_o = AtomsState(label='OW')
+        ms = ModelSystem()
+        ms.particle_states = [ps_o]
+        simulation = Simulation()
+        simulation.model_system.append(ms)
+        archive = EntryArchive()
+        archive.data = simulation
+
+        apc = AtomParametersContainer()
+        ap = AtomParameters()
+        ap.atom_type = 'CT'  # no AtomsState with this label
+        apc.atom_parameters = [ap]
+        apc.normalize(archive, logger)
+
+        assert ap.species_scope is None or len(ap.species_scope) == 0
 
     def test_fits_into_force_field_numerical_settings(self):
         ff = ForceField()

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1061,10 +1061,10 @@ class TestParticleParameters:
         ps_o = AtomsState(label='OW')
         ps_h1 = AtomsState(label='HW1')
         ap = ParticleParameters()
-        ap.atom_type = 'OW'
+        ap.particle_type = 'OW'
         ap.species_scope = [ps_o, ps_h1]
 
-        assert ap.atom_type == 'OW'
+        assert ap.particle_type == 'OW'
         assert len(ap.species_scope) == 2
 
     def test_partial_charge_and_mass(self):
@@ -1083,12 +1083,12 @@ class TestParticleParametersContainer:
         ps_h2 = AtomsState(label='HW2')
         apc = ParticleParametersContainer()
         ap_o = ParticleParameters()
-        ap_o.atom_type = 'OW'
+        ap_o.particle_type = 'OW'
         ap_o.species_scope = [ps_o]
         ap_h = ParticleParameters()
-        ap_h.atom_type = 'HW'
+        ap_h.particle_type = 'HW'
         ap_h.species_scope = [ps_h1, ps_h2]
-        apc.atom_parameters = [ap_o, ap_h]
+        apc.particle_parameters = [ap_o, ap_h]
 
         # Should not raise
         apc.normalize(EntryArchive(), logger)
@@ -1097,12 +1097,12 @@ class TestParticleParametersContainer:
         ps_shared = AtomsState(label='OW')
         apc = ParticleParametersContainer()
         ap1 = ParticleParameters()
-        ap1.atom_type = 'OW'
+        ap1.particle_type = 'OW'
         ap1.species_scope = [ps_shared]
         ap2 = ParticleParameters()
-        ap2.atom_type = 'HW'
+        ap2.particle_type = 'HW'
         ap2.species_scope = [ps_shared]  # same object → overlap
-        apc.atom_parameters = [ap1, ap2]
+        apc.particle_parameters = [ap1, ap2]
 
         apc.normalize(EntryArchive(), logger)  # must not raise
         # scopes are left intact after the error is logged
@@ -1110,7 +1110,7 @@ class TestParticleParametersContainer:
         assert ap2.species_scope == [ps_shared]
 
     def test_normalize_resolves_species_scope_from_archive(self):
-        """species_scope is populated by matching atom_type against AtomsState.label.
+        """species_scope is populated by matching particle_type against AtomsState.label.
 
         A decoy ModelSystem at index 0 holds different labels so the test fails
         if normalize() uses model_system[0] instead of model_system[-1].
@@ -1135,10 +1135,10 @@ class TestParticleParametersContainer:
 
         apc = ParticleParametersContainer()
         ap_o = ParticleParameters()
-        ap_o.atom_type = 'OW'
+        ap_o.particle_type = 'OW'
         ap_h = ParticleParameters()
-        ap_h.atom_type = 'HW'
-        apc.atom_parameters = [ap_o, ap_h]
+        ap_h.particle_type = 'HW'
+        apc.particle_parameters = [ap_o, ap_h]
         apc.normalize(archive, logger)
 
         assert len(ap_o.species_scope) == 1
@@ -1147,7 +1147,7 @@ class TestParticleParametersContainer:
         assert set(ap_h.species_scope) == {ps_h1, ps_h2}
 
     def test_normalize_species_scope_empty_when_no_match(self):
-        """species_scope stays empty when atom_type matches no AtomsState.label."""
+        """species_scope stays empty when particle_type matches no AtomsState.label."""
         ps_o = AtomsState(label='OW')
         ms = ModelSystem()
         ms.particle_states = [ps_o]
@@ -1158,8 +1158,8 @@ class TestParticleParametersContainer:
 
         apc = ParticleParametersContainer()
         ap = ParticleParameters()
-        ap.atom_type = 'CT'  # no AtomsState with this label
-        apc.atom_parameters = [ap]
+        ap.particle_type = 'CT'  # no AtomsState with this label
+        apc.particle_parameters = [ap]
         apc.normalize(archive, logger)
 
         assert ap.species_scope is None or len(ap.species_scope) == 0
@@ -1168,13 +1168,13 @@ class TestParticleParametersContainer:
         ff = ForceField()
         apc = ParticleParametersContainer()
         ap = ParticleParameters()
-        ap.atom_type = 'OW'
-        apc.atom_parameters = [ap]
+        ap.particle_type = 'OW'
+        apc.particle_parameters = [ap]
         ff.numerical_settings.append(apc)
 
         assert len(ff.numerical_settings) == 1
         assert isinstance(ff.numerical_settings[0], ParticleParametersContainer)
-        assert ff.numerical_settings[0].atom_parameters[0].atom_type == 'OW'
+        assert ff.numerical_settings[0].particle_parameters[0].particle_type == 'OW'
 
 
 def test_missing_units_skip_derivation():

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1110,14 +1110,24 @@ class TestAtomParametersContainer:
             apc.normalize(EntryArchive(), logger)
 
     def test_normalize_resolves_species_scope_from_archive(self):
-        """species_scope is populated by matching atom_type against AtomsState.label."""
+        """species_scope is populated by matching atom_type against AtomsState.label.
+
+        A decoy ModelSystem at index 0 holds different labels so the test would fail
+        if normalize() hardcodes model_system[0] instead of the representative system.
+        """
+        decoy_ps = AtomsState(label='DECOY')
+        ms_decoy = ModelSystem()
+        ms_decoy.particle_states = [decoy_ps]
+
         ps_o = AtomsState(label='OW')
         ps_h1 = AtomsState(label='HW')
         ps_h2 = AtomsState(label='HW')
         ms = ModelSystem()
         ms.particle_states = [ps_o, ps_h1, ps_h2]
+
         simulation = Simulation()
-        simulation.model_system.append(ms)
+        simulation.model_system = [ms_decoy, ms]
+        simulation.representative_system_index = 1
         archive = EntryArchive()
         archive.data = simulation
 
@@ -1133,6 +1143,30 @@ class TestAtomParametersContainer:
         assert ap_o.species_scope[0] is ps_o
         assert len(ap_h.species_scope) == 2
         assert set(ap_h.species_scope) == {ps_h1, ps_h2}
+
+    def test_normalize_uses_representative_system(self):
+        """species_scope is resolved from the representative system, not always index 0."""
+        ps_wrong = AtomsState(label='OW')  # in non-representative system
+        ps_correct = AtomsState(label='OW')  # in representative system
+        ms0 = ModelSystem()
+        ms0.particle_states = [ps_wrong]
+        ms1 = ModelSystem()
+        ms1.particle_states = [ps_correct]
+        simulation = Simulation()
+        simulation.model_system = [ms0, ms1]
+        simulation.representative_system_index = 1
+        archive = EntryArchive()
+        archive.data = simulation
+
+        apc = AtomParametersContainer()
+        ap = AtomParameters()
+        ap.atom_type = 'OW'
+        apc.atom_parameters = [ap]
+        apc.normalize(archive, logger)
+
+        assert len(ap.species_scope) == 1
+        assert ap.species_scope[0] is ps_correct
+        assert ap.species_scope[0] is not ps_wrong
 
     def test_normalize_species_scope_empty_when_no_match(self):
         """species_scope stays empty when atom_type matches no AtomsState.label."""

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -9,8 +9,6 @@ from nomad_simulations.schema_packages.atoms_state import AtomsState
 
 # from nomad_simulations.schema_packages.method import ModelMethod
 from nomad_simulations.schema_packages.force_field import (
-    AtomParameters,
-    AtomParametersContainer,
     BondPotential,
     CosineAngle,
     CubicBond,
@@ -24,6 +22,8 @@ from nomad_simulations.schema_packages.force_field import (
     LinearBondAngleCoupling,
     MorseBond,
     ParameterEntry,
+    ParticleParameters,
+    ParticleParametersContainer,
     PeriodicDihedral,
     PeriodicImproper,
     PolynomialAngle,
@@ -1056,11 +1056,11 @@ def test_potentials(
 ## Other types of tests
 
 
-class TestAtomParameters:
+class TestParticleParameters:
     def test_basic_instantiation(self):
         ps_o = AtomsState(label='OW')
         ps_h1 = AtomsState(label='HW1')
-        ap = AtomParameters()
+        ap = ParticleParameters()
         ap.atom_type = 'OW'
         ap.species_scope = [ps_o, ps_h1]
 
@@ -1068,7 +1068,7 @@ class TestAtomParameters:
         assert len(ap.species_scope) == 2
 
     def test_partial_charge_and_mass(self):
-        ap = AtomParameters()
+        ap = ParticleParameters()
         ap.partial_charge = -0.834 * ureg.elementary_charge
         ap.effective_mass = 15.999 * ureg.amu
 
@@ -1076,16 +1076,16 @@ class TestAtomParameters:
         assert ap.effective_mass.to('amu').magnitude == pytest.approx(15.999)
 
 
-class TestAtomParametersContainer:
+class TestParticleParametersContainer:
     def test_normalize_passes_for_non_overlapping_scope(self):
         ps_o = AtomsState(label='OW')
         ps_h1 = AtomsState(label='HW1')
         ps_h2 = AtomsState(label='HW2')
-        apc = AtomParametersContainer()
-        ap_o = AtomParameters()
+        apc = ParticleParametersContainer()
+        ap_o = ParticleParameters()
         ap_o.atom_type = 'OW'
         ap_o.species_scope = [ps_o]
-        ap_h = AtomParameters()
+        ap_h = ParticleParameters()
         ap_h.atom_type = 'HW'
         ap_h.species_scope = [ps_h1, ps_h2]
         apc.atom_parameters = [ap_o, ap_h]
@@ -1095,11 +1095,11 @@ class TestAtomParametersContainer:
 
     def test_normalize_logs_for_overlapping_scope(self):
         ps_shared = AtomsState(label='OW')
-        apc = AtomParametersContainer()
-        ap1 = AtomParameters()
+        apc = ParticleParametersContainer()
+        ap1 = ParticleParameters()
         ap1.atom_type = 'OW'
         ap1.species_scope = [ps_shared]
-        ap2 = AtomParameters()
+        ap2 = ParticleParameters()
         ap2.atom_type = 'HW'
         ap2.species_scope = [ps_shared]  # same object → overlap
         apc.atom_parameters = [ap1, ap2]
@@ -1133,10 +1133,10 @@ class TestAtomParametersContainer:
         archive = EntryArchive()
         archive.data = simulation
 
-        apc = AtomParametersContainer()
-        ap_o = AtomParameters()
+        apc = ParticleParametersContainer()
+        ap_o = ParticleParameters()
         ap_o.atom_type = 'OW'
-        ap_h = AtomParameters()
+        ap_h = ParticleParameters()
         ap_h.atom_type = 'HW'
         apc.atom_parameters = [ap_o, ap_h]
         apc.normalize(archive, logger)
@@ -1156,8 +1156,8 @@ class TestAtomParametersContainer:
         archive = EntryArchive()
         archive.data = simulation
 
-        apc = AtomParametersContainer()
-        ap = AtomParameters()
+        apc = ParticleParametersContainer()
+        ap = ParticleParameters()
         ap.atom_type = 'CT'  # no AtomsState with this label
         apc.atom_parameters = [ap]
         apc.normalize(archive, logger)
@@ -1166,14 +1166,14 @@ class TestAtomParametersContainer:
 
     def test_fits_into_force_field_numerical_settings(self):
         ff = ForceField()
-        apc = AtomParametersContainer()
-        ap = AtomParameters()
+        apc = ParticleParametersContainer()
+        ap = ParticleParameters()
         ap.atom_type = 'OW'
         apc.atom_parameters = [ap]
         ff.numerical_settings.append(apc)
 
         assert len(ff.numerical_settings) == 1
-        assert isinstance(ff.numerical_settings[0], AtomParametersContainer)
+        assert isinstance(ff.numerical_settings[0], ParticleParametersContainer)
         assert ff.numerical_settings[0].atom_parameters[0].atom_type == 'OW'
 
 

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1058,8 +1058,6 @@ def test_potentials(
 
 class TestAtomParameters:
     def test_basic_instantiation(self):
-        from nomad_simulations.schema_packages.atoms_state import AtomsState
-
         ps_o = AtomsState(label='OW')
         ps_h1 = AtomsState(label='HW1')
         ap = AtomParameters()
@@ -1106,7 +1104,7 @@ class TestAtomParametersContainer:
         ap2.species_scope = [ps_shared]  # same object → overlap
         apc.atom_parameters = [ap1, ap2]
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match='conflicting atom_type'):
             apc.normalize(EntryArchive(), logger)
 
     def test_normalize_resolves_species_scope_from_archive(self):

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -5,8 +5,12 @@ import pytest
 from nomad.datamodel import EntryArchive
 from nomad.units import ureg
 
+from nomad_simulations.schema_packages.atoms_state import AtomsState
+
 # from nomad_simulations.schema_packages.method import ModelMethod
 from nomad_simulations.schema_packages.force_field import (
+    AtomParameters,
+    AtomParametersContainer,
     BondPotential,
     CosineAngle,
     CubicBond,
@@ -1049,6 +1053,72 @@ def test_potentials(
 
 
 ## Other types of tests
+
+
+class TestAtomParameters:
+    def test_basic_instantiation(self):
+        from nomad_simulations.schema_packages.atoms_state import AtomsState
+
+        ps_o = AtomsState(label='OW')
+        ps_h1 = AtomsState(label='HW1')
+        ap = AtomParameters()
+        ap.atom_type = 'OW'
+        ap.species_scope = [ps_o, ps_h1]
+
+        assert ap.atom_type == 'OW'
+        assert len(ap.species_scope) == 2
+
+    def test_partial_charge_and_mass(self):
+        ap = AtomParameters()
+        ap.partial_charge = -0.834 * ureg.elementary_charge
+        ap.effective_mass = 15.999 * ureg.amu
+
+        assert ap.partial_charge.magnitude == pytest.approx(-0.834)
+        assert ap.effective_mass.to('amu').magnitude == pytest.approx(15.999)
+
+
+class TestAtomParametersContainer:
+    def test_normalize_passes_for_non_overlapping_scope(self):
+        ps_o = AtomsState(label='OW')
+        ps_h1 = AtomsState(label='HW1')
+        ps_h2 = AtomsState(label='HW2')
+        apc = AtomParametersContainer()
+        ap_o = AtomParameters()
+        ap_o.atom_type = 'OW'
+        ap_o.species_scope = [ps_o]
+        ap_h = AtomParameters()
+        ap_h.atom_type = 'HW'
+        ap_h.species_scope = [ps_h1, ps_h2]
+        apc.atom_parameters = [ap_o, ap_h]
+
+        # Should not raise
+        apc.normalize(EntryArchive(), logger)
+
+    def test_normalize_raises_for_overlapping_scope(self):
+        ps_shared = AtomsState(label='OW')
+        apc = AtomParametersContainer()
+        ap1 = AtomParameters()
+        ap1.atom_type = 'OW'
+        ap1.species_scope = [ps_shared]
+        ap2 = AtomParameters()
+        ap2.atom_type = 'HW'
+        ap2.species_scope = [ps_shared]  # same object → overlap
+        apc.atom_parameters = [ap1, ap2]
+
+        with pytest.raises(AssertionError):
+            apc.normalize(EntryArchive(), logger)
+
+    def test_fits_into_force_field_numerical_settings(self):
+        ff = ForceField()
+        apc = AtomParametersContainer()
+        ap = AtomParameters()
+        ap.atom_type = 'OW'
+        apc.atom_parameters = [ap]
+        ff.numerical_settings.append(apc)
+
+        assert len(ff.numerical_settings) == 1
+        assert isinstance(ff.numerical_settings[0], AtomParametersContainer)
+        assert ff.numerical_settings[0].atom_parameters[0].atom_type == 'OW'
 
 
 def test_missing_units_skip_derivation():

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1093,7 +1093,7 @@ class TestAtomParametersContainer:
         # Should not raise
         apc.normalize(EntryArchive(), logger)
 
-    def test_normalize_raises_for_overlapping_scope(self):
+    def test_normalize_logs_for_overlapping_scope(self):
         ps_shared = AtomsState(label='OW')
         apc = AtomParametersContainer()
         ap1 = AtomParameters()
@@ -1104,14 +1104,16 @@ class TestAtomParametersContainer:
         ap2.species_scope = [ps_shared]  # same object → overlap
         apc.atom_parameters = [ap1, ap2]
 
-        with pytest.raises(ValueError, match='conflicting atom_type'):
-            apc.normalize(EntryArchive(), logger)
+        apc.normalize(EntryArchive(), logger)  # must not raise
+        # scopes are left intact after the error is logged
+        assert ap1.species_scope == [ps_shared]
+        assert ap2.species_scope == [ps_shared]
 
     def test_normalize_resolves_species_scope_from_archive(self):
         """species_scope is populated by matching atom_type against AtomsState.label.
 
-        A decoy ModelSystem at index 0 holds different labels so the test would fail
-        if normalize() hardcodes model_system[0] instead of the representative system.
+        A decoy ModelSystem at index 0 holds different labels so the test fails
+        if normalize() uses model_system[0] instead of model_system[-1].
         """
         decoy_ps = AtomsState(label='DECOY')
         ms_decoy = ModelSystem()
@@ -1124,8 +1126,10 @@ class TestAtomParametersContainer:
         ms.particle_states = [ps_o, ps_h1, ps_h2]
 
         simulation = Simulation()
-        simulation.model_system = [ms_decoy, ms]
-        simulation.representative_system_index = 1
+        simulation.model_system = [
+            ms_decoy,
+            ms,
+        ]  # ms is last, selected by model_system[-1]
         archive = EntryArchive()
         archive.data = simulation
 
@@ -1141,30 +1145,6 @@ class TestAtomParametersContainer:
         assert ap_o.species_scope[0] is ps_o
         assert len(ap_h.species_scope) == 2
         assert set(ap_h.species_scope) == {ps_h1, ps_h2}
-
-    def test_normalize_uses_representative_system(self):
-        """species_scope is resolved from the representative system, not always index 0."""
-        ps_wrong = AtomsState(label='OW')  # in non-representative system
-        ps_correct = AtomsState(label='OW')  # in representative system
-        ms0 = ModelSystem()
-        ms0.particle_states = [ps_wrong]
-        ms1 = ModelSystem()
-        ms1.particle_states = [ps_correct]
-        simulation = Simulation()
-        simulation.model_system = [ms0, ms1]
-        simulation.representative_system_index = 1
-        archive = EntryArchive()
-        archive.data = simulation
-
-        apc = AtomParametersContainer()
-        ap = AtomParameters()
-        ap.atom_type = 'OW'
-        apc.atom_parameters = [ap]
-        apc.normalize(archive, logger)
-
-        assert len(ap.species_scope) == 1
-        assert ap.species_scope[0] is ps_correct
-        assert ap.species_scope[0] is not ps_wrong
 
     def test_normalize_species_scope_empty_when_no_match(self):
         """species_scope stays empty when atom_type matches no AtomsState.label."""


### PR DESCRIPTION
## Purpose
`partial_charge` and `effective_mass` are method-dependent FF parameters, not invariant particle properties. This PR adds corresponding quantities for them on `ForceField`, enabling downstream code to read FF-assigned values separately from physical elemental masses.

## Scope

**Included**

- Added `partial_charges` (float64, unit `elementary_charge`, shape `['*']`) to `ForceField`
- Added `effective_masses` (float64, unit `kg`, shape `['*']`) to `ForceField`

**Out of scope**

- Removing `mass`/`partial_charge` from `AtomsState`/`CGBeadState`
- Updating parsers to write to the new fields
- Updating `archive_to_universe` to read from the new fields

## Context & Links

- Companion PRs: https://github.com/FAIRmat-NFDI/nomad-simulations/pull/338, https://github.com/FAIRmat-NFDI/nomad-simulations/pull/342, https://github.com/FAIRmat-NFDI/nomad-simulations/pull/343, https://github.com/FAIRmat-NFDI/nomad-simulations/pull/347

## Reviewer Notes

- `effective_masses` is intentionally named to distinguish from `ParticleState.mass` (physical/elemental): FF mass assignments can deviate (virtual sites → 0, united-atom beads → summed mass, TIP4P dummy site → 0).
- `partial_charges` has no direct equivalent remaining on `ParticlesState`/`AtomsState`/`CGBeadState`, this is the sole charge storage for FF simulations.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] External dependencies: downstream parsers (`nomad-parser-plugins-simulation`) and `archive_to_universe` in `nomad-simulations` must be updated to populate/read these fields.

## Testing / Validation

- [x] None (explain): quantities are schema additions only; functional validation will occur as part of the parser integration tests.