### PR TITLE
integrate `AtomParameters`

### DIFF
--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1244,13 +1244,13 @@ class AtomParameters(ArchiveSection):
     """
     Per-atom force field parameters. Stores method-specific atom descriptors
     (partial charge, effective mass, atom type label) and references the
-    corresponding `AtomsState` instance via `species_scope`.
+    corresponding `AtomsState` instance via `atoms_state_ref`.
 
-    One `AtomParameters` instance corresponds to one particle entry in
+    One `AtomParameters` instance corresponds to one atom entry in
     `ModelSystem.particle_states`.
     """
 
-    species_scope = Quantity(
+    atoms_state_ref = Quantity(
         type=Reference(
             SectionProxy('nomad_simulations.schema_packages.atoms_state.AtomsState')
         ),
@@ -1258,7 +1258,7 @@ class AtomParameters(ArchiveSection):
         description="""
         Reference to the `AtomsState` instance to which this atom-parameter entry applies.
         With repeating `atom_parameters` in `AtomParameterSettings`, one entry is
-        expected per particle.
+        expected per atom.
         """,
     )
 
@@ -1277,10 +1277,12 @@ class AtomParameters(ArchiveSection):
         type=np.float64,
         unit='elementary_charge',
         description="""
-        Partial charge for this force field atom type, as a force field parameter.
-        Adjusted from formal/oxidation charges to model electrostatic interactions
-        within the context of the force field. Distinct from formal or oxidation-
-        state style charges.
+        Partial charge assigned in this `AtomParameters` entry for the referenced
+        `AtomsState` instance, as a force field parameter. Adjusted from formal/
+        oxidation charges to model electrostatic interactions within the context
+        of the force field. Distinct from formal or oxidation-state style charges.
+        The `atom_type` value is a grouping label and does not require identical
+        per-atom values across all entries sharing the same label.
         """,
     )
 
@@ -1288,9 +1290,12 @@ class AtomParameters(ArchiveSection):
         type=positive_float(),
         unit='kg',
         description="""
-        Effective mass for this force field atom type, as a force field parameter.
-        May differ from the standard atomic mass when force-field parameterization
-        adjusts masses for numerical stability or coarse-grained representations.
+        Effective mass assigned in this `AtomParameters` entry for the referenced
+        `AtomsState` instance, as a force field parameter. May differ from the
+        standard atomic mass when force-field parameterization adjusts masses for
+        numerical stability or coarse-grained representations.
+        The `atom_type` value is a grouping label and does not require identical
+        per-atom values across all entries sharing the same label.
         """,
     )
 
@@ -1304,9 +1309,9 @@ class AtomParameterSettings(NumericalSettings):
         sub_section=AtomParameters.m_def,
         repeats=True,
         description="""
-        Per-particle force field parameters (partial charge, effective mass, atom
+        Per-atom force field parameters (partial charge, effective mass, atom
         type label). Each subsection references one `AtomsState` entry via
-        `species_scope`.
+        `atoms_state_ref`.
         """,
     )
 
@@ -1314,7 +1319,7 @@ class AtomParameterSettings(NumericalSettings):
 class ForceField(ModelMethod):
     """
     Section containing the parameters of a (classical, particle-based) force field model.
-    Typical `numerical_settings` are ForceCalculations.
+    Typical `numerical_settings` are ForceCalculations and AtomParameterSettings.
     Lists of interactions by type and, if available, corresponding parameters can be given within `interactions`.
     Additionally, a published model can be referenced with `reference`.
     """

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -10,6 +10,7 @@ from nomad.metainfo import JSON, URL, MEnum, Quantity, Section, SubSection
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
+from nomad_simulations.schema_packages.data_types import positive_float
 from nomad_simulations.schema_packages.model_method import BaseModelMethod, ModelMethod
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
 
@@ -1271,10 +1272,18 @@ class ForceField(ModelMethod):
         """,
     )
 
+    n_particles = Quantity(
+        type=np.int32,
+        description="""
+        Number of particles in the system described by this force field.
+        Used as the shared dimension for per-particle arrays (partial_charges, effective_masses).
+        """,
+    )
+
     partial_charges = Quantity(
         type=np.float64,
         unit='elementary_charge',
-        shape=['*'],
+        shape=['n_particles'],
         description="""
         List of partial charges for each particle in the system, as force field
         parameters. Adjusted from partial atomic charges to model interactions
