### PR TITLE
Distinguish between `ModelMethod` and `NumericalSettings`

### DIFF
--- a/docs/explanation/model_method/model_method_vs_numerical_settings.md
+++ b/docs/explanation/model_method/model_method_vs_numerical_settings.md
@@ -1,0 +1,116 @@
+# ModelMethod vs NumericalSettings
+
+## Purpose
+
+This page explains how to decide whether information belongs in
+`ModelMethod` or `NumericalSettings`.
+
+For generated structure and quantity tables, use:
+
+- [Model Method (Schema Navigation)](../../schema/model_method.md)
+- [Numerical Settings (Schema Navigation)](../../schema/numerical_settings.md)
+
+## Core Distinction
+
+- `ModelMethod` answers: what mathematical model or physical approximation is
+  being solved?
+- `NumericalSettings` answers: how is that chosen model realized,
+  discretized, converged, or evaluated in practice?
+
+In schema terms, the split is primarily semantic, but it also has technical
+value. `NumericalSettings` are attached to a specific method instance through
+`BaseModelMethod.numerical_settings`, so they remain method-scoped without
+being mixed into the method taxonomy itself.
+
+## Decision Heuristics
+
+Put information in `ModelMethod` when changing it would change at least one of
+the following:
+
+- the target Hamiltonian or operator content,
+- the governing equations or ansatz,
+- the physical approximation being made,
+- the method family or subtype used to interpret the result.
+
+Put information in `NumericalSettings` when changing it mainly affects:
+
+- discretization or sampling,
+- convergence behavior,
+- basis or auxiliary representation choices,
+- solver execution details,
+- code-specific evaluation knobs for a fixed method.
+
+A practical test is:
+
+1. If two calculations would still be described as "the same method, but with
+   different convergence/setup choices", use `NumericalSettings`.
+2. If changing the value means you would cite a different approximation,
+   Hamiltonian term, or method flavor in the methods section of a paper, use
+   `ModelMethod`.
+
+## Common Cases
+
+Use `ModelMethod` for:
+
+- `DFT`, `TB`, `GW`, `BSE`, `DMFT`, `HartreeFock`,
+- XC functional identity,
+- relativistic treatment as a physical approximation,
+- active-space or multireference method definition,
+- implicit-solvent or dispersion model family selection.
+
+Use `NumericalSettings` for:
+
+- k-point meshes and k-line paths,
+- SCF thresholds and iteration limits,
+- smearing controls,
+- basis-set containers and basis tiers,
+- pseudopotential metadata used to realize the calculation,
+- surface tessellation, PB/GB grids, and other solver-side solvation knobs,
+- dispersion switches or typed numerical knobs.
+
+## Edge Cases
+
+Some concepts naturally split across both sections.
+
+`ImplicitSolvationModel` versus `SolvationSettings`:
+The model family itself belongs in `ModelMethod`; tessellation, dielectric-grid,
+or solver controls belong in `NumericalSettings`.
+
+`EmpiricalDispersionModel` versus `EmpiricalDispersionSettings`:
+The correction family belongs in `ModelMethod`; term switches, partitioning
+choices, and scalar tuning knobs belong in `NumericalSettings`.
+
+Basis sets and pseudopotentials:
+These strongly affect numerical quality and sometimes practical transferability,
+but in this schema they are treated as the numerical realization attached to a
+chosen method, not as the method identity itself.
+
+## Why Keep the Split
+
+Keeping the split as separate sections is still useful because it:
+
+- preserves a stable method identity across convergence studies and code-level
+  setup changes,
+- keeps method taxonomy distinct from code-specific numerical controls,
+- makes parser output easier to normalize and compare across codes,
+- avoids overloading one section with both physical meaning and execution
+  details.
+
+The intended rule is therefore not "everything important goes into
+`ModelMethod`". The rule is "keep model semantics in `ModelMethod`, and keep
+their numerical realization in `NumericalSettings`".
+
+## Pitfalls
+
+- Do not duplicate the same concept in both sections just because a code places
+  the keywords close together in its input file.
+- Do not put every parser keyword into `ModelMethod`; many are only numerical
+  controls.
+- When a concept has both a model identity and a realization layer, model them
+  separately rather than forcing one mixed section.
+
+## Related Pages
+
+- [Model Method Overview](overview.md)
+- [Basis Sets](basis_sets.md)
+- [Simulation Entry](../simulation_entry.md)

