### PR TITLE
add `SelfInteractionCorrection` and related tests

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -285,22 +285,22 @@ class SelfInteractionCorrection(BaseModelMethod):
 
     method = Quantity(
         type=MEnum(
-            'SIC_AD',
-            'SIC_SOSEX',
-            'SIC_EXPLICIT_ORBITALS',
-            'SIC_MAURI_SPZ',
-            'SIC_MAURI_US',
+            'AD',
+            'SOSEX',
+            'EXPLICIT_ORBITALS',
+            'MAURI_SPZ',
+            'MAURI_US',
         ),
         description="""
         Identifier of the self-interaction correction approximation.
 
         | SIC method                | Description |
         |---------------------------|-------------|
-        | `SIC_AD`                  | Average-density correction |
-        | `SIC_SOSEX`               | Second-order screened exchange |
-        | `SIC_EXPLICIT_ORBITALS`   | Perdew-Zunger-style correction on an explicit set of orbitals |
-        | `SIC_MAURI_SPZ`           | Mauri spin-polarized Perdew-Zunger expression |
-        | `SIC_MAURI_US`            | Mauri unpaired-spin correction |
+        | `AD`                      | Average-density correction |
+        | `SOSEX`                   | Second-order screened exchange |
+        | `EXPLICIT_ORBITALS`       | Perdew-Zunger-style correction on an explicit set of orbitals |
+        | `MAURI_SPZ`               | Mauri spin-polarized Perdew-Zunger expression |
+        | `MAURI_US`                | Mauri unpaired-spin correction |
         """,
     )
 
@@ -332,7 +332,7 @@ class SelfInteractionCorrection(BaseModelMethod):
         type=positive_int(),
         description="""
         Number of explicitly corrected orbitals.
-        Relevant for orbital-resolved SIC variants such as `SIC_EXPLICIT_ORBITALS`.
+        Relevant for orbital-resolved SIC variants such as `EXPLICIT_ORBITALS`.
         """,
     )
 
@@ -351,11 +351,11 @@ class SelfInteractionCorrection(BaseModelMethod):
             self.name = 'SIC'
 
         inferred_targets = {
-            'SIC_AD': 'average_density',
-            'SIC_SOSEX': 'screened_exchange',
-            'SIC_EXPLICIT_ORBITALS': 'selected_orbitals',
-            'SIC_MAURI_SPZ': 'spin_density',
-            'SIC_MAURI_US': 'doublet_unpaired_orbital',
+            'AD': 'average_density',
+            'SOSEX': 'screened_exchange',
+            'EXPLICIT_ORBITALS': 'selected_orbitals',
+            'MAURI_SPZ': 'spin_density',
+            'MAURI_US': 'doublet_unpaired_orbital',
         }
         if self.correction_target is None:
             self.correction_target = inferred_targets.get(self.method)
@@ -364,12 +364,12 @@ class SelfInteractionCorrection(BaseModelMethod):
             self.n_corrected_orbitals = len(self.corrected_orbitals_ref)
 
         if (
-            self.method == 'SIC_EXPLICIT_ORBITALS'
+            self.method == 'EXPLICIT_ORBITALS'
             and not self.corrected_orbitals_ref
             and self.n_corrected_orbitals is None
         ):
             logger.warning(
-                'SelfInteractionCorrection.method is SIC_EXPLICIT_ORBITALS but no corrected orbitals were provided.'
+                'SelfInteractionCorrection.method is EXPLICIT_ORBITALS but no corrected orbitals were provided.'
             )
 
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -17,7 +17,11 @@ if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
 
 from nomad_simulations.schema_packages.atoms_state import CoreHole, ElectronicState
-from nomad_simulations.schema_packages.data_types import positive_int, unit_float
+from nomad_simulations.schema_packages.data_types import (
+    positive_float,
+    positive_int,
+    unit_float,
+)
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
 from nomad_simulations.schema_packages.utils.libxc.build import (
@@ -268,6 +272,105 @@ class EmpiricalDispersionModel(BaseModelMethod):
         type=str,
         description="Base XC functional used/tuned for (e.g. 'PBE', 'SCAN', 'B3LYP').",
     )