@@ -1284,9 +1293,9 @@ class ForceField(ModelMethod):
     )
 
     effective_masses = Quantity(
-        type=np.float64,
+        type=positive_float(),
         unit='kg',
-        shape=['*'],
+        shape=['n_particles'],
         description="""
         List of masses for each particle in the system, as force field parameters.
         Adjusted from atomic masses to model interactions within the context of the
@@ -1299,7 +1308,22 @@ class ForceField(ModelMethod):
         super().normalize(archive, logger)
 
         self.name = 'ForceField'
-        logger.warning('in force field')
+
+        # Infer n_particles from whichever per-particle array is present
+        if not self.n_particles:
+            if self.partial_charges is not None:
+                self.n_particles = len(self.partial_charges)
+            elif self.effective_masses is not None:
+                self.n_particles = len(self.effective_masses)
+
+        # Validate consistency when both arrays are present
+        if self.partial_charges is not None and self.effective_masses is not None:
+            if len(self.partial_charges) != len(self.effective_masses):
+                logger.warning(
+                    'partial_charges and effective_masses have different lengths: %s vs %s',
+                    len(self.partial_charges),
+                    len(self.effective_masses),
+                )
 
 
 # TODO Need to survey Lammps and maybe openmm and check for other common potential types

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1257,7 +1257,8 @@ class AtomParameters(ArchiveSection):
         shape=[1],
         description="""
         Reference to the `AtomsState` instance to which this atom-parameter entry applies.
-        With repeating `atom_parameters` in `ForceField`, one entry is expected per particle.
+        With repeating `atom_parameters` in `AtomParameterSettings`, one entry is
+        expected per particle.
         """,
     )
 
@@ -1290,6 +1291,22 @@ class AtomParameters(ArchiveSection):
         Effective mass for this force field atom type, as a force field parameter.
         May differ from the standard atomic mass when force-field parameterization
         adjusts masses for numerical stability or coarse-grained representations.
+        """,
+    )
+
+
+class AtomParameterSettings(NumericalSettings):
+    """
+    Numerical-settings container for per-atom force field parameter entries.
+    """
+
+    atom_parameters = SubSection(
+        sub_section=AtomParameters.m_def,
+        repeats=True,
+        description="""
+        Per-particle force field parameters (partial charge, effective mass, atom
+        type label). Each subsection references one `AtomsState` entry via
+        `species_scope`.
         """,
     )
 