--- a/docs/explanation/model_method/overview.md
+++ b/docs/explanation/model_method/overview.md
@@ -11,6 +11,7 @@ For full section and quantity definitions, use:
 - [Model Method Electronic (Schema Navigation)](../../schema/model_method_electronic.md)
 - [Numerical Settings (Schema Navigation)](../../schema/numerical_settings.md)
 - [Force Field (Schema Navigation)](../../schema/force_field.md)
+- [ModelMethod vs NumericalSettings](model_method_vs_numerical_settings.md)
 
 ## Rules and Invariants
 
@@ -19,6 +20,9 @@ For full section and quantity definitions, use:
 - Keep numerical control parameters under `numerical_settings`.
 - Use `contributions` for additive model terms instead of flattening all terms
   into one section.
+- When a concept has both a physical-model aspect and an implementation aspect,
+  split them: keep the model identity in `ModelMethod` and the realization knobs
+  in `NumericalSettings`.
 
 ## Hierarchy Snapshot
 
@@ -44,6 +48,7 @@ For full section and quantity definitions, use:
 
 ## Related Pages
 
+- [ModelMethod vs NumericalSettings](model_method_vs_numerical_settings.md)
 - [Basis Sets](basis_sets.md)
 - [Model System Usage Guidelines](../model_system/usage_guidelines.md)
 - [Normalization](../normalize.md)

--- a/docs/explanation/simulation_entry.md
+++ b/docs/explanation/simulation_entry.md
@@ -43,7 +43,7 @@ The `Simulation` base section is composed of 4 main sub-sections:
 
 1. `Program`: contains all the program information, e.g., `name` of the program, `version`, etc.
 2. `ModelSystem`: contains all the system information about geometrical positions of atoms, their states, simulation cells, symmetry information, etc.
-3. `ModelMethod`: contains all the methodological information, and it is divided in two main aspects: the mathematical model or approximation used in the simulation (e.g., `DFT`, `GW`, `ForceFields`, etc.) and the numerical settings used to compute the properties (e.g., meshes, self-consistent parameters, basis sets settings, etc.).
+3. `ModelMethod`: contains the methodological information for the simulation. In practice this combines the model identity itself (e.g., `DFT`, `GW`, `ForceFields`) with attached numerical realizations stored under `numerical_settings` (e.g., meshes, self-consistency parameters, basis-set settings). See [ModelMethod vs NumericalSettings](model_method/model_method_vs_numerical_settings.md) for the distinction.
 4. `Outputs`: contains all the output properties, as well as references to the `ModelSystem` used to obtain such properties. It might also contain information which will populate `ModelSystem` (e.g., atomic occupations, atomic moments, crystal field energies, etc.).
 
 !!! note "Self-consistent steps, SinglePoint entries, and more complex workflows."

--- a/docs/schema/force_field.md
+++ b/docs/schema/force_field.md
@@ -35,7 +35,7 @@ classDiagram
 
 | Section | Description | MetaInfo |
 |---|---|---|
-| `ModelMethod` | A base section containing the parameters that define the mathematical model itself. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
+| `ModelMethod` | A base section for the method-defining choices of a simulation. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
 | `ForceField` | Section containing the parameters of a (classical, particle-based) force field model. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.force_field.ForceField){:target="_blank"} |
 | `Potential` | Section containing information about an interaction potential. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.force_field.Potential){:target="_blank"} |
 

--- a/docs/schema/force_field.md
+++ b/docs/schema/force_field.md
@@ -35,7 +35,7 @@ classDiagram
 
 | Section | Description | MetaInfo |
 |---|---|---|
-| `ModelMethod` | A base section containing the mathematical model parameters. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
+| `ModelMethod` | A base section containing the parameters that define the mathematical model itself. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
 | `ForceField` | Section containing the parameters of a (classical, particle-based) force field model. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.force_field.ForceField){:target="_blank"} |
 | `Potential` | Section containing information about an interaction potential. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.force_field.Potential){:target="_blank"} |
 

--- a/docs/schema/model_method.md
+++ b/docs/schema/model_method.md
@@ -30,7 +30,7 @@ classDiagram
 | Section | Description | MetaInfo |
 |---|---|---|
 | `BaseModelMethod` | A base section used to define the abstract class of a Hamiltonian section. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.BaseModelMethod){:target="_blank"} |
