### PR TITLE
initial plugin metadata extraction

### DIFF
--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -1,0 +1,142 @@
+id: nomad-simulations
+metadata_schema_version: 1.0.0
+name: nomad-simulations
+description: A NOMAD plugin for FAIR schemas for simulation data.
+license: LICENSE
+upstream_repository: https://github.com/fairmat-nfdi/nomad-simulations
+documentation: https://fairmat-nfdi.github.io/nomad-simulations/
+homepage: https://github.com/fairmat-nfdi/nomad-simulations
+issue_tracker: https://github.com/fairmat-nfdi/nomad-simulations/issues
+maintainers:
+- name: Jose M. Pizarro
+  email: jose.pizarro@physik.hu-berlin.de
+- name: Joseph F. Rudzinski
+  email: joseph.rudzinski@physik.hu-berlin.de
+authors:
+- name: "Jos\xE9 M. Pizarro"
+- name: Esma B. Boydas
+- name: Nathan Daelman
+- name: Alvin Noe Ladines
+- name: Bernadette Mohr
+- name: Joseph F. Rudzinski
+entry_points:
+- id: nomad.plugin:nomad_simulations_plugin
+  entry_point_group: nomad.plugin
+  entry_point_name: nomad_simulations_plugin
+  python_object: nomad_simulations.schema_packages:nomad_simulations_plugin
+  capability_type: schema
+capabilities:
+- id: nomad_simulations_plugin
+  capability_type: schema
+  title: NOMADSimulations
+  summary: A NOMAD plugin for FAIR schemas for simulation data.
+schema_dependencies:
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '[infrastructure]>=1.3.15'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: matid
+  version_range: '>=2.0.0.dev2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: MDAnalysis
+  version_range: '>=2.4.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: networkx
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mypy
+  version_range: '>=1.15'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest
+  version_range: '>= 5.3.0, <8'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-timeout
+  version_range: '>=1.4.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-cov
+  version_range: '>=2.7.1'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-asyncio
+  version_range: '>=0.21.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: '>=0.6'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: structlog
+  version_range: '>=1.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: typing-extensions
+  version_range: '>=4.12'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs
+  version_range: '>=1.6'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material
+  version_range: '>=9.5'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pymdown-extensions
+  version_range: '>=10.5'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-click
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-awesome-pages-plugin
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-panzoom-plugin
+  version_range: '>=0.5.2'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:30:44.631505+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:30:44.631546+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:30:44.631563+00:00'
+  generator_version: 0.1.0
+stars: 7
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2024-01-17T11:45:02Z'
+last_updated: '2026-03-19T13:40:53Z'
+archived: false

--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -124,15 +124,15 @@ schema_dependencies:
 metadata_provenance:
 - source: pyproject
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:30:44.631505+00:00'
+  generated_at: '2026-03-19T14:52:11.912295+00:00'
   generator_version: 0.1.0
 - source: plugin_entry_points
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:30:44.631546+00:00'
+  generated_at: '2026-03-19T14:52:11.912347+00:00'
   generator_version: 0.1.0
 - source: citation_cff
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:30:44.631563+00:00'
+  generated_at: '2026-03-19T14:52:11.912369+00:00'
   generator_version: 0.1.0
 stars: 7
 owner: FAIRmat-NFDI

--- a/.metadata/nomad_plugin_metadata.manual.yaml
+++ b/.metadata/nomad_plugin_metadata.manual.yaml
@@ -1,0 +1,68 @@
+# Maintainer-owned metadata overrides and manual additions.
+# This file is never machine-overwritten after creation.
+# Use null/empty values as placeholders; only non-empty values override auto output.
+# list[str] domain/topic tags (e.g. "simulations", "spectroscopy")
+
+# enum {alpha, beta, stable, archived}
+maturity: beta
+# str, e.g. "main"
+repository_default_branch: develop
+
+# Deployment flags.
+deployment:
+  # boolean
+  on_central: true
+  # boolean
+  on_example_oasis: true
+  # boolean
+  on_pypi: true
+  # str (PyPI package name)
+  pypi_package: nomad-simulations
+
+# Suggested usages for registry filtering/discovery.
+suggested_usages:
+  - id: simulation-schema-foundation
+    title: Use FAIR simulation schemas in NOMAD plugins
+    user_intent: Reuse common simulation metainfo sections in plugin schema packages
+    domain_category: simulations
+    technique: simulation-schema
+    audience: plugin-developers
+    maturity: stable
+    tags:
+      - schema
+      - metainfo
+      - reuse
+
+  - id: harmonize-simulation-data-models
+    title: Harmonize simulation data models across parsers
+    user_intent: Standardize simulation outputs to shared semantic sections
+    domain_category: cross-domain
+    technique: ontology-and-schema-harmonization
+    audience: advanced
+    maturity: stable
+    tags:
+      - harmonization
+      - interoperability
+      - simulation
+
+# Optional file format metadata enrichments.
+file_format_support:
+  -
+    # str (stable ID), e.g. "csv"
+    id: null
+    # str display label, e.g. ".csv"
+    label: null
+    # str capability reference (links to capabilities[].id), e.g. "vasp_parser"
+    capability_id: null
+    # str producer/code family for ambiguous extensions, e.g. "vasp", "quantumespresso"
+    producer: null
+    # list[str] extensions including dot, e.g. [".csv", ".txt"]
+    extensions: []
+    # list[str], e.g. ["text/csv"]
+    mime_types: []
+    # str, e.g. "CIF", "NeXus"
+    standard: null
+    # str, instrument or context label
+    instrument_context: null
+    # str free text notes
+    notes: null