@@ -1332,16 +1349,6 @@ class ForceField(ModelMethod):
         repeats=True,
         description="""
         Contribution or sub-term of the total model Hamiltonian.
-        """,
-    )
-
-    atom_parameters = SubSection(
-        sub_section=AtomParameters.m_def,
-        repeats=True,
-        description="""
-        Per-particle force field parameters (partial charge, effective mass, atom
-        type label). Each subsection references one `AtomsState` entry via
-        `species_scope`.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1242,24 +1242,22 @@ class PeriodicImproper(ImproperDihedralPotential):
 
 class AtomParameters(NumericalSettings):
     """
-    Per-species force field parameters. Stores method-level atom descriptors
+    Per-atom force field parameters. Stores method-specific atom descriptors
     (partial charge, effective mass, atom type label) and references the
-    corresponding `AtomsState` entries via `species_scope`.
+    corresponding `AtomsState` instance via `species_scope`.
 
-    One `AtomParameters` instance covers all atoms sharing the same force field
-    type (e.g. AMBER `CT`, CHARMM `HT`). The `species_scope` list points to
-    every `AtomsState` section that carries that type.
+    One `AtomParameters` instance corresponds to one particle entry in
+    `ModelSystem.particle_states`.
     """
 
     species_scope = Quantity(
         type=Reference(
             SectionProxy('nomad_simulations.schema_packages.atoms_state.AtomsState')
         ),
-        shape=['*'],
+        shape=[1],
         description="""
-        References to the `AtomsState` sections to which these force field
-        parameters apply. Mirrors the `BasisSetComponent.species_scope` pattern:
-        the method section references the system sections, not vice versa.
+        Reference to the `AtomsState` instance to which this atom-parameter entry applies.
+        With repeating `atom_parameters` in `ForceField`, one entry is expected per particle.
         """,
     )
 
@@ -1267,8 +1265,10 @@ class AtomParameters(NumericalSettings):
         type=str,
         description="""
         Force field atom type label as defined by the force field (e.g. `'CT'`,
-        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple atoms in `species_scope` share
-        this label.
+        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple `AtomParameters` entries may
+        share this label.
+        This identifier is part of the force-field parameterization, not chemical
+        element/species identity.
         """,
     )
 
@@ -1278,8 +1278,8 @@ class AtomParameters(NumericalSettings):
         description="""
         Partial charge for this force field atom type, as a force field parameter.
         Adjusted from formal/oxidation charges to model electrostatic interactions
-        within the context of the force field. Distinct from the formal integer
-        charge stored on `AtomsState.charge`.
+        within the context of the force field. Distinct from formal or oxidation-
+        state style charges.
         """,
     )
 
@@ -1288,8 +1288,8 @@ class AtomParameters(NumericalSettings):
         unit='kg',
         description="""
         Effective mass for this force field atom type, as a force field parameter.
-        May differ from the standard atomic mass when a force field adjusts masses
-        for numerical stability or coarse-graining purposes.
+        May differ from the standard atomic mass when force-field parameterization
+        adjusts masses for numerical stability or coarse-grained representations.
         """,
     )
 
@@ -1339,9 +1339,9 @@ class ForceField(ModelMethod):
         sub_section=AtomParameters.m_def,
         repeats=True,
         description="""
-        Per-species force field parameters (partial charge, effective mass, atom
-        type label). Each subsection covers one force field atom type and
-        references the corresponding `AtomsState` entries via `species_scope`.
+        Per-particle force field parameters (partial charge, effective mass, atom
+        type label). Each subsection references one `AtomsState` entry via
+        `species_scope`.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1271,6 +1271,30 @@ class ForceField(ModelMethod):
         """,
     )
 
+    partial_charges = Quantity(
+        type=np.float64,
+        unit='elementary_charge',
+        shape=['*'],
+        description="""
+        List of partial charges for each particle in the system, as force field
+        parameters. Adjusted from partial atomic charges to model interactions
+        within the context of the force field.
+        Different from the formal integer charges in AtomsState.charge!
+        """,
+    )
+
+    effective_masses = Quantity(
+        type=np.float64,
+        unit='kg',
+        shape=['*'],
+        description="""
+        List of masses for each particle in the system, as force field parameters.
+        Adjusted from atomic masses to model interactions within the context of the
+        force field.
+        Can be different from the elemental atomic masses from ParticleState.mass!
+        """,
+    )
+
     def normalize(self, archive, logger) -> None:
         super().normalize(archive, logger)
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1279,7 +1279,7 @@ class ForceField(ModelMethod):
         List of partial charges for each particle in the system, as force field
         parameters. Adjusted from partial atomic charges to model interactions
         within the context of the force field.
-        Different from the formal integer charges in AtomsState.charge!
+        Different from any formal/oxidation-state style charges stored on the system/particle state.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -6,7 +6,16 @@ import numpy as np
 from ase.dft.kpoints import get_monkhorst_pack_size_and_offset, monkhorst_pack
 from nomad.datamodel.context import Context
 from nomad.datamodel.data import ArchiveSection
-from nomad.metainfo import JSON, URL, MEnum, Quantity, Section, SubSection
+from nomad.metainfo import (
+    JSON,
+    URL,
+    MEnum,
+    Quantity,
+    Reference,
+    Section,
+    SectionProxy,
+    SubSection,
+)
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
@@ -1231,6 +1240,60 @@ class PeriodicImproper(ImproperDihedralPotential):
             self.functional_form = 'periodic'
 
 
+class AtomParameters(NumericalSettings):
+    """
+    Per-species force field parameters. Stores method-level atom descriptors
+    (partial charge, effective mass, atom type label) and references the
+    corresponding `AtomsState` entries via `species_scope`.
+
+    One `AtomParameters` instance covers all atoms sharing the same force field
+    type (e.g. AMBER `CT`, CHARMM `HT`). The `species_scope` list points to
+    every `AtomsState` section that carries that type.
+    """
+
+    species_scope = Quantity(
+        type=Reference(
+            SectionProxy('nomad_simulations.schema_packages.atoms_state.AtomsState')
+        ),
+        shape=['*'],
+        description="""
+        References to the `AtomsState` sections to which these force field
+        parameters apply. Mirrors the `BasisSetComponent.species_scope` pattern:
+        the method section references the system sections, not vice versa.
+        """,
+    )
+
+    atom_type = Quantity(
+        type=str,
+        description="""
+        Force field atom type label as defined by the force field (e.g. `'CT'`,
+        `'OW'`, `'HW'` in AMBER/CHARMM). Multiple atoms in `species_scope` share
+        this label.
+        """,
+    )
+
+    partial_charge = Quantity(
+        type=np.float64,
+        unit='elementary_charge',
+        description="""
+        Partial charge for this force field atom type, as a force field parameter.
+        Adjusted from formal/oxidation charges to model electrostatic interactions
+        within the context of the force field. Distinct from the formal integer
+        charge stored on `AtomsState.charge`.
+        """,
+    )
+
+    effective_mass = Quantity(
+        type=positive_float(),
+        unit='kg',
+        description="""
+        Effective mass for this force field atom type, as a force field parameter.
+        May differ from the standard atomic mass when a force field adjusts masses
+        for numerical stability or coarse-graining purposes.
+        """,
+    )
+
+
 class ForceField(ModelMethod):
     """
     Section containing the parameters of a (classical, particle-based) force field model.
@@ -1272,35 +1335,13 @@ class ForceField(ModelMethod):
         """,
     )
 
-    n_particles = Quantity(
-        type=np.int32,
+    atom_parameters = SubSection(
+        sub_section=AtomParameters.m_def,
+        repeats=True,
         description="""
-        Number of particles in the system described by this force field.
-        Used as the shared dimension for per-particle arrays (partial_charges, effective_masses).
-        """,
-    )
-
-    partial_charges = Quantity(
-        type=np.float64,
-        unit='elementary_charge',
-        shape=['n_particles'],
-        description="""
-        List of partial charges for each particle in the system, as force field
-        parameters. Adjusted from partial atomic charges to model interactions
-        within the context of the force field.
-        Different from any formal/oxidation-state style charges stored on the system/particle state.
-        """,
-    )
-
-    effective_masses = Quantity(
-        type=positive_float(),
-        unit='kg',
-        shape=['n_particles'],
-        description="""
-        List of masses for each particle in the system, as force field parameters.
-        Adjusted from atomic masses to model interactions within the context of the
-        force field.
-        Can differ from the standard atomic masses.
+        Per-species force field parameters (partial charge, effective mass, atom
+        type label). Each subsection covers one force field atom type and
+        references the corresponding `AtomsState` entries via `species_scope`.
         """,
     )
 
@@ -1308,22 +1349,7 @@ class ForceField(ModelMethod):
         super().normalize(archive, logger)
 
         self.name = 'ForceField'
-
-        # Infer n_particles from whichever per-particle array is present
-        if not self.n_particles:
-            if self.partial_charges is not None:
-                self.n_particles = len(self.partial_charges)
-            elif self.effective_masses is not None:
-                self.n_particles = len(self.effective_masses)
-
-        # Validate consistency when both arrays are present
-        if self.partial_charges is not None and self.effective_masses is not None:
-            if len(self.partial_charges) != len(self.effective_masses):
-                logger.warning(
-                    'partial_charges and effective_masses have different lengths: %s vs %s',
-                    len(self.partial_charges),
-                    len(self.effective_masses),
-                )
+        logger.warning('in force field')
 
 
 # TODO Need to survey Lammps and maybe openmm and check for other common potential types

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1291,7 +1291,7 @@ class ForceField(ModelMethod):
         List of masses for each particle in the system, as force field parameters.
         Adjusted from atomic masses to model interactions within the context of the
         force field.
-        Can be different from the elemental atomic masses from ParticleState.mass!
+        Can differ from the standard atomic masses.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -11,14 +11,13 @@ from nomad.metainfo import (
     URL,
     MEnum,
     Quantity,
-    Reference,
     Section,
-    SectionProxy,
     SubSection,
 )
 from nomad.units import ureg
 from scipy.interpolate import UnivariateSpline
 
+from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.data_types import positive_float
 from nomad_simulations.schema_packages.model_method import BaseModelMethod, ModelMethod
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
@@ -1242,23 +1241,21 @@ class PeriodicImproper(ImproperDihedralPotential):
 
 class AtomParameters(ArchiveSection):
     """
-    Per-atom force field parameters. Stores method-specific atom descriptors
+    Per-atom-type force field parameters. Stores method-specific atom descriptors
     (partial charge, effective mass, atom type label) and references the
-    corresponding `AtomsState` instance via `atoms_state_ref`.
+    corresponding `AtomsState` instances via `species_scope`.
 
-    One `AtomParameters` instance corresponds to one atom entry in
-    `ModelSystem.particle_states`.
+    One `AtomParameters` instance corresponds to one atom type and may apply
+    to multiple entries in `ModelSystem.particle_states`.
     """
 
-    atoms_state_ref = Quantity(
-        type=Reference(
-            SectionProxy('nomad_simulations.schema_packages.atoms_state.AtomsState')
-        ),
-        shape=[1],
+    species_scope = Quantity(
+        type=AtomsState,
+        shape=['*'],
         description="""
-        Reference to the `AtomsState` instance to which this atom-parameter entry applies.
-        With repeating `atom_parameters` in `AtomParameterSettings`, one entry is
-        expected per atom.
+        References to the `AtomsState` entries to which this atom-parameter entry
+        applies. With repeating `atom_parameters` in `AtomParameterSettings`, one
+        entry is expected per atom type.
         """,
     )
 
@@ -1277,8 +1274,9 @@ class AtomParameters(ArchiveSection):
         type=np.float64,
         unit='elementary_charge',
         description="""
-        Partial charge assigned in this `AtomParameters` entry for the referenced
-        `AtomsState` instance, as a force field parameter. Adjusted from formal/
+        Partial charge assigned in this `AtomParameters` entry for the
+        `AtomsState` entries in `species_scope`, as a force field parameter.
+        Adjusted from formal/
         oxidation charges to model electrostatic interactions within the context
         of the force field. Distinct from formal or oxidation-state style charges.
         """,
@@ -1288,26 +1286,27 @@ class AtomParameters(ArchiveSection):
         type=positive_float(),
         unit='kg',
         description="""
-        Effective mass assigned in this `AtomParameters` entry for the referenced
-        `AtomsState` instance, as a force field parameter. May differ from the
-        standard atomic mass when force-field parameterization adjusts masses for
-        numerical stability or coarse-grained representations.
+        Effective mass assigned in this `AtomParameters` entry for the
+        `AtomsState` entries in `species_scope`, as a force field parameter.
+        May differ from the standard atomic mass when force-field
+        parameterization adjusts masses for numerical stability or coarse-grained
+        representations.
         """,
     )
 
 
 class AtomParameterSettings(NumericalSettings):
     """
-    Numerical-settings container for per-atom force field parameter entries.
+    Numerical-settings container for per-atom-type force field parameter entries.
     """
 
     atom_parameters = SubSection(
         sub_section=AtomParameters.m_def,
         repeats=True,
         description="""
-        Per-atom force field parameters (partial charge, effective mass, atom
-        type label). Each subsection references one `AtomsState` entry via
-        `atoms_state_ref`.
+        Per-atom-type force field parameters (partial charge, effective mass,
+        atom type label). Each subsection references one or more `AtomsState`
+        entries via `species_scope`.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1240,7 +1240,7 @@ class PeriodicImproper(ImproperDihedralPotential):
             self.functional_form = 'periodic'
 
 
-class AtomParameters(NumericalSettings):
+class AtomParameters(ArchiveSection):
     """
     Per-atom force field parameters. Stores method-specific atom descriptors
     (partial charge, effective mass, atom type label) and references the

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1281,8 +1281,6 @@ class AtomParameters(ArchiveSection):
         `AtomsState` instance, as a force field parameter. Adjusted from formal/
         oxidation charges to model electrostatic interactions within the context
         of the force field. Distinct from formal or oxidation-state style charges.
-        The `atom_type` value is a grouping label and does not require identical
-        per-atom values across all entries sharing the same label.
         """,
     )
 
@@ -1294,8 +1292,6 @@ class AtomParameters(ArchiveSection):
         `AtomsState` instance, as a force field parameter. May differ from the
         standard atomic mass when force-field parameterization adjusts masses for
         numerical stability or coarse-grained representations.
-        The `atom_type` value is a grouping label and does not require identical
-        per-atom values across all entries sharing the same label.
         """,
     )
 

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1124,8 +1124,6 @@ def test_force_field_atom_parameters():
     o_ref = '/data/model_system/0/particle_states/0'
     h1_ref = '/data/model_system/0/particle_states/1'
     h2_ref = '/data/model_system/0/particle_states/2'
-    ow_charge = (-0.834 * ureg.elementary_charge).to(ureg.coulomb).magnitude
-    hw_charge = (0.417 * ureg.elementary_charge).to(ureg.coulomb).magnitude
 
     def ref_path(value):
         return value[0] if isinstance(value, list) else value
@@ -1137,10 +1135,10 @@ def test_force_field_atom_parameters():
     assert len(hw_items) == 2
 
     assert ref_path(ow_items[0]['species_scope']) == o_ref
-    assert ow_items[0]['partial_charge'] == approx(ow_charge)
+    assert ow_items[0]['partial_charge'] == approx(-0.834)
     assert ow_items[0]['effective_mass'] == approx(2.6567e-26)
 
     assert {ref_path(item['species_scope']) for item in hw_items} == {h1_ref, h2_ref}
     for item in hw_items:
-        assert item['partial_charge'] == approx(hw_charge)
+        assert item['partial_charge'] == approx(0.417)
         assert item['effective_mass'] == approx(1.6735e-27)

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1094,24 +1094,24 @@ def test_force_field_atom_parameters():
         AtomParameters(
             species_scope=[entry.data.model_system[0].particle_states[0]],
             atom_type='OW',
-            partial_charge=-0.834,
-            effective_mass=2.6567e-26,
+            partial_charge=-0.834 * ureg.elementary_charge,
+            effective_mass=2.6567e-26 * ureg.kg,
         )
     )
     ff.atom_parameters.append(
         AtomParameters(
             species_scope=[entry.data.model_system[0].particle_states[1]],
             atom_type='HW',
-            partial_charge=0.417,
-            effective_mass=1.6735e-27,
+            partial_charge=0.417 * ureg.elementary_charge,
+            effective_mass=1.6735e-27 * ureg.kg,
         )
     )
     ff.atom_parameters.append(
         AtomParameters(
             species_scope=[entry.data.model_system[0].particle_states[2]],
             atom_type='HW',
-            partial_charge=0.417,
-            effective_mass=1.6735e-27,
+            partial_charge=0.417 * ureg.elementary_charge,
+            effective_mass=1.6735e-27 * ureg.kg,
         )
     )
 
@@ -1124,6 +1124,8 @@ def test_force_field_atom_parameters():
     o_ref = '/data/model_system/0/particle_states/0'
     h1_ref = '/data/model_system/0/particle_states/1'
     h2_ref = '/data/model_system/0/particle_states/2'
+    ow_charge = (-0.834 * ureg.elementary_charge).to(ureg.coulomb).magnitude
+    hw_charge = (0.417 * ureg.elementary_charge).to(ureg.coulomb).magnitude
 
     def ref_path(value):
         return value[0] if isinstance(value, list) else value
@@ -1135,10 +1137,10 @@ def test_force_field_atom_parameters():
     assert len(hw_items) == 2
 
     assert ref_path(ow_items[0]['species_scope']) == o_ref
-    assert ow_items[0]['partial_charge'] == approx(-0.834)
+    assert ow_items[0]['partial_charge'] == approx(ow_charge)
     assert ow_items[0]['effective_mass'] == approx(2.6567e-26)
 
     assert {ref_path(item['species_scope']) for item in hw_items} == {h1_ref, h2_ref}
     for item in hw_items:
-        assert item['partial_charge'] == approx(0.417)
+        assert item['partial_charge'] == approx(hw_charge)
         assert item['effective_mass'] == approx(1.6735e-27)

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -10,6 +10,7 @@ from nomad_simulations.schema_packages.atoms_state import AtomsState
 # from nomad_simulations.schema_packages.method import ModelMethod
 from nomad_simulations.schema_packages.force_field import (
     AtomParameters,
+    AtomParameterSettings,
     BondPotential,
     CosineAngle,
     CubicBond,
@@ -1090,7 +1091,8 @@ def test_force_field_atom_parameters():
     )
 
     ff = entry.data.model_method[0]
-    ff.atom_parameters.append(
+    atom_parameter_settings = AtomParameterSettings()
+    atom_parameter_settings.atom_parameters.append(
         AtomParameters(
             species_scope=[entry.data.model_system[0].particle_states[0]],
             atom_type='OW',
@@ -1098,7 +1100,7 @@ def test_force_field_atom_parameters():
             effective_mass=2.6567e-26 * ureg.kg,
         )
     )
-    ff.atom_parameters.append(
+    atom_parameter_settings.atom_parameters.append(
         AtomParameters(
             species_scope=[entry.data.model_system[0].particle_states[1]],
             atom_type='HW',
@@ -1106,7 +1108,7 @@ def test_force_field_atom_parameters():
             effective_mass=1.6735e-27 * ureg.kg,
         )
     )
-    ff.atom_parameters.append(
+    atom_parameter_settings.atom_parameters.append(
         AtomParameters(
             species_scope=[entry.data.model_system[0].particle_states[2]],
             atom_type='HW',
@@ -1114,12 +1116,16 @@ def test_force_field_atom_parameters():
             effective_mass=1.6735e-27 * ureg.kg,
         )
     )
+    ff.numerical_settings.append(atom_parameter_settings)
 
     ff.normalize(None, logger)
     d = ff.m_to_dict()
 
     assert d['name'] == 'ForceField'
-    assert len(d['atom_parameters']) == 3
+    assert len(d['numerical_settings']) == 1
+    setting = d['numerical_settings'][0]
+    assert setting['m_def'].endswith('.AtomParameterSettings')
+    assert len(setting['atom_parameters']) == 3
 
     o_ref = '/data/model_system/0/particle_states/0'
     h1_ref = '/data/model_system/0/particle_states/1'
@@ -1128,8 +1134,12 @@ def test_force_field_atom_parameters():
     def ref_path(value):
         return value[0] if isinstance(value, list) else value
 
-    ow_items = [item for item in d['atom_parameters'] if item['atom_type'] == 'OW']
-    hw_items = [item for item in d['atom_parameters'] if item['atom_type'] == 'HW']
+    ow_items = [
+        item for item in setting['atom_parameters'] if item['atom_type'] == 'OW'
+    ]
+    hw_items = [
+        item for item in setting['atom_parameters'] if item['atom_type'] == 'HW'
+    ]
 
     assert len(ow_items) == 1
     assert len(hw_items) == 2

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -5,8 +5,11 @@ import pytest
 from nomad.datamodel import EntryArchive
 from nomad.units import ureg
 
+from nomad_simulations.schema_packages.atoms_state import AtomsState
+
 # from nomad_simulations.schema_packages.method import ModelMethod
 from nomad_simulations.schema_packages.force_field import (
+    AtomParameters,
     BondPotential,
     CosineAngle,
     CubicBond,
@@ -34,6 +37,7 @@ from nomad_simulations.schema_packages.force_field import (
     UreyBradleyAngle,
 )
 from nomad_simulations.schema_packages.general import Simulation
+from nomad_simulations.schema_packages.model_system import ModelSystem
 
 # from structlog.stdlib import BoundLogger
 from . import logger
@@ -1067,3 +1071,74 @@ def test_missing_units_skip_derivation():
 
     # Ensure that normalization does not produce an error
     dummy.normalize(None, logger)
+
+
+def test_force_field_atom_parameters():
+    entry = EntryArchive(
+        data=Simulation(
+            model_system=[
+                ModelSystem(
+                    particle_states=[
+                        AtomsState(chemical_symbol='O'),
+                        AtomsState(chemical_symbol='H'),
+                        AtomsState(chemical_symbol='H'),
+                    ]
+                )
+            ],
+            model_method=[ForceField()],
+        )
+    )
+
+    ff = entry.data.model_method[0]
+    ff.atom_parameters.append(
+        AtomParameters(
+            species_scope=[entry.data.model_system[0].particle_states[0]],
+            atom_type='OW',
+            partial_charge=-0.834,
+            effective_mass=2.6567e-26,
+        )
+    )
+    ff.atom_parameters.append(
+        AtomParameters(
+            species_scope=[entry.data.model_system[0].particle_states[1]],
+            atom_type='HW',
+            partial_charge=0.417,
+            effective_mass=1.6735e-27,
+        )
+    )
+    ff.atom_parameters.append(
+        AtomParameters(
+            species_scope=[entry.data.model_system[0].particle_states[2]],
+            atom_type='HW',
+            partial_charge=0.417,
+            effective_mass=1.6735e-27,
+        )
+    )
+
+    ff.normalize(None, logger)
+    d = ff.m_to_dict()
+
+    assert d['name'] == 'ForceField'
+    assert len(d['atom_parameters']) == 3
+
+    o_ref = '/data/model_system/0/particle_states/0'
+    h1_ref = '/data/model_system/0/particle_states/1'
+    h2_ref = '/data/model_system/0/particle_states/2'
+
+    def ref_path(value):
+        return value[0] if isinstance(value, list) else value
+
+    ow_items = [item for item in d['atom_parameters'] if item['atom_type'] == 'OW']
+    hw_items = [item for item in d['atom_parameters'] if item['atom_type'] == 'HW']
+
+    assert len(ow_items) == 1
+    assert len(hw_items) == 2
+
+    assert ref_path(ow_items[0]['species_scope']) == o_ref
+    assert ow_items[0]['partial_charge'] == approx(-0.834)
+    assert ow_items[0]['effective_mass'] == approx(2.6567e-26)
+
+    assert {ref_path(item['species_scope']) for item in hw_items} == {h1_ref, h2_ref}
+    for item in hw_items:
+        assert item['partial_charge'] == approx(0.417)
+        assert item['effective_mass'] == approx(1.6735e-27)

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1094,7 +1094,7 @@ def test_force_field_atom_parameters():
     atom_parameter_settings = AtomParameterSettings()
     atom_parameter_settings.atom_parameters.append(
         AtomParameters(
-            atoms_state_ref=[entry.data.model_system[0].particle_states[0]],
+            species_scope=[entry.data.model_system[0].particle_states[0]],
             atom_type='OW',
             partial_charge=-0.834 * ureg.elementary_charge,
             effective_mass=2.6567e-26 * ureg.kg,
@@ -1102,15 +1102,10 @@ def test_force_field_atom_parameters():
     )
     atom_parameter_settings.atom_parameters.append(
         AtomParameters(
-            atoms_state_ref=[entry.data.model_system[0].particle_states[1]],
-            atom_type='HW',
-            partial_charge=0.417 * ureg.elementary_charge,
-            effective_mass=1.6735e-27 * ureg.kg,
-        )
-    )
-    atom_parameter_settings.atom_parameters.append(
-        AtomParameters(
-            atoms_state_ref=[entry.data.model_system[0].particle_states[2]],
+            species_scope=[
+                entry.data.model_system[0].particle_states[1],
+                entry.data.model_system[0].particle_states[2],
+            ],
             atom_type='HW',
             partial_charge=0.417 * ureg.elementary_charge,
             effective_mass=1.6735e-27 * ureg.kg,
@@ -1125,14 +1120,11 @@ def test_force_field_atom_parameters():
     assert len(d['numerical_settings']) == 1
     setting = d['numerical_settings'][0]
     assert setting['m_def'].endswith('.AtomParameterSettings')
-    assert len(setting['atom_parameters']) == 3
+    assert len(setting['atom_parameters']) == 2
 
     o_ref = '/data/model_system/0/particle_states/0'
     h1_ref = '/data/model_system/0/particle_states/1'
     h2_ref = '/data/model_system/0/particle_states/2'
-
-    def ref_path(value):
-        return value[0] if isinstance(value, list) else value
 
     ow_items = [
         item for item in setting['atom_parameters'] if item['atom_type'] == 'OW'
@@ -1142,13 +1134,12 @@ def test_force_field_atom_parameters():
     ]
 
     assert len(ow_items) == 1
-    assert len(hw_items) == 2
+    assert len(hw_items) == 1
 
-    assert ref_path(ow_items[0]['atoms_state_ref']) == o_ref
+    assert ow_items[0]['species_scope'] == [o_ref]
     assert ow_items[0]['partial_charge'] == approx(-0.834)
     assert ow_items[0]['effective_mass'] == approx(2.6567e-26)
 
-    assert {ref_path(item['atoms_state_ref']) for item in hw_items} == {h1_ref, h2_ref}
-    for item in hw_items:
-        assert item['partial_charge'] == approx(0.417)
-        assert item['effective_mass'] == approx(1.6735e-27)
+    assert hw_items[0]['species_scope'] == [h1_ref, h2_ref]
+    assert hw_items[0]['partial_charge'] == approx(0.417)
+    assert hw_items[0]['effective_mass'] == approx(1.6735e-27)

--- a/tests/test_force_field.py
+++ b/tests/test_force_field.py
@@ -1094,7 +1094,7 @@ def test_force_field_atom_parameters():
     atom_parameter_settings = AtomParameterSettings()
     atom_parameter_settings.atom_parameters.append(
         AtomParameters(
-            species_scope=[entry.data.model_system[0].particle_states[0]],
+            atoms_state_ref=[entry.data.model_system[0].particle_states[0]],
             atom_type='OW',
             partial_charge=-0.834 * ureg.elementary_charge,
             effective_mass=2.6567e-26 * ureg.kg,
@@ -1102,7 +1102,7 @@ def test_force_field_atom_parameters():
     )
     atom_parameter_settings.atom_parameters.append(
         AtomParameters(
-            species_scope=[entry.data.model_system[0].particle_states[1]],
+            atoms_state_ref=[entry.data.model_system[0].particle_states[1]],
             atom_type='HW',
             partial_charge=0.417 * ureg.elementary_charge,
             effective_mass=1.6735e-27 * ureg.kg,
@@ -1110,7 +1110,7 @@ def test_force_field_atom_parameters():
     )
     atom_parameter_settings.atom_parameters.append(
         AtomParameters(
-            species_scope=[entry.data.model_system[0].particle_states[2]],
+            atoms_state_ref=[entry.data.model_system[0].particle_states[2]],
             atom_type='HW',
             partial_charge=0.417 * ureg.elementary_charge,
             effective_mass=1.6735e-27 * ureg.kg,
@@ -1144,11 +1144,11 @@ def test_force_field_atom_parameters():
     assert len(ow_items) == 1
     assert len(hw_items) == 2
 
-    assert ref_path(ow_items[0]['species_scope']) == o_ref
+    assert ref_path(ow_items[0]['atoms_state_ref']) == o_ref
     assert ow_items[0]['partial_charge'] == approx(-0.834)
     assert ow_items[0]['effective_mass'] == approx(2.6567e-26)
 
-    assert {ref_path(item['species_scope']) for item in hw_items} == {h1_ref, h2_ref}
+    assert {ref_path(item['atoms_state_ref']) for item in hw_items} == {h1_ref, h2_ref}
     for item in hw_items:
         assert item['partial_charge'] == approx(0.417)
         assert item['effective_mass'] == approx(1.6735e-27)


### PR DESCRIPTION
## Purpose

Follow-up to #346, small cleanups for `AtomParameters`

## Scope

**Included**

- Refined section/quantity docstrings to avoid references to optional archive fields that may be absent in a given parsed entry.
- Changed `AtomParameters` base class from `NumericalSettings` to `ArchiveSection` for semantic correctness.
- Introduced `AtomParameterSettings(NumericalSettings)` as a container attached via the existing `ForceField.numerical_settings` pattern (same attachment style as `ForceCalculations`), so per-atom entries are grouped consistently with existing schema architecture (similar to the basis-set container pattern). This also keeps the parent `ModelMethod` structure less crowded and easier to navigate.

## Context & Links

- #346 

## Reviewer Notes

**Question 1)** No schema-level count validation is enforced yet between `len(atom_parameters)` and total particles; I can add this in a follow up, if desired.

**Question 2)** Current `ForceField` normalization looks like the following:
```
    def normalize(self, archive, logger) -> None:
        super().normalize(archive, logger)

        self.name = 'ForceField'
        logger.warning('in force field')
```
Looks like a leftover debug breadcrumb. Can fix this as well in conjunction with Q1, if desired.


## Status
- [x] Ready for review

## Breaking Changes
- [x] None

## Dependencies / Blockers
- [x]  None

## Testing / Validation
- [x] Unit tests in `test_force_field.py`