-| `ModelMethod` | A base section containing the mathematical model parameters. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
+| `ModelMethod` | A base section containing the parameters that define the mathematical model itself. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
 | `ModelMethodElectronic` | A base section used to define the parameters of a model Hamiltonian used in electronic structure calculations (TB, DFT, GW, BSE, DMFT, etc). | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethodElectronic){:target="_blank"} |
 
 
@@ -59,3 +59,4 @@ classDiagram
 ## Related Pages
 
 - [Model Method Overview](../explanation/model_method/overview.md)
+- [ModelMethod vs NumericalSettings](../explanation/model_method/model_method_vs_numerical_settings.md)

--- a/docs/schema/model_method.md
+++ b/docs/schema/model_method.md
@@ -30,7 +30,7 @@ classDiagram
 | Section | Description | MetaInfo |
 |---|---|---|
 | `BaseModelMethod` | A base section used to define the abstract class of a Hamiltonian section. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.BaseModelMethod){:target="_blank"} |
-| `ModelMethod` | A base section containing the parameters that define the mathematical model itself. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
+| `ModelMethod` | A base section for the method-defining choices of a simulation. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethod){:target="_blank"} |
 | `ModelMethodElectronic` | A base section used to define the parameters of a model Hamiltonian used in electronic structure calculations (TB, DFT, GW, BSE, DMFT, etc). | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.model_method.ModelMethodElectronic){:target="_blank"} |
 
 

--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -51,7 +51,7 @@ classDiagram
 
 | Section | Description | MetaInfo |
 |---|---|---|
-| `NumericalSettings` | A base section used to define the numerical settings used in a simulation. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.numerical_settings.NumericalSettings){:target="_blank"} |
+| `NumericalSettings` | A base section used to define how a chosen `ModelMethod` is realized numerically in a simulation. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.numerical_settings.NumericalSettings){:target="_blank"} |
 | `Mesh` | A base section used to specify the settings of a sampling mesh. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.numerical_settings.Mesh){:target="_blank"} |
 | `KMesh` | A base section used to specify the settings of a sampling mesh in reciprocal space. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.numerical_settings.KMesh){:target="_blank"} |
 | `KLinePath` | A base section used to define the settings of a k-line path within a multidimensional mesh. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.numerical_settings.KLinePath){:target="_blank"} |
@@ -71,7 +71,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `name` | m_str(str) | Name of the numerical settings section. This is typically used to easy identification of the `NumericalSettings` section. Possible values: "KMesh", "FrequencyMesh", "TimeMesh", "SelfConsistency", "BasisSet". |
+| `name` | m_str(str) | Name of the numerical settings section. This is typically used for easy identification of the `NumericalSettings` section within a `ModelMethod`. Possible values: "KMesh", "FrequencyMesh", "TimeMesh", "SelfConsistency", "BasisSet". |
 
 ### `Mesh`
 
@@ -177,3 +177,4 @@ classDiagram
 ## Related Pages
 
 - [Model Method Overview](../explanation/model_method/overview.md)
+- [ModelMethod vs NumericalSettings](../explanation/model_method/model_method_vs_numerical_settings.md)

--- a/docs/schema/outputs.diagram.md
+++ b/docs/schema/outputs.diagram.md
@@ -14,21 +14,21 @@ This diagram shows the relationships between schema classes:
 
 ```mermaid
 classDiagram
+    class AbsorptionSpectrum {
+    }
     class ChemicalPotential {
     }
-    class ElectronicBandGap {
+    class ElectronicDensityOfStates {
+    }
+    class ElectronicEigenvalues {
     }
     class ElectronicGreensFunction {
-    }
-    class ElectronicSelfEnergy {
-    }
-    class FermiSurface {
-    }
-    class HoppingMatrix {
     }
     class HybridizationFunction {
     }
     class KineticEnergy {
+    }
+    class Occupancy {
     }
     class Outputs {
     }
@@ -36,26 +36,26 @@ classDiagram
     }
     class PotentialEnergy {
     }
-    class QuasiparticleWeight {
+    class RadiusOfGyration {
     }
     class SCFOutputs {
     }
-    class TotalEnergy {
+    class Temperature {
     }
     class TotalForce {
     }
     Outputs <|-- SCFOutputs
+    Outputs --> AbsorptionSpectrum : absorption_spectra
     Outputs --> ChemicalPotential
-    Outputs --> ElectronicBandGap
+    Outputs --> ElectronicDensityOfStates : electronic_dos
+    Outputs --> ElectronicEigenvalues
     Outputs --> ElectronicGreensFunction
-    Outputs --> ElectronicSelfEnergy : electronic_self_energies
-    Outputs --> FermiSurface
-    Outputs --> HoppingMatrix : hopping_matrices
     Outputs --> HybridizationFunction
     Outputs --> KineticEnergy : kinetic_energies
+    Outputs --> Occupancy : occupancies
     Outputs --> PotentialEnergy : potential_energies
-    Outputs --> QuasiparticleWeight
-    Outputs --> TotalEnergy : total_energies
+    Outputs --> RadiusOfGyration : radii_of_gyration
+    Outputs --> Temperature
     Outputs --> TotalForce
     SCFOutputs --> Outputs : scf_steps
 ```