+
+
+class SelfInteractionCorrection(BaseModelMethod):
+    """Self-interaction correction (SIC) add-on used together with DFT.
+
+    This section replaces the legacy flat
+    `DFT.self_interaction_correction_method` string with a structured record
+    that can also store approximation-specific parameters, such as scaling
+    factors and explicitly corrected orbitals.
+    """
+
+    method = Quantity(
+        type=MEnum(
+            'SIC_AD',
+            'SIC_SOSEX',
+            'SIC_EXPLICIT_ORBITALS',
+            'SIC_MAURI_SPZ',
+            'SIC_MAURI_US',
+        ),
+        description="""
+        Identifier of the self-interaction correction approximation.
+
+        | SIC method                | Description |
+        |---------------------------|-------------|
+        | `SIC_AD`                  | Average-density correction |
+        | `SIC_SOSEX`               | Second-order screened exchange |
+        | `SIC_EXPLICIT_ORBITALS`   | Perdew-Zunger-style correction on an explicit set of orbitals |
+        | `SIC_MAURI_SPZ`           | Mauri spin-polarized Perdew-Zunger expression |
+        | `SIC_MAURI_US`            | Mauri unpaired-spin correction |
+        """,
+    )
+
+    correction_target = Quantity(
+        type=MEnum(
+            'average_density',
+            'screened_exchange',
+            'selected_orbitals',
+            'spin_density',
+            'doublet_unpaired_orbital',
+        ),
+        description="""
+        Object to which the SIC approximation is applied.
+
+        This is often implied by `method`, but can be set explicitly by a
+        parser when the code reports it directly.
+        """,
+    )
+
+    scaling_factor = Quantity(
+        type=positive_float(),
+        description="""
+        Optional multiplicative prefactor for scaled SIC variants.
+        A value of `1.0` corresponds to the unscaled form.
+        """,
+    )
+
+    n_corrected_orbitals = Quantity(
+        type=np.int32,
+        description="""
+        Number of explicitly corrected orbitals.
+        Relevant for orbital-resolved SIC variants such as `SIC_EXPLICIT_ORBITALS`.
+        """,
+    )
+
+    corrected_orbitals_ref = SubSection(
+        sub_section=ElectronicState.m_def,
+        repeats=True,
+        description="""
+        References to orbitals explicitly included in the SIC correction.
+        """,
+    )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+        if self.name is None:
+            self.name = 'SIC'
+
+        inferred_targets = {
+            'SIC_AD': 'average_density',
+            'SIC_SOSEX': 'screened_exchange',
+            'SIC_EXPLICIT_ORBITALS': 'selected_orbitals',
+            'SIC_MAURI_SPZ': 'spin_density',
+            'SIC_MAURI_US': 'doublet_unpaired_orbital',
+        }
+        if self.correction_target is None:
+            self.correction_target = inferred_targets.get(self.method)
+
+        if self.n_corrected_orbitals is None and self.corrected_orbitals_ref:
+            self.n_corrected_orbitals = len(self.corrected_orbitals_ref)
+
+        if (
+            self.method == 'SIC_EXPLICIT_ORBITALS'
+            and not self.corrected_orbitals_ref
+            and self.n_corrected_orbitals is None
+        ):
+            logger.warning(
+                'SelfInteractionCorrection.method is SIC_EXPLICIT_ORBITALS but no corrected orbitals were provided.'
+            )
 
 
 class RelativityModel(BaseModelMethod):

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -329,7 +329,7 @@ class SelfInteractionCorrection(BaseModelMethod):
     )
 
     n_corrected_orbitals = Quantity(
-        type=np.int32,
+        type=positive_int(),
         description="""
         Number of explicitly corrected orbitals.
         Relevant for orbital-resolved SIC variants such as `SIC_EXPLICIT_ORBITALS`.

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -15,6 +15,7 @@ from nomad_simulations.schema_packages.model_method import (
     MultireferencePT,
     MultireferenceSCF,
     RelativityModel,
+    SelfInteractionCorrection,
     SlaterKoster,
     SlaterKosterBond,
     Wannier,
@@ -641,17 +642,28 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
         dkh_order=None,
     )
 
+    sic = SelfInteractionCorrection(
+        method='SIC_EXPLICIT_ORBITALS',
+        scaling_factor=0.5,
+        corrected_orbitals_ref=[
+            ElectronicState(name='orbital_1'),
+            ElectronicState(name='orbital_2'),
+        ],
+    )
+
     dft.m_add_sub_section(type(dft).contributions, ism)
     dft.m_add_sub_section(type(dft).contributions, edm)
     dft.m_add_sub_section(type(dft).contributions, rel)
+    dft.m_add_sub_section(type(dft).contributions, sic)
 
     for c in dft.contributions:
         c.normalize(EntryArchive(), logger=logger)
 
-    assert len(dft.contributions) == 3
+    assert len(dft.contributions) == 4
     assert isinstance(dft.contributions[0], ImplicitSolvationModel)
     assert isinstance(dft.contributions[1], EmpiricalDispersionModel)
     assert isinstance(dft.contributions[2], RelativityModel)
+    assert isinstance(dft.contributions[3], SelfInteractionCorrection)
 
     # Solvation
     assert (
@@ -669,6 +681,46 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
     assert dft.contributions[2].level == 'two-component'
     assert dft.contributions[2].approximation == 'X2C'
     assert dft.contributions[2].dkh_order is None
+
+    # Self-interaction correction
+    assert dft.contributions[3].name == 'SIC'
+    assert dft.contributions[3].method == 'SIC_EXPLICIT_ORBITALS'
+    assert dft.contributions[3].correction_target == 'selected_orbitals'
+    assert dft.contributions[3].scaling_factor == pytest.approx(0.5)
+    assert dft.contributions[3].n_corrected_orbitals == 2
+
+
+@pytest.mark.parametrize(
+    'method, expected_target',
+    [
+        ('SIC_AD', 'average_density'),
+        ('SIC_SOSEX', 'screened_exchange'),
+        ('SIC_EXPLICIT_ORBITALS', 'selected_orbitals'),
+        ('SIC_MAURI_SPZ', 'spin_density'),
+        ('SIC_MAURI_US', 'doublet_unpaired_orbital'),
+    ],
+)
+def test_self_interaction_correction_infers_target_from_method(method, expected_target):
+    sic = SelfInteractionCorrection(method=method)
+    sic.normalize(EntryArchive(), logger=logger)
+
+    assert sic.name == 'SIC'
+    assert sic.correction_target == expected_target
+
+
+def test_self_interaction_correction_counts_corrected_orbitals():
+    sic = SelfInteractionCorrection(
+        method='SIC_EXPLICIT_ORBITALS',
+        corrected_orbitals_ref=[
+            ElectronicState(name='orbital_1'),
+            ElectronicState(name='orbital_2'),
+            ElectronicState(name='orbital_3'),
+        ],
+    )
+
+    sic.normalize(EntryArchive(), logger=logger)
+
+    assert sic.n_corrected_orbitals == 3
 
 
 def test_solvation_derives_optical_eps_if_only_n_given():

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -643,7 +643,7 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
     )
 
     sic = SelfInteractionCorrection(
-        method='SIC_EXPLICIT_ORBITALS',
+        method='EXPLICIT_ORBITALS',
         scaling_factor=0.5,
         corrected_orbitals_ref=[
             ElectronicState(name='orbital_1'),
@@ -684,7 +684,7 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
 
     # Self-interaction correction
     assert dft.contributions[3].name == 'SIC'
-    assert dft.contributions[3].method == 'SIC_EXPLICIT_ORBITALS'
+    assert dft.contributions[3].method == 'EXPLICIT_ORBITALS'
     assert dft.contributions[3].correction_target == 'selected_orbitals'
     assert dft.contributions[3].scaling_factor == pytest.approx(0.5)
     assert dft.contributions[3].n_corrected_orbitals == 2
@@ -693,11 +693,11 @@ def test_dft_contributions_solvation_dispersion_relativity_normalize():
 @pytest.mark.parametrize(
     'method, expected_target',
     [
-        ('SIC_AD', 'average_density'),
-        ('SIC_SOSEX', 'screened_exchange'),
-        ('SIC_EXPLICIT_ORBITALS', 'selected_orbitals'),
-        ('SIC_MAURI_SPZ', 'spin_density'),
-        ('SIC_MAURI_US', 'doublet_unpaired_orbital'),
+        ('AD', 'average_density'),
+        ('SOSEX', 'screened_exchange'),
+        ('EXPLICIT_ORBITALS', 'selected_orbitals'),
+        ('MAURI_SPZ', 'spin_density'),
+        ('MAURI_US', 'doublet_unpaired_orbital'),
     ],
 )
 def test_self_interaction_correction_infers_target_from_method(method, expected_target):
@@ -710,7 +710,7 @@ def test_self_interaction_correction_infers_target_from_method(method, expected_
 
 def test_self_interaction_correction_counts_corrected_orbitals():
     sic = SelfInteractionCorrection(
-        method='SIC_EXPLICIT_ORBITALS',
+        method='EXPLICIT_ORBITALS',
         corrected_orbitals_ref=[
             ElectronicState(name='orbital_1'),
             ElectronicState(name='orbital_2'),


### PR DESCRIPTION
## Purpose

This PR addresses issue #268 by replacing the old flat DFT field for self-interaction correction with a modular schema section. This matters because the previous string-only representation could identify the SIC method, but could not capture method-specific parameters such as scaling factors or explicitly corrected orbitals.


## Scope

**Included**

- Add a dedicated `SelfInteractionCorrection` model-method contribution section
- Preserve the existing SIC method taxonomy as structured enum values
- Add fields for `correction_target`, `scaling_factor`, `n_corrected_orbitals`, and `corrected_orbitals_ref`
- Add normalization logic to infer correction targets from the SIC method and count corrected orbitals
- Add unit-test coverage for SIC normalization and DFT contribution integration

## Context & Links

- Closes #268: add self interaction method class
- Issue context: the old DFT schema only exposed `self_interaction_correction_method` as a string, which was insufficient for storing important approximation-specific parameters

## Reviewer Notes

The main design choice here is to model SIC as a first-class `BaseModelMethod` contribution, matching the existing modular pattern already used for other DFT add-ons. I kept the method enum aligned with the legacy values so parser migration should be straightforward. Please let me know if you are happy with the enum semantics

**FYI:** This PR keeps the SIC change focused on the schema addition needed for #268. I will later create a clean PR for #290 as well, mainly to distinguish semantically between method add-ons and numerical settings.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None


## Testing / Validation

- [x] Unit tests