--- a/.metadata/plugin-metadata.override-report.yaml
+++ b/.metadata/plugin-metadata.override-report.yaml
@@ -1,0 +1,4 @@
+summary:
+  overridden_field_count: 0
+  manual_precedence: true
+overridden_fields: []

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -1,0 +1,142 @@
+id: nomad-simulations
+metadata_schema_version: 1.0.0
+name: nomad-simulations
+description: A NOMAD plugin for FAIR schemas for simulation data.
+license: LICENSE
+upstream_repository: https://github.com/fairmat-nfdi/nomad-simulations
+documentation: https://fairmat-nfdi.github.io/nomad-simulations/
+homepage: https://github.com/fairmat-nfdi/nomad-simulations
+issue_tracker: https://github.com/fairmat-nfdi/nomad-simulations/issues
+maintainers:
+- name: Jose M. Pizarro
+  email: jose.pizarro@physik.hu-berlin.de
+- name: Joseph F. Rudzinski
+  email: joseph.rudzinski@physik.hu-berlin.de
+authors:
+- name: "Jos\xE9 M. Pizarro"
+- name: Esma B. Boydas
+- name: Nathan Daelman
+- name: Alvin Noe Ladines
+- name: Bernadette Mohr
+- name: Joseph F. Rudzinski
+entry_points:
+- id: nomad.plugin:nomad_simulations_plugin
+  entry_point_group: nomad.plugin
+  entry_point_name: nomad_simulations_plugin
+  python_object: nomad_simulations.schema_packages:nomad_simulations_plugin
+  capability_type: schema
+capabilities:
+- id: nomad_simulations_plugin
+  capability_type: schema
+  title: NOMADSimulations
+  summary: A NOMAD plugin for FAIR schemas for simulation data.
+schema_dependencies:
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '[infrastructure]>=1.3.15'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: matid
+  version_range: '>=2.0.0.dev2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: MDAnalysis
+  version_range: '>=2.4.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: networkx
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mypy
+  version_range: '>=1.15'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest
+  version_range: '>= 5.3.0, <8'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-timeout
+  version_range: '>=1.4.2'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-cov
+  version_range: '>=2.7.1'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest-asyncio
+  version_range: '>=0.21.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: '>=0.6'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: structlog
+  version_range: '>=1.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: typing-extensions
+  version_range: '>=4.12'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs
+  version_range: '>=1.6'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material
+  version_range: '>=9.5'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pymdown-extensions
+  version_range: '>=10.5'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-click
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-awesome-pages-plugin
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-panzoom-plugin
+  version_range: '>=0.5.2'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:30:44.631505+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:30:44.631546+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:30:44.631563+00:00'
+  generator_version: 0.1.0
+stars: 7
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2024-01-17T11:45:02Z'
+last_updated: '2026-03-19T13:40:53Z'
+archived: false

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -124,15 +124,15 @@ schema_dependencies:
 metadata_provenance:
 - source: pyproject
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:30:44.631505+00:00'
+  generated_at: '2026-03-19T14:52:11.912295+00:00'
   generator_version: 0.1.0
 - source: plugin_entry_points
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:30:44.631546+00:00'
+  generated_at: '2026-03-19T14:52:11.912347+00:00'
   generator_version: 0.1.0
 - source: citation_cff
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:30:44.631563+00:00'
+  generated_at: '2026-03-19T14:52:11.912369+00:00'
   generator_version: 0.1.0
 stars: 7
 owner: FAIRmat-NFDI
@@ -140,3 +140,33 @@ owner_type: Organization
 created: '2024-01-17T11:45:02Z'
 last_updated: '2026-03-19T13:40:53Z'
 archived: false
+maturity: beta
+repository_default_branch: develop
+deployment:
+  on_central: true
+  on_example_oasis: true
+  on_pypi: true
+  pypi_package: nomad-simulations
+suggested_usages:
+- id: simulation-schema-foundation
+  title: Use FAIR simulation schemas in NOMAD plugins
+  user_intent: Reuse common simulation metainfo sections in plugin schema packages
+  domain_category: simulations
+  technique: simulation-schema
+  audience: plugin-developers
+  maturity: stable
+  tags:
+  - schema
+  - metainfo
+  - reuse
+- id: harmonize-simulation-data-models
+  title: Harmonize simulation data models across parsers
+  user_intent: Standardize simulation outputs to shared semantic sections
+  domain_category: cross-domain
+  technique: ontology-and-schema-harmonization
+  audience: advanced
+  maturity: stable
+  tags:
+  - harmonization
+  - interoperability
+  - simulation


### PR DESCRIPTION
## Summary

This PR adds the first metadata extraction for `nomad-simulation-parsers` using the `nomad-plugin-metadata` pipeline.

## What to review

Please review **`nomad_plugin_metadata.yaml`**.  
This is the canonical, merged file intended for querying/registry usage.

## How files work

- `.metadata/nomad_plugin_metadata.auto.yaml`  
  Machine-generated metadata from package/plugin introspection.
- `.metadata/nomad_plugin_metadata.manual.yaml`  
  Maintainer-owned manual curation/overrides (not machine-overwritten).
- `nomad_plugin_metadata.yaml`  
  Final merged output (auto + manual; manual non-empty values take precedence).
- `.metadata/plugin-metadata.override-report.yaml`  
  Report of conflicts where manual overrides auto.

## Goal of this PR

Initial extraction pass for developer feedback before broader rollout:
- verify extracted parser/file-format metadata
- identify missing/incorrect fields
- align expected manual curation scope

## References

- `nomad-plugins-metadata`: https://github.com/FAIRmat-NFDI/nomad-plugins-metadata, https://fairmat-nfdi.github.io/nomad-plugins-metadata/reference/schema_reference.html#full-schema-shaped-yaml-template
- `datatractor`: https://github.com/datatractor