@@ -67,17 +67,17 @@ _Diagram 2 of 2 (split due to large number of children)_
 
 ```mermaid
 classDiagram
-    class AbsorptionSpectrum {
-    }
     class CrystalFieldSplitting {
+    }
+    class ElectronicBandGap {
     }
     class ElectronicBandStructure {
     }
-    class ElectronicDensityOfStates {
+    class ElectronicSelfEnergy {
     }
-    class ElectronicEigenvalues {
+    class FermiSurface {
     }
-    class Occupancy {
+    class HoppingMatrix {
     }
     class Outputs {
     }
@@ -85,24 +85,24 @@ classDiagram
     }
     class PhysicalProperty {
     }
-    class RadiusOfGyration {
+    class QuasiparticleWeight {
     }
     class SCFOutputs {
     }
-    class Temperature {
+    class TotalEnergy {
     }
     class XASSpectrum {
     }
     Outputs <|-- SCFOutputs
-    Outputs --> AbsorptionSpectrum : absorption_spectra
     Outputs --> CrystalFieldSplitting
+    Outputs --> ElectronicBandGap
     Outputs --> ElectronicBandStructure
-    Outputs --> ElectronicDensityOfStates : electronic_dos
-    Outputs --> ElectronicEigenvalues
-    Outputs --> Occupancy : occupancies
+    Outputs --> ElectronicSelfEnergy : electronic_self_energies
+    Outputs --> FermiSurface
+    Outputs --> HoppingMatrix : hopping_matrices
     Outputs --> Permittivity : permittivities
-    Outputs --> RadiusOfGyration : radii_of_gyration
-    Outputs --> Temperature
+    Outputs --> QuasiparticleWeight
+    Outputs --> TotalEnergy : total_energies
     Outputs --> XASSpectrum : xas_spectra
     SCFOutputs --> Outputs : scf_steps
 ```

--- a/docs/snippets/generated/model_method_hierarchy.md
+++ b/docs/snippets/generated/model_method_hierarchy.md
@@ -4,7 +4,7 @@
 | Class | Description |
 |---|---|
 | `BaseModelMethod` | A base section used to define the abstract class of a Hamiltonian section. |
-| `ModelMethod` | A base section containing the mathematical model parameters. |
+| `ModelMethod` | A base section for the method-defining choices of a simulation. |
 | `ModelMethodElectronic` | A base section used to define the parameters of a model Hamiltonian used in electronic structure calculations (TB, DFT, GW, BSE, DMFT, etc). |
 
 Source reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
           - Usage Guidelines: explanation/model_system/usage_guidelines.md
       - Model Method:
           - Overview: explanation/model_method/overview.md
+          - ModelMethod vs NumericalSettings: explanation/model_method/model_method_vs_numerical_settings.md
           - Basis Sets: explanation/model_method/basis_sets.md
       # - Outputs:
       #     - Outputs: explanation/outputs/outputs.md

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -82,10 +82,10 @@ class BaseModelMethod(ArchiveSection):
 
 class ModelMethod(BaseModelMethod):
     """
-    A base section containing the parameters that define the mathematical model itself. Store here
-    choices that change the target Hamiltonian, equations, ansatz, or physical approximation used
-    by the simulation. Numerical controls for discretization, convergence, basis representations,
-    solver execution, or related implementation details belong in `numerical_settings`.
+    A base section for the method-defining choices of a simulation. Store here choices that change
+    the target Hamiltonian, governing equations, ansatz, or physical approximation used by the
+    simulation. Numerical controls for discretization, convergence, basis representations, solver
+    execution, or related implementation details belong in `numerical_settings`.
 
     Optionally, this section can be decomposed in a series of contributions by storing them under
     the `contributions` quantity.

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -32,8 +32,9 @@ from nomad_simulations.schema_packages.utils.libxc.expand import (
 class BaseModelMethod(ArchiveSection):
     """
     A base section used to define the abstract class of a Hamiltonian section. This section is an
