### PR TITLE
add semi empirical methods

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -1167,6 +1167,35 @@ class xTB(TB):
     # ? Deprecate this
 
 
+class SemiEmpirical(ModelMethodElectronic):
+    """
+    A base section used to define semi-empirical quantum chemistry methods such as MINDO, MNDO,
+    AM1, PM3, PM6, PM7, and SAM1.
+    """
+
+    type = Quantity(
+        type=MEnum('MINDO', 'MNDO', 'AM1', 'PM3', 'PM6', 'PM7', 'SAM1'),
+        description="""
+        Semi-empirical quantum chemistry method. These can be:
+
+        | Value | Description |
+        | --------- | ----------------------- |
+        | `'MINDO'` | Modified Intermediate Neglect of Differential Overlap |
+        | `'MNDO'` | Modified Neglect of Diatomic Overlap |
+        | `'AM1'` | Austin Model 1 |
+        | `'PM3'` | Parametric Method 3 |
+        | `'PM6'` | Parametric Method 6 |
+        | `'PM7'` | Parametric Method 7 |
+        | `'SAM1'` | Semi-Ab Initio Method 1 |
+        """,
+    )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+        self.name = 'SemiEmpirical'
+
+
 class Photon(ArchiveSection):
     """
     A base section used to define parameters of a photon, typically used for optical responses.


### PR DESCRIPTION
## Purpose
Add minimal schema support for semi-empirical quantum chemistry methods in `ModelMethod`.

## Scope

**Included**

- Add a new `SemiEmpirical` section under `ModelMethodElectronic`
- Add type enum values for `MINDO`, `MNDO`, `AM1`, `PM3`, `PM6`, `PM7`, and `SAM1`
- Normalize the archive name to `SemiEmpirical`, following the existing `TB` pattern where `name` is the family and `type` is the concrete method


## Context & Links

- Closes #273: add semi-empirical quantum chemistry methods
- Minimal implementation only: one family-level schema section, no per-method subclasses
- These methods are still in active scientific use, especially PM6 and PM7, which continue to appear in recent work for ML, molecular screening, docking, thermochemistry, and method development, and they also remain common as lower-level components in multilayer approaches such as ONIOM. So adding a minimal schema support is somewhat necessary. Here are some recent examples:
https://pubs.acs.org/doi/10.1021/acs.jctc.4c01330
https://www.sciencedirect.com/science/article/pii/S0022286024007889
https://www.sciencedirect.com/science/article/pii/S0360319925015575
https://www.sciencedirect.com/science/article/pii/S0167577X25018464


## Reviewer Notes

name = 'SemiEmpirical'
type = 'AM1', PM6, etc.

- **Open quick question:** Should the name be `SemiEmpiricalMethod`  or `SemiEmpiricalModel` or something? I am not sure.
I thought `SemiEmpirical` fit the current naming style better

- **Open question:** TB-family methods such as `DFTB` and `xTB` are also considered semi-empirical; for now this PR keeps them separate, but should the longer-term schema taxonomy make that relationship more explicit?

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

_How was this change validated?_

- [x] None (explain):