-    abstraction of the `ModelMethod` section, which contains the settings and parameters used in
-    the mathematical model solved in a simulation. This abstraction is needed in order to allow
+    abstraction of the `ModelMethod` section, which contains the parameters that define the
+    mathematical model solved in a simulation. Numerical choices for how that model is evaluated
+    are stored separately under `numerical_settings`. This abstraction is needed in order to allow
     `ModelMethod` to be divided into specific `terms`, so that the total Hamiltonian is specified in
     `ModelMethod`, while its contributions are defined in `ModelMethod.terms`.
 
@@ -81,9 +82,13 @@ class BaseModelMethod(ArchiveSection):
 
 class ModelMethod(BaseModelMethod):
     """
-    A base section containing the mathematical model parameters. These are both the parameters of
-    the model and the settings used in the simulation. Optionally, this section can be decomposed
-    in a series of contributions by storing them under the `contributions` quantity.
+    A base section containing the parameters that define the mathematical model itself. Store here
+    choices that change the target Hamiltonian, equations, ansatz, or physical approximation used
+    by the simulation. Numerical controls for discretization, convergence, basis representations,
+    solver execution, or related implementation details belong in `numerical_settings`.
+
+    Optionally, this section can be decomposed in a series of contributions by storing them under
+    the `contributions` quantity.
     """
 
     contributions = SubSection(

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -21,16 +21,20 @@ from nomad_simulations.schema_packages.utils import log
 
 class NumericalSettings(ArchiveSection):
     """
-    A base section used to define the numerical settings used in a simulation. These are meshes,
-    self-consistency parameters, and basis sets.
+    A base section used to define how a chosen `ModelMethod` is realized numerically in a
+    simulation. These settings capture discretization, convergence, basis or auxiliary
+    representations, solver controls, and related evaluation choices.
+
+    As a rule of thumb, changing only `NumericalSettings` should not change the intended model
+    semantics, even though it can change numerical accuracy, stability, or computational cost.
     """
 
     name = Quantity(
         type=str,
         description="""
-        Name of the numerical settings section. This is typically used to easy identification of the
-        `NumericalSettings` section. Possible values: "KMesh", "FrequencyMesh", "TimeMesh",
-        "SelfConsistency", "BasisSet".
+        Name of the numerical settings section. This is typically used for easy identification of
+        the `NumericalSettings` section within a `ModelMethod`. Possible values: "KMesh",
+        "FrequencyMesh", "TimeMesh", "SelfConsistency", "BasisSet".
         """,
     )
 


### PR DESCRIPTION
## Purpose

Clarify the distinction between `ModelMethod` and `NumericalSettings` in the docs and schema descriptions.

This PR addresses issue #290 by making the separation between method semantics and numerical realization explicit. The distinction matters because the current wording is ambiguous enough to cause inconsistent interpretation when extending the schema.

## Scope

**Included**

- Tightened the `ModelMethod` and `NumericalSettings` section descriptions in the schema source.
- Added documentation explaining how to decide whether information belongs in `ModelMethod` or `NumericalSettings`.
- Added practical heuristics, common cases, and edge-case guidance.
- Regenerated affected generated documentation pages and snippets.

**Out of scope**

- Any schema restructuring or metainfo model changes.
- Moving existing quantities or sections between `ModelMethod` and `NumericalSettings`.

## Context & Links

- #290 

## Reviewer Notes

The main design choice in this PR is to keep the distinction semantic but operationally useful:

- `ModelMethod` is for method or ansatz-defining choices.
- `NumericalSettings` is for the numerical realization of that chosen method.
The generated docs changed because the source docstrings and generated explanation fragments were updated. No unrelated schema behavior is intended to change.


## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None


## Testing / Validation

- [x] None (explain):



