### PR TITLE
add legend to UML diagrams

### DIFF
--- a/docs/assets/mermaid-uml-markers.js
+++ b/docs/assets/mermaid-uml-markers.js
@@ -1,0 +1,45 @@
+function fixMermaidInheritanceMarkers(root = document) {
+    const docStyle = getComputedStyle(document.documentElement);
+    const edge =
+        docStyle.getPropertyValue('--md-mermaid-edge-color').trim()
+        || docStyle.getPropertyValue('--md-default-fg-color').trim()
+        || '#000000';
+
+    root.querySelectorAll('svg defs marker.marker.extension.class path').forEach((path) => {
+        path.style.setProperty('fill', '#ffffff', 'important');
+        path.style.setProperty('stroke', edge, 'important');
+        path.style.setProperty('stroke-width', '1.8px', 'important');
+    });
+}
+
+function watchMermaidInheritanceMarkers() {
+    fixMermaidInheritanceMarkers();
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (!(node instanceof Element)) {
+                    continue;
+                }
+                if (node.matches('svg, .mermaid, .panzoom-box')) {
+                    fixMermaidInheritanceMarkers(node);
+                } else if (node.querySelector('svg defs marker.marker.extension.class path')) {
+                    fixMermaidInheritanceMarkers(node);
+                }
+            }
+        }
+    });
+
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', watchMermaidInheritanceMarkers, {
+        once: true,
+    });
+} else {
+    watchMermaidInheritanceMarkers();
+}

--- a/docs/schema/chemical_formula.diagram.md
+++ b/docs/schema/chemical_formula.diagram.md
@@ -9,9 +9,12 @@
 
 This diagram shows the relationships between schema classes:
 
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
     class ChemicalFormula {
     }
 ```
+
+</div>

--- a/docs/schema/chemical_formula.md
+++ b/docs/schema/chemical_formula.md
@@ -15,10 +15,14 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class ChemicalFormula
 ```
+
+</div>
 
 
 ## Key sections

--- a/docs/schema/electronic_properties.diagram.md
+++ b/docs/schema/electronic_properties.diagram.md
@@ -34,16 +34,16 @@ classDiagram
     ElectronicEigenvalues <|-- ElectronicBandStructure
     DOSProfile <|-- ElectronicDensityOfStates
     BaseElectronicEigenvalues <|-- ElectronicEigenvalues
-    DOSProfile --> Energy2 : energies
-    ElectronicDensityOfStates --> DOSProfile : projected_dos
-    ElectronicDensityOfStates --> Energy2 : energies
-    ElectronicEigenvalues --> BaseElectronicEigenvalues : contributions
+    DOSProfile *-- Energy2 : energies
+    ElectronicDensityOfStates *-- DOSProfile : projected_dos
+    ElectronicDensityOfStates *-- Energy2 : energies
+    ElectronicEigenvalues *-- BaseElectronicEigenvalues : contributions
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/electronic_properties.diagram.md
+++ b/docs/schema/electronic_properties.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -40,3 +39,11 @@ classDiagram
     ElectronicDensityOfStates --> Energy2 : energies
     ElectronicEigenvalues --> BaseElectronicEigenvalues : contributions
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/electronic_properties.diagram.md
+++ b/docs/schema/electronic_properties.diagram.md
@@ -40,8 +40,8 @@ classDiagram
     ElectronicEigenvalues --> BaseElectronicEigenvalues : contributions
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/electronic_properties.diagram.md
+++ b/docs/schema/electronic_properties.diagram.md
@@ -42,7 +42,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/electronic_properties.md
+++ b/docs/schema/electronic_properties.md
@@ -39,7 +39,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/electronic_properties.md
+++ b/docs/schema/electronic_properties.md
@@ -37,8 +37,8 @@ classDiagram
     ElectronicEigenvalues --> BaseElectronicEigenvalues : contributions
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/electronic_properties.md
+++ b/docs/schema/electronic_properties.md
@@ -15,6 +15,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseElectronicEigenvalues
@@ -35,10 +37,13 @@ classDiagram
     ElectronicEigenvalues --> BaseElectronicEigenvalues : contributions
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/electronic_properties.md
+++ b/docs/schema/electronic_properties.md
@@ -31,16 +31,16 @@ classDiagram
     ElectronicEigenvalues <|-- ElectronicBandStructure
     DOSProfile <|-- ElectronicDensityOfStates
     BaseElectronicEigenvalues <|-- ElectronicEigenvalues
-    DOSProfile --> Energy2 : energies
-    ElectronicDensityOfStates --> DOSProfile : projected_dos
-    ElectronicDensityOfStates --> Energy2 : energies
-    ElectronicEigenvalues --> BaseElectronicEigenvalues : contributions
+    DOSProfile *-- Energy2 : energies
+    ElectronicDensityOfStates *-- DOSProfile : projected_dos
+    ElectronicDensityOfStates *-- Energy2 : energies
+    ElectronicEigenvalues *-- BaseElectronicEigenvalues : contributions
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/force_field.diagram.md
+++ b/docs/schema/force_field.diagram.md
@@ -24,15 +24,15 @@ classDiagram
     class Potential {
     }
     ModelMethod <|-- ForceField
-    ForceField --> Potential : contributions
-    ModelMethod --> BaseModelMethod : contributions
-    Potential --> ParameterEntry : parameters
+    ForceField *-- Potential : contributions
+    ModelMethod *-- BaseModelMethod : contributions
+    Potential *-- ParameterEntry : parameters
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/force_field.diagram.md
+++ b/docs/schema/force_field.diagram.md
@@ -29,8 +29,8 @@ classDiagram
     Potential --> ParameterEntry : parameters
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/force_field.diagram.md
+++ b/docs/schema/force_field.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -29,3 +28,11 @@ classDiagram
     ModelMethod --> BaseModelMethod : contributions
     Potential --> ParameterEntry : parameters
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/force_field.diagram.md
+++ b/docs/schema/force_field.diagram.md
@@ -31,7 +31,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/force_field.md
+++ b/docs/schema/force_field.md
@@ -12,6 +12,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseModelMethod
@@ -25,10 +27,13 @@ classDiagram
     Potential --> ParameterEntry : parameters
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/force_field.md
+++ b/docs/schema/force_field.md
@@ -27,8 +27,8 @@ classDiagram
     Potential --> ParameterEntry : parameters
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/force_field.md
+++ b/docs/schema/force_field.md
@@ -29,7 +29,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/force_field.md
+++ b/docs/schema/force_field.md
@@ -22,15 +22,15 @@ classDiagram
     class ParameterEntry
     class Potential
     ModelMethod <|-- ForceField
-    ForceField --> Potential : contributions
-    ModelMethod --> BaseModelMethod : contributions
-    Potential --> ParameterEntry : parameters
+    ForceField *-- Potential : contributions
+    ModelMethod *-- BaseModelMethod : contributions
+    Potential *-- ParameterEntry : parameters
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/manybody_properties.diagram.md
+++ b/docs/schema/manybody_properties.diagram.md
@@ -47,8 +47,8 @@ classDiagram
     BaseGreensFunction --> WignerSeitz
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/manybody_properties.diagram.md
+++ b/docs/schema/manybody_properties.diagram.md
@@ -49,7 +49,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/manybody_properties.diagram.md
+++ b/docs/schema/manybody_properties.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -47,3 +46,11 @@ classDiagram
     BaseGreensFunction --> Time
     BaseGreensFunction --> WignerSeitz
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/manybody_properties.diagram.md
+++ b/docs/schema/manybody_properties.diagram.md
@@ -40,17 +40,17 @@ classDiagram
     BaseGreensFunction <|-- ElectronicGreensFunction
     BaseGreensFunction <|-- ElectronicSelfEnergy
     BaseGreensFunction <|-- HybridizationFunction
-    BaseGreensFunction --> Frequency : real_frequency
-    BaseGreensFunction --> ImaginaryTime
-    BaseGreensFunction --> MatsubaraFrequency
-    BaseGreensFunction --> Time
-    BaseGreensFunction --> WignerSeitz
+    BaseGreensFunction *-- Frequency : real_frequency
+    BaseGreensFunction *-- ImaginaryTime
+    BaseGreensFunction *-- MatsubaraFrequency
+    BaseGreensFunction *-- Time
+    BaseGreensFunction *-- WignerSeitz
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/manybody_properties.md
+++ b/docs/schema/manybody_properties.md
@@ -15,6 +15,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseGreensFunction
@@ -39,10 +41,13 @@ classDiagram
     BaseGreensFunction --> WignerSeitz : wigner_seitz
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/manybody_properties.md
+++ b/docs/schema/manybody_properties.md
@@ -34,17 +34,17 @@ classDiagram
     BaseGreensFunction <|-- ElectronicGreensFunction
     BaseGreensFunction <|-- ElectronicSelfEnergy
     BaseGreensFunction <|-- HybridizationFunction
-    BaseGreensFunction --> Frequency : real_frequency
-    BaseGreensFunction --> ImaginaryTime : imaginary_time
-    BaseGreensFunction --> MatsubaraFrequency : matsubara_frequency
-    BaseGreensFunction --> Time : time
-    BaseGreensFunction --> WignerSeitz : wigner_seitz
+    BaseGreensFunction *-- Frequency : real_frequency
+    BaseGreensFunction *-- ImaginaryTime : imaginary_time
+    BaseGreensFunction *-- MatsubaraFrequency : matsubara_frequency
+    BaseGreensFunction *-- Time : time
+    BaseGreensFunction *-- WignerSeitz : wigner_seitz
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/manybody_properties.md
+++ b/docs/schema/manybody_properties.md
@@ -43,7 +43,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/manybody_properties.md
+++ b/docs/schema/manybody_properties.md
@@ -41,8 +41,8 @@ classDiagram
     BaseGreensFunction --> WignerSeitz : wigner_seitz
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/model_method.diagram.md
+++ b/docs/schema/model_method.diagram.md
@@ -25,7 +25,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method.diagram.md
+++ b/docs/schema/model_method.diagram.md
@@ -25,7 +25,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method.diagram.md
+++ b/docs/schema/model_method.diagram.md
@@ -9,7 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -22,3 +22,10 @@ classDiagram
     BaseModelMethod <|-- ModelMethod
     ModelMethod <|-- ModelMethodElectronic
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+</div>
+
+</div>

--- a/docs/schema/model_method.diagram.md
+++ b/docs/schema/model_method.diagram.md
@@ -23,8 +23,8 @@ classDiagram
     ModelMethod <|-- ModelMethodElectronic
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 </div>
 

--- a/docs/schema/model_method.md
+++ b/docs/schema/model_method.md
@@ -24,7 +24,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method.md
+++ b/docs/schema/model_method.md
@@ -22,8 +22,8 @@ classDiagram
     ModelMethod <|-- ModelMethodElectronic
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 </div>
 

--- a/docs/schema/model_method.md
+++ b/docs/schema/model_method.md
@@ -24,7 +24,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method.md
+++ b/docs/schema/model_method.md
@@ -11,6 +11,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseModelMethod
@@ -20,9 +22,12 @@ classDiagram
     ModelMethod <|-- ModelMethodElectronic
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/model_method_electronic.diagram.md
+++ b/docs/schema/model_method_electronic.diagram.md
@@ -67,7 +67,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method_electronic.diagram.md
+++ b/docs/schema/model_method_electronic.diagram.md
@@ -9,7 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -64,3 +64,10 @@ classDiagram
     TB <|-- Wannier
     TB <|-- xTB
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+</div>
+
+</div>

--- a/docs/schema/model_method_electronic.diagram.md
+++ b/docs/schema/model_method_electronic.diagram.md
@@ -65,8 +65,8 @@ classDiagram
     TB <|-- xTB
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 </div>
 

--- a/docs/schema/model_method_electronic.diagram.md
+++ b/docs/schema/model_method_electronic.diagram.md
@@ -67,7 +67,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method_electronic.md
+++ b/docs/schema/model_method_electronic.md
@@ -14,6 +14,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BSE
@@ -51,9 +53,12 @@ classDiagram
     TB <|-- xTB
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/model_method_electronic.md
+++ b/docs/schema/model_method_electronic.md
@@ -53,8 +53,8 @@ classDiagram
     TB <|-- xTB
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 </div>
 

--- a/docs/schema/model_method_electronic.md
+++ b/docs/schema/model_method_electronic.md
@@ -55,7 +55,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_method_electronic.md
+++ b/docs/schema/model_method_electronic.md
@@ -55,7 +55,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_system.diagram.md
+++ b/docs/schema/model_system.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -36,3 +35,11 @@ classDiagram
     ModelSystem --> GlobalSymmetry : symmetry
     ModelSystem --> ParticleState
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/model_system.diagram.md
+++ b/docs/schema/model_system.diagram.md
@@ -38,7 +38,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/model_system.diagram.md
+++ b/docs/schema/model_system.diagram.md
@@ -36,8 +36,8 @@ classDiagram
     ModelSystem --> ParticleState
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/model_system.diagram.md
+++ b/docs/schema/model_system.diagram.md
@@ -29,17 +29,17 @@ classDiagram
     }
     Representation <|-- AlternativeRepresentation
     Representation <|-- ModelSystem
-    ModelSystem --> AlternativeRepresentation : representations
-    ModelSystem --> ChemicalFormula
-    ModelSystem --> ElectronicState
-    ModelSystem --> GlobalSymmetry : symmetry
-    ModelSystem --> ParticleState
+    ModelSystem *-- AlternativeRepresentation : representations
+    ModelSystem *-- ChemicalFormula
+    ModelSystem *-- ElectronicState
+    ModelSystem *-- GlobalSymmetry : symmetry
+    ModelSystem *-- ParticleState
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_system.md
+++ b/docs/schema/model_system.md
@@ -36,7 +36,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/model_system.md
+++ b/docs/schema/model_system.md
@@ -27,17 +27,17 @@ classDiagram
     class Representation
     Representation <|-- AlternativeRepresentation
     Representation <|-- ModelSystem
-    ModelSystem --> AlternativeRepresentation : representations
-    ModelSystem --> ChemicalFormula : chemical_formula
-    ModelSystem --> ElectronicState : electronic_state
-    ModelSystem --> GlobalSymmetry : symmetry
-    ModelSystem --> ParticleState : particle_states
+    ModelSystem *-- AlternativeRepresentation : representations
+    ModelSystem *-- ChemicalFormula : chemical_formula
+    ModelSystem *-- ElectronicState : electronic_state
+    ModelSystem *-- GlobalSymmetry : symmetry
+    ModelSystem *-- ParticleState : particle_states
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/model_system.md
+++ b/docs/schema/model_system.md
@@ -34,8 +34,8 @@ classDiagram
     ModelSystem --> ParticleState : particle_states
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/model_system.md
+++ b/docs/schema/model_system.md
@@ -14,6 +14,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class AlternativeRepresentation
@@ -32,10 +34,13 @@ classDiagram
     ModelSystem --> ParticleState : particle_states
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/numerical_settings.diagram.md
+++ b/docs/schema/numerical_settings.diagram.md
@@ -45,14 +45,14 @@ classDiagram
     KMesh <|-- PlaneWaveBasisSet
     NumericalSettings <|-- SelfConsistency
     NumericalSettings <|-- Smearing
-    KSpace --> KLinePath
-    KSpace --> KMesh
+    KSpace *-- KLinePath
+    KSpace *-- KMesh
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/numerical_settings.diagram.md
+++ b/docs/schema/numerical_settings.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -49,3 +48,11 @@ classDiagram
     KSpace --> KLinePath
     KSpace --> KMesh
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/numerical_settings.diagram.md
+++ b/docs/schema/numerical_settings.diagram.md
@@ -49,8 +49,8 @@ classDiagram
     KSpace --> KMesh
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/numerical_settings.diagram.md
+++ b/docs/schema/numerical_settings.diagram.md
@@ -51,7 +51,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -15,6 +15,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class APWPlaneWaveBasisSet
@@ -41,10 +43,13 @@ classDiagram
     KSpace --> KMesh : k_mesh
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -45,7 +45,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -39,14 +39,14 @@ classDiagram
     KMesh <|-- PlaneWaveBasisSet
     NumericalSettings <|-- SelfConsistency
     NumericalSettings <|-- Smearing
-    KSpace --> KLinePath : k_line_path
-    KSpace --> KMesh : k_mesh
+    KSpace *-- KLinePath : k_line_path
+    KSpace *-- KMesh : k_mesh
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -43,8 +43,8 @@ classDiagram
     KSpace --> KMesh : k_mesh
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/outputs.diagram.md
+++ b/docs/schema/outputs.diagram.md
@@ -13,46 +13,46 @@ This diagram shows the relationships between schema classes:
 
 ```mermaid
 classDiagram
-    class ChemicalPotential {
+    class AbsorptionSpectrum {
     }
     class ElectronicBandStructure {
     }
-    class ElectronicEigenvalues {
+    class ElectronicDensityOfStates {
     }
-    class ElectronicGreensFunction {
+    class ElectronicEigenvalues {
     }
     class ElectronicSelfEnergy {
     }
+    class FermiSurface {
+    }
     class HoppingMatrix {
     }
-    class HybridizationFunction {
+    class KineticEnergy {
     }
     class Outputs {
     }
     class PhysicalProperty {
     }
-    class QuasiparticleWeight {
+    class PotentialEnergy {
     }
-    class RadiusOfGyration {
+    class QuasiparticleWeight {
     }
     class SCFSteps {
     }
     class TotalForce {
     }
-    class XASSpectrum {
-    }
-    Outputs *-- ChemicalPotential
+    Outputs *-- AbsorptionSpectrum : absorption_spectra
     Outputs *-- ElectronicBandStructure
+    Outputs *-- ElectronicDensityOfStates : electronic_dos
     Outputs *-- ElectronicEigenvalues
-    Outputs *-- ElectronicGreensFunction
     Outputs *-- ElectronicSelfEnergy : electronic_self_energies
+    Outputs *-- FermiSurface
     Outputs *-- HoppingMatrix : hopping_matrices
-    Outputs *-- HybridizationFunction
+    Outputs *-- KineticEnergy : kinetic_energies
+    Outputs *-- PotentialEnergy : potential_energies
     Outputs *-- QuasiparticleWeight
-    Outputs *-- RadiusOfGyration : radii_of_gyration
     Outputs *-- SCFSteps
     Outputs *-- TotalForce
-    Outputs *-- XASSpectrum : xas_spectra
 ```
 
 </div>
@@ -67,17 +67,15 @@ _Diagram 2 of 2 (split due to large number of children)_
 
 ```mermaid
 classDiagram
-    class AbsorptionSpectrum {
+    class ChemicalPotential {
     }
     class CrystalFieldSplitting {
     }
     class ElectronicBandGap {
     }
-    class ElectronicDensityOfStates {
+    class ElectronicGreensFunction {
     }
-    class FermiSurface {
-    }
-    class KineticEnergy {
+    class HybridizationFunction {
     }
     class Occupancy {
     }
@@ -87,23 +85,25 @@ classDiagram
     }
     class PhysicalProperty {
     }
-    class PotentialEnergy {
+    class RadiusOfGyration {
     }
     class Temperature {
     }
     class TotalEnergy {
     }
-    Outputs *-- AbsorptionSpectrum : absorption_spectra
+    class XASSpectrum {
+    }
+    Outputs *-- ChemicalPotential
     Outputs *-- CrystalFieldSplitting
     Outputs *-- ElectronicBandGap
-    Outputs *-- ElectronicDensityOfStates : electronic_dos
-    Outputs *-- FermiSurface
-    Outputs *-- KineticEnergy : kinetic_energies
+    Outputs *-- ElectronicGreensFunction
+    Outputs *-- HybridizationFunction
     Outputs *-- Occupancy : occupancies
     Outputs *-- Permittivity : permittivities
-    Outputs *-- PotentialEnergy : potential_energies
+    Outputs *-- RadiusOfGyration : radii_of_gyration
     Outputs *-- Temperature
     Outputs *-- TotalEnergy : total_energies
+    Outputs *-- XASSpectrum : xas_spectra
 ```
 
 <p class="uml-legend__title">Legend</p>

--- a/docs/schema/outputs.diagram.md
+++ b/docs/schema/outputs.diagram.md
@@ -9,18 +9,13 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
     class AbsorptionSpectrum {
     }
     class ChemicalPotential {
-    }
-    class CrystalFieldSplitting {
-    }
-    class ElectronicBandGap {
     }
     class ElectronicBandStructure {
     }
@@ -30,43 +25,52 @@ classDiagram
     }
     class ElectronicGreensFunction {
     }
+    class KineticEnergy {
+    }
+    class Occupancy {
+    }
     class Outputs {
     }
     class Permittivity {
     }
     class PhysicalProperty {
     }
-    class PotentialEnergy {
-    }
     class QuasiparticleWeight {
-    }
-    class SCFOutputs {
     }
     class Temperature {
     }
-    Outputs <|-- SCFOutputs
+    class XASSpectrum {
+    }
     Outputs --> AbsorptionSpectrum : absorption_spectra
     Outputs --> ChemicalPotential
-    Outputs --> CrystalFieldSplitting
-    Outputs --> ElectronicBandGap
     Outputs --> ElectronicBandStructure
     Outputs --> ElectronicDensityOfStates : electronic_dos
     Outputs --> ElectronicEigenvalues
     Outputs --> ElectronicGreensFunction
+    Outputs --> KineticEnergy : kinetic_energies
+    Outputs --> Occupancy : occupancies
     Outputs --> Permittivity : permittivities
-    Outputs --> PotentialEnergy : potential_energies
     Outputs --> QuasiparticleWeight
     Outputs --> Temperature
-    SCFOutputs --> Outputs : scf_steps
+    Outputs --> XASSpectrum : xas_spectra
 ```
+
+</div>
+
 
 ---
 
 
 _Diagram 2 of 2 (split due to large number of children)_
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
+    class CrystalFieldSplitting {
+    }
+    class ElectronicBandGap {
+    }
     class ElectronicSelfEnergy {
     }
     class FermiSurface {
@@ -75,34 +79,36 @@ classDiagram
     }
     class HybridizationFunction {
     }
-    class KineticEnergy {
-    }
-    class Occupancy {
-    }
     class Outputs {
     }
     class PhysicalProperty {
     }
+    class PotentialEnergy {
+    }
     class RadiusOfGyration {
     }
-    class SCFOutputs {
+    class SCFSteps {
     }
     class TotalEnergy {
     }
     class TotalForce {
     }
-    class XASSpectrum {
-    }
-    Outputs <|-- SCFOutputs
+    Outputs --> CrystalFieldSplitting
+    Outputs --> ElectronicBandGap
     Outputs --> ElectronicSelfEnergy : electronic_self_energies
     Outputs --> FermiSurface
     Outputs --> HoppingMatrix : hopping_matrices
     Outputs --> HybridizationFunction
-    Outputs --> KineticEnergy : kinetic_energies
-    Outputs --> Occupancy : occupancies
+    Outputs --> PotentialEnergy : potential_energies
     Outputs --> RadiusOfGyration : radii_of_gyration
+    Outputs --> SCFSteps
     Outputs --> TotalEnergy : total_energies
     Outputs --> TotalForce
-    Outputs --> XASSpectrum : xas_spectra
-    SCFOutputs --> Outputs : scf_steps
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/outputs.diagram.md
+++ b/docs/schema/outputs.diagram.md
@@ -13,46 +13,46 @@ This diagram shows the relationships between schema classes:
 
 ```mermaid
 classDiagram
-    class AbsorptionSpectrum {
-    }
     class ChemicalPotential {
     }
     class ElectronicBandStructure {
-    }
-    class ElectronicDensityOfStates {
     }
     class ElectronicEigenvalues {
     }
     class ElectronicGreensFunction {
     }
-    class KineticEnergy {
+    class ElectronicSelfEnergy {
     }
-    class Occupancy {
+    class HoppingMatrix {
+    }
+    class HybridizationFunction {
     }
     class Outputs {
-    }
-    class Permittivity {
     }
     class PhysicalProperty {
     }
     class QuasiparticleWeight {
     }
-    class Temperature {
+    class RadiusOfGyration {
+    }
+    class SCFSteps {
+    }
+    class TotalForce {
     }
     class XASSpectrum {
     }
-    Outputs --> AbsorptionSpectrum : absorption_spectra
-    Outputs --> ChemicalPotential
-    Outputs --> ElectronicBandStructure
-    Outputs --> ElectronicDensityOfStates : electronic_dos
-    Outputs --> ElectronicEigenvalues
-    Outputs --> ElectronicGreensFunction
-    Outputs --> KineticEnergy : kinetic_energies
-    Outputs --> Occupancy : occupancies
-    Outputs --> Permittivity : permittivities
-    Outputs --> QuasiparticleWeight
-    Outputs --> Temperature
-    Outputs --> XASSpectrum : xas_spectra
+    Outputs *-- ChemicalPotential
+    Outputs *-- ElectronicBandStructure
+    Outputs *-- ElectronicEigenvalues
+    Outputs *-- ElectronicGreensFunction
+    Outputs *-- ElectronicSelfEnergy : electronic_self_energies
+    Outputs *-- HoppingMatrix : hopping_matrices
+    Outputs *-- HybridizationFunction
+    Outputs *-- QuasiparticleWeight
+    Outputs *-- RadiusOfGyration : radii_of_gyration
+    Outputs *-- SCFSteps
+    Outputs *-- TotalForce
+    Outputs *-- XASSpectrum : xas_spectra
 ```
 
 </div>
@@ -67,48 +67,48 @@ _Diagram 2 of 2 (split due to large number of children)_
 
 ```mermaid
 classDiagram
+    class AbsorptionSpectrum {
+    }
     class CrystalFieldSplitting {
     }
     class ElectronicBandGap {
     }
-    class ElectronicSelfEnergy {
+    class ElectronicDensityOfStates {
     }
     class FermiSurface {
     }
-    class HoppingMatrix {
+    class KineticEnergy {
     }
-    class HybridizationFunction {
+    class Occupancy {
     }
     class Outputs {
+    }
+    class Permittivity {
     }
     class PhysicalProperty {
     }
     class PotentialEnergy {
     }
-    class RadiusOfGyration {
-    }
-    class SCFSteps {
+    class Temperature {
     }
     class TotalEnergy {
     }
-    class TotalForce {
-    }
-    Outputs --> CrystalFieldSplitting
-    Outputs --> ElectronicBandGap
-    Outputs --> ElectronicSelfEnergy : electronic_self_energies
-    Outputs --> FermiSurface
-    Outputs --> HoppingMatrix : hopping_matrices
-    Outputs --> HybridizationFunction
-    Outputs --> PotentialEnergy : potential_energies
-    Outputs --> RadiusOfGyration : radii_of_gyration
-    Outputs --> SCFSteps
-    Outputs --> TotalEnergy : total_energies
-    Outputs --> TotalForce
+    Outputs *-- AbsorptionSpectrum : absorption_spectra
+    Outputs *-- CrystalFieldSplitting
+    Outputs *-- ElectronicBandGap
+    Outputs *-- ElectronicDensityOfStates : electronic_dos
+    Outputs *-- FermiSurface
+    Outputs *-- KineticEnergy : kinetic_energies
+    Outputs *-- Occupancy : occupancies
+    Outputs *-- Permittivity : permittivities
+    Outputs *-- PotentialEnergy : potential_energies
+    Outputs *-- Temperature
+    Outputs *-- TotalEnergy : total_energies
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/outputs.diagram.md
+++ b/docs/schema/outputs.diagram.md
@@ -106,8 +106,8 @@ classDiagram
     Outputs --> TotalForce
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>
 

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -14,6 +14,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class AbsorptionSpectrum
@@ -66,9 +68,12 @@ classDiagram
     Outputs --> XASSpectrum : xas_spectra
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -43,34 +43,34 @@ classDiagram
     class TotalEnergy
     class TotalForce
     class XASSpectrum
-    Outputs --> AbsorptionSpectrum : absorption_spectra
-    Outputs --> ChemicalPotential : chemical_potentials
-    Outputs --> CrystalFieldSplitting : crystal_field_splittings
-    Outputs --> ElectronicBandGap : electronic_band_gaps
-    Outputs --> ElectronicBandStructure : electronic_band_structures
-    Outputs --> ElectronicDensityOfStates : electronic_dos
-    Outputs --> ElectronicEigenvalues : electronic_eigenvalues
-    Outputs --> ElectronicGreensFunction : electronic_greens_functions
-    Outputs --> ElectronicSelfEnergy : electronic_self_energies
-    Outputs --> FermiSurface : fermi_surfaces
-    Outputs --> HoppingMatrix : hopping_matrices
-    Outputs --> HybridizationFunction : hybridization_functions
-    Outputs --> KineticEnergy : kinetic_energies
-    Outputs --> Occupancy : occupancies
-    Outputs --> Permittivity : permittivities
-    Outputs --> PotentialEnergy : potential_energies
-    Outputs --> QuasiparticleWeight : quasiparticle_weights
-    Outputs --> RadiusOfGyration : radii_of_gyration
-    Outputs --> SCFSteps : scf_steps
-    Outputs --> Temperature : temperatures
-    Outputs --> TotalEnergy : total_energies
-    Outputs --> TotalForce : total_forces
-    Outputs --> XASSpectrum : xas_spectra
+    Outputs *-- AbsorptionSpectrum : absorption_spectra
+    Outputs *-- ChemicalPotential : chemical_potentials
+    Outputs *-- CrystalFieldSplitting : crystal_field_splittings
+    Outputs *-- ElectronicBandGap : electronic_band_gaps
+    Outputs *-- ElectronicBandStructure : electronic_band_structures
+    Outputs *-- ElectronicDensityOfStates : electronic_dos
+    Outputs *-- ElectronicEigenvalues : electronic_eigenvalues
+    Outputs *-- ElectronicGreensFunction : electronic_greens_functions
+    Outputs *-- ElectronicSelfEnergy : electronic_self_energies
+    Outputs *-- FermiSurface : fermi_surfaces
+    Outputs *-- HoppingMatrix : hopping_matrices
+    Outputs *-- HybridizationFunction : hybridization_functions
+    Outputs *-- KineticEnergy : kinetic_energies
+    Outputs *-- Occupancy : occupancies
+    Outputs *-- Permittivity : permittivities
+    Outputs *-- PotentialEnergy : potential_energies
+    Outputs *-- QuasiparticleWeight : quasiparticle_weights
+    Outputs *-- RadiusOfGyration : radii_of_gyration
+    Outputs *-- SCFSteps : scf_steps
+    Outputs *-- Temperature : temperatures
+    Outputs *-- TotalEnergy : total_energies
+    Outputs *-- TotalForce : total_forces
+    Outputs *-- XASSpectrum : xas_spectra
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -68,8 +68,8 @@ classDiagram
     Outputs --> XASSpectrum : xas_spectra
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>
 

--- a/docs/schema/particle_states.diagram.md
+++ b/docs/schema/particle_states.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -33,3 +32,11 @@ classDiagram
     AtomsState --> ElectronicState
     HubbardInteractions --> ElectronicState : orbitals_ref
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/particle_states.diagram.md
+++ b/docs/schema/particle_states.diagram.md
@@ -29,14 +29,14 @@ classDiagram
     }
     ParticleState <|-- AtomsState
     ParticleState <|-- CGBeadState
-    AtomsState --> ElectronicState
-    HubbardInteractions --> ElectronicState : orbitals_ref
+    AtomsState *-- ElectronicState
+    HubbardInteractions *-- ElectronicState : orbitals_ref
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/particle_states.diagram.md
+++ b/docs/schema/particle_states.diagram.md
@@ -33,8 +33,8 @@ classDiagram
     HubbardInteractions --> ElectronicState : orbitals_ref
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/particle_states.diagram.md
+++ b/docs/schema/particle_states.diagram.md
@@ -35,7 +35,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/particle_states.md
+++ b/docs/schema/particle_states.md
@@ -38,7 +38,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/particle_states.md
+++ b/docs/schema/particle_states.md
@@ -19,6 +19,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class AtomicOrbitals
@@ -34,10 +36,13 @@ classDiagram
     HubbardInteractions --> ElectronicState : orbitals_ref
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/particle_states.md
+++ b/docs/schema/particle_states.md
@@ -36,8 +36,8 @@ classDiagram
     HubbardInteractions --> ElectronicState : orbitals_ref
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/particle_states.md
+++ b/docs/schema/particle_states.md
@@ -32,14 +32,14 @@ classDiagram
     class ParticleState
     ParticleState <|-- AtomsState
     ParticleState <|-- CGBeadState
-    AtomsState --> ElectronicState : electronic_state
-    HubbardInteractions --> ElectronicState : orbitals_ref
+    AtomsState *-- ElectronicState : electronic_state
+    HubbardInteractions *-- ElectronicState : orbitals_ref
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/physical_property.diagram.md
+++ b/docs/schema/physical_property.diagram.md
@@ -44,20 +44,20 @@ classDiagram
     PhysicalProperty <|-- BaseForce
     PhysicalProperty <|-- BaseGreensFunction
     PhysicalProperty <|-- SpectralProfile
-    BaseGreensFunction --> Frequency : real_frequency
-    BaseGreensFunction --> ImaginaryTime
-    BaseGreensFunction --> MatsubaraFrequency
-    BaseGreensFunction --> Time
-    BaseGreensFunction --> WignerSeitz
-    PhysicalProperty --> ErrorEstimate : errors
-    SpectralProfile --> Energy2 : energies
-    SpectralProfile --> Energy2 : frequencies
+    BaseGreensFunction *-- Frequency : real_frequency
+    BaseGreensFunction *-- ImaginaryTime
+    BaseGreensFunction *-- MatsubaraFrequency
+    BaseGreensFunction *-- Time
+    BaseGreensFunction *-- WignerSeitz
+    PhysicalProperty *-- ErrorEstimate : errors
+    SpectralProfile *-- Energy2 : energies
+    SpectralProfile *-- Energy2 : frequencies
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/physical_property.diagram.md
+++ b/docs/schema/physical_property.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -54,3 +53,11 @@ classDiagram
     SpectralProfile --> Energy2 : energies
     SpectralProfile --> Energy2 : frequencies
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/physical_property.diagram.md
+++ b/docs/schema/physical_property.diagram.md
@@ -54,8 +54,8 @@ classDiagram
     SpectralProfile --> Energy2 : frequencies
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/physical_property.diagram.md
+++ b/docs/schema/physical_property.diagram.md
@@ -56,7 +56,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/physical_property.md
+++ b/docs/schema/physical_property.md
@@ -35,20 +35,20 @@ classDiagram
     PhysicalProperty <|-- BaseForce
     PhysicalProperty <|-- BaseGreensFunction
     PhysicalProperty <|-- SpectralProfile
-    BaseGreensFunction --> Frequency : real_frequency
-    BaseGreensFunction --> ImaginaryTime : imaginary_time
-    BaseGreensFunction --> MatsubaraFrequency : matsubara_frequency
-    BaseGreensFunction --> Time : time
-    BaseGreensFunction --> WignerSeitz : wigner_seitz
-    PhysicalProperty --> ErrorEstimate : errors
-    SpectralProfile --> Energy2 : energies
-    SpectralProfile --> Energy2 : frequencies
+    BaseGreensFunction *-- Frequency : real_frequency
+    BaseGreensFunction *-- ImaginaryTime : imaginary_time
+    BaseGreensFunction *-- MatsubaraFrequency : matsubara_frequency
+    BaseGreensFunction *-- Time : time
+    BaseGreensFunction *-- WignerSeitz : wigner_seitz
+    PhysicalProperty *-- ErrorEstimate : errors
+    SpectralProfile *-- Energy2 : energies
+    SpectralProfile *-- Energy2 : frequencies
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/physical_property.md
+++ b/docs/schema/physical_property.md
@@ -45,8 +45,8 @@ classDiagram
     SpectralProfile --> Energy2 : frequencies
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/physical_property.md
+++ b/docs/schema/physical_property.md
@@ -47,7 +47,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/physical_property.md
+++ b/docs/schema/physical_property.md
@@ -13,6 +13,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseElectronicEigenvalues
@@ -43,10 +45,13 @@ classDiagram
     SpectralProfile --> Energy2 : frequencies
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/representations.diagram.md
+++ b/docs/schema/representations.diagram.md
@@ -9,9 +9,12 @@
 
 This diagram shows the relationships between schema classes:
 
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
     class AlternativeRepresentation {
     }
 ```
+
+</div>

--- a/docs/schema/representations.md
+++ b/docs/schema/representations.md
@@ -13,10 +13,14 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class AlternativeRepresentation
 ```
+
+</div>
 
 
 ## Key sections

--- a/docs/schema/simulation.diagram.md
+++ b/docs/schema/simulation.diagram.md
@@ -32,8 +32,8 @@ classDiagram
     Simulation --> Outputs
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/simulation.diagram.md
+++ b/docs/schema/simulation.diagram.md
@@ -34,7 +34,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/simulation.diagram.md
+++ b/docs/schema/simulation.diagram.md
@@ -26,16 +26,16 @@ classDiagram
     class Simulation {
     }
     BaseSimulation <|-- Simulation
-    BaseSimulation --> Program
-    Simulation --> ModelMethod
-    Simulation --> ModelSystem
-    Simulation --> Outputs
+    BaseSimulation *-- Program
+    Simulation *-- ModelMethod
+    Simulation *-- ModelSystem
+    Simulation *-- Outputs
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/simulation.diagram.md
+++ b/docs/schema/simulation.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -32,3 +31,11 @@ classDiagram
     Simulation --> ModelSystem
     Simulation --> Outputs
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/simulation.md
+++ b/docs/schema/simulation.md
@@ -24,16 +24,16 @@ classDiagram
     class Program
     class Simulation
     BaseSimulation <|-- Simulation
-    BaseSimulation --> Program : program
-    Simulation --> ModelMethod : model_method
-    Simulation --> ModelSystem : model_system
-    Simulation --> Outputs : outputs
+    BaseSimulation *-- Program : program
+    Simulation *-- ModelMethod : model_method
+    Simulation *-- ModelSystem : model_system
+    Simulation *-- Outputs : outputs
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/simulation.md
+++ b/docs/schema/simulation.md
@@ -13,6 +13,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseSimulation
@@ -28,10 +30,13 @@ classDiagram
     Simulation --> Outputs : outputs
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/simulation.md
+++ b/docs/schema/simulation.md
@@ -30,8 +30,8 @@ classDiagram
     Simulation --> Outputs : outputs
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/simulation.md
+++ b/docs/schema/simulation.md
@@ -32,7 +32,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/spectroscopy.diagram.md
+++ b/docs/schema/spectroscopy.diagram.md
@@ -27,17 +27,17 @@ classDiagram
     }
     SpectralProfile <|-- AbsorptionSpectrum
     AbsorptionSpectrum <|-- XASSpectrum
-    Permittivity --> Frequency : frequencies
-    SpectralProfile --> Energy2 : energies
-    SpectralProfile --> Energy2 : frequencies
-    XASSpectrum --> AbsorptionSpectrum : exafs_spectrum
-    XASSpectrum --> AbsorptionSpectrum : xanes_spectrum
+    Permittivity *-- Frequency : frequencies
+    SpectralProfile *-- Energy2 : energies
+    SpectralProfile *-- Energy2 : frequencies
+    XASSpectrum *-- AbsorptionSpectrum : exafs_spectrum
+    XASSpectrum *-- AbsorptionSpectrum : xanes_spectrum
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/spectroscopy.diagram.md
+++ b/docs/schema/spectroscopy.diagram.md
@@ -34,8 +34,8 @@ classDiagram
     XASSpectrum --> AbsorptionSpectrum : xanes_spectrum
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/spectroscopy.diagram.md
+++ b/docs/schema/spectroscopy.diagram.md
@@ -36,7 +36,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/spectroscopy.diagram.md
+++ b/docs/schema/spectroscopy.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -34,3 +33,11 @@ classDiagram
     XASSpectrum --> AbsorptionSpectrum : exafs_spectrum
     XASSpectrum --> AbsorptionSpectrum : xanes_spectrum
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/spectroscopy.md
+++ b/docs/schema/spectroscopy.md
@@ -32,8 +32,8 @@ classDiagram
     XASSpectrum --> AbsorptionSpectrum : xanes_spectrum
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/spectroscopy.md
+++ b/docs/schema/spectroscopy.md
@@ -34,7 +34,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/spectroscopy.md
+++ b/docs/schema/spectroscopy.md
@@ -13,6 +13,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class AbsorptionSpectrum
@@ -30,10 +32,13 @@ classDiagram
     XASSpectrum --> AbsorptionSpectrum : xanes_spectrum
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/spectroscopy.md
+++ b/docs/schema/spectroscopy.md
@@ -25,17 +25,17 @@ classDiagram
     class XASSpectrum
     SpectralProfile <|-- AbsorptionSpectrum
     AbsorptionSpectrum <|-- XASSpectrum
-    Permittivity --> Frequency : frequencies
-    SpectralProfile --> Energy2 : energies
-    SpectralProfile --> Energy2 : frequencies
-    XASSpectrum --> AbsorptionSpectrum : exafs_spectrum
-    XASSpectrum --> AbsorptionSpectrum : xanes_spectrum
+    Permittivity *-- Frequency : frequencies
+    SpectralProfile *-- Energy2 : energies
+    SpectralProfile *-- Energy2 : frequencies
+    XASSpectrum *-- AbsorptionSpectrum : exafs_spectrum
+    XASSpectrum *-- AbsorptionSpectrum : xanes_spectrum
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/symmetry.diagram.md
+++ b/docs/schema/symmetry.diagram.md
@@ -27,7 +27,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/symmetry.diagram.md
+++ b/docs/schema/symmetry.diagram.md
@@ -25,8 +25,8 @@ classDiagram
     LocalSymmetry <|-- LocalCrystalSymmetry
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 </div>
 

--- a/docs/schema/symmetry.diagram.md
+++ b/docs/schema/symmetry.diagram.md
@@ -9,7 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -24,3 +24,10 @@ classDiagram
     GlobalSymmetry <|-- GlobalCrystalSymmetry
     LocalSymmetry <|-- LocalCrystalSymmetry
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+</div>
+
+</div>

--- a/docs/schema/symmetry.diagram.md
+++ b/docs/schema/symmetry.diagram.md
@@ -27,7 +27,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/symmetry.md
+++ b/docs/schema/symmetry.md
@@ -28,7 +28,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/symmetry.md
+++ b/docs/schema/symmetry.md
@@ -28,7 +28,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/symmetry.md
+++ b/docs/schema/symmetry.md
@@ -14,6 +14,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class GlobalCrystalSymmetry
@@ -24,9 +26,12 @@ classDiagram
     LocalSymmetry <|-- LocalCrystalSymmetry
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/symmetry.md
+++ b/docs/schema/symmetry.md
@@ -26,8 +26,8 @@ classDiagram
     LocalSymmetry <|-- LocalCrystalSymmetry
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 </div>
 

--- a/docs/schema/thermodynamics.diagram.md
+++ b/docs/schema/thermodynamics.diagram.md
@@ -71,8 +71,8 @@ classDiagram
     TotalForce --> BaseForce : contributions
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/thermodynamics.diagram.md
+++ b/docs/schema/thermodynamics.diagram.md
@@ -73,7 +73,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/thermodynamics.diagram.md
+++ b/docs/schema/thermodynamics.diagram.md
@@ -67,14 +67,14 @@ classDiagram
     BaseForce <|-- TotalForce
     BaseEnergy <|-- VirialTensor
     BaseEnergy <|-- Work
-    TotalEnergy --> BaseEnergy : contributions
-    TotalForce --> BaseForce : contributions
+    TotalEnergy *-- BaseEnergy : contributions
+    TotalForce *-- BaseForce : contributions
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/schema/thermodynamics.diagram.md
+++ b/docs/schema/thermodynamics.diagram.md
@@ -9,8 +9,7 @@
 
 This diagram shows the relationships between schema classes:
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+<div class="uml-diagram-card" markdown="1">
 
 ```mermaid
 classDiagram
@@ -71,3 +70,11 @@ classDiagram
     TotalEnergy --> BaseEnergy : contributions
     TotalForce --> BaseForce : contributions
 ```
+
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
+
+</div>

--- a/docs/schema/thermodynamics.md
+++ b/docs/schema/thermodynamics.md
@@ -59,7 +59,7 @@ classDiagram
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/></svg><span>inheritance (is-a)</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 

--- a/docs/schema/thermodynamics.md
+++ b/docs/schema/thermodynamics.md
@@ -16,6 +16,8 @@
 ## Relationship map
 
 
+<div class="uml-diagram-card" markdown="1">
+
 ```mermaid
 classDiagram
     class BaseEnergy
@@ -55,10 +57,13 @@ classDiagram
     TotalForce --> BaseForce : contributions
 ```
 
-**Legend**
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
+<p class="uml-legend__title">Legend</p>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+</div>
 
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/></svg><code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)</div>
-<div style="display:flex; align-items:center; gap:8px; margin:3px 0;"><svg width="56" height="16" aria-hidden="true"><line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/><polygon points="46,8 38,4 38,12" fill="currentColor"/></svg><code>Owner --&gt; SubSection</code> containment/subsection</div>
+</div>
 
 
 ## Key sections

--- a/docs/schema/thermodynamics.md
+++ b/docs/schema/thermodynamics.md
@@ -57,8 +57,8 @@ classDiagram
     TotalForce --> BaseForce : contributions
 ```
 
-<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <p class="uml-legend__title">Legend</p>
+<div class="uml-legend" role="list" aria-label="Diagram relationship legend">
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
 <div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
 </div>

--- a/docs/schema/thermodynamics.md
+++ b/docs/schema/thermodynamics.md
@@ -53,14 +53,14 @@ classDiagram
     BaseForce <|-- TotalForce
     BaseEnergy <|-- VirialTensor
     BaseEnergy <|-- Work
-    TotalEnergy --> BaseEnergy : contributions
-    TotalForce --> BaseForce : contributions
+    TotalEnergy *-- BaseEnergy : contributions
+    TotalForce *-- BaseForce : contributions
 ```
 
 <p class="uml-legend__title">Legend</p>
 <div class="uml-legend" role="list" aria-label="Diagram relationship legend">
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/><path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/></svg><span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span></div>
-<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/></svg><span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/><path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/></svg><span>inheritance (is-a)</span></div>
+<div class="uml-legend__item" role="listitem"><svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true"><path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/><line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/></svg><span>composition (has-a)</span></div>
 </div>
 
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -146,6 +146,23 @@
 }
 
 /* Mermaid + panzoom: keep wide diagrams readable on page */
+.md-typeset .uml-diagram-card {
+    margin: 1.25rem 0;
+    padding: 0.75rem 0.875rem 0.875rem;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 0.75rem;
+    background: var(--md-default-bg-color);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.md-typeset .uml-diagram-card .mermaid {
+    margin: 0;
+    padding: 0.25rem 0 0.5rem;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+
 .md-typeset .mermaid {
     max-width: 100%;
     overflow-x: auto;
@@ -166,8 +183,67 @@
     margin: 0 auto;
 }
 
+.md-typeset .uml-legend {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset .uml-legend__title {
+    margin: 0 0 0.5rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .uml-legend__item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0.35rem 0;
+}
+
+.md-typeset .uml-legend__item code {
+    white-space: nowrap;
+}
+
+.md-typeset .uml-legend__swatch {
+    flex: 0 0 4rem;
+    width: 4rem;
+    height: 1.125rem;
+    overflow: visible;
+    color: var(--md-default-fg-color);
+}
+
+.md-typeset .uml-legend__line,
+.md-typeset .uml-legend__head {
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vector-effect: non-scaling-stroke;
+}
+
+.md-typeset .uml-legend__line--dashed {
+    stroke-dasharray: 4 3;
+}
+
+.md-typeset .uml-legend__head--open {
+    fill: none;
+}
+
+.md-typeset .uml-legend__head--filled {
+    fill: currentColor;
+}
+
 /* Preserve usable viewport on smaller screens */
 @media screen and (max-width: 76.1875em) {
+    .md-typeset .uml-diagram-card {
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
     .md-typeset .mermaid {
         min-height: clamp(220px, 52vw, 420px);
     }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -238,6 +238,19 @@
     fill: currentColor;
 }
 
+/* Mermaid namespaces class-diagram inheritance markers like
+   classDiagram-extensionStart/End. Force a hollow triangle to match UML. */
+.md-typeset .mermaid svg marker.extension,
+.md-typeset .mermaid svg marker[id$="extensionStart"],
+.md-typeset .mermaid svg marker[id$="extensionEnd"],
+.md-typeset .mermaid svg marker.extension path,
+.md-typeset .mermaid svg marker[id$="extensionStart"] path,
+.md-typeset .mermaid svg marker[id$="extensionEnd"] path {
+    fill: var(--md-default-bg-color) !important;
+    stroke: currentColor !important;
+    stroke-width: 1.8px !important;
+}
+
 /* Preserve usable viewport on smaller screens */
 @media screen and (max-width: 76.1875em) {
     .md-typeset .uml-diagram-card {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ extra_javascript:
   - 'https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js'
   - 'https://unpkg.com/cytoscape@3.19.1/dist/cytoscape.min.js'
   - 'https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js'
+  - assets/mermaid-uml-markers.js
   #   - assets/click-zoom.js  # Disabled: using panzoom plugin
   #   - assets/svg-pan-zoom-diagram.js  # Disabled: using panzoom plugin
   # - assets/code/parse.js

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -404,10 +404,10 @@ Checks:
 
 Three types of relationships are tracked:
 
-1. **Containment** (`-->` solid arrow)
+1. **Containment** (`*--` filled diamond)
    - SubSection relationships
-   - Example: `ModelSystem --> Cell`
-   - Represents "has-a" relationships
+   - Example: `ModelSystem *-- Cell`
+   - Represents composition / "contains-a" relationships
 
 2. **Reference** (`..>` dashed arrow)
    - Quantity type references
@@ -435,7 +435,7 @@ Each diagram includes an inline SVG legend:
 ```html
 <svg width="60" height="30">
   <line/><polygon fill="none"/> <!-- Inheritance: open triangle -->
-  <line/><polygon fill="currentColor"/> <!-- Containment: filled triangle -->
+  <polygon fill="currentColor"/><line/> <!-- Containment: filled diamond -->
   <line stroke-dasharray="4,4"/><polygon/> <!-- Reference: dashed + filled -->
 </svg>
 ```

--- a/scripts/diagram_legend.py
+++ b/scripts/diagram_legend.py
@@ -11,10 +11,10 @@ def build_relation_legend(
         items.append(
             '<div class="uml-legend__item" role="listitem">'
             '<svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true">'
-            '<line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/>'
-            '<path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/>'
+            '<line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/>'
+            '<path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/>'
             '</svg>'
-            '<span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span>'
+            '<span>inheritance (is-a)</span>'
             '</div>'
         )
 
@@ -22,10 +22,10 @@ def build_relation_legend(
         items.append(
             '<div class="uml-legend__item" role="listitem">'
             '<svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true">'
-            '<line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/>'
-            '<path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/>'
+            '<path class="uml-legend__head uml-legend__head--filled" d="M10 8 L16 2 L22 8 L16 14 Z"/>'
+            '<line class="uml-legend__line" x1="22" y1="8" x2="52" y2="8"/>'
             '</svg>'
-            '<span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span>'
+            '<span>composition (has-a)</span>'
             '</div>'
         )
 

--- a/scripts/diagram_legend.py
+++ b/scripts/diagram_legend.py
@@ -11,8 +11,8 @@ def build_relation_legend(
         items.append(
             '<div class="uml-legend__item" role="listitem">'
             '<svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true">'
-            '<line class="uml-legend__line" x1="54" y1="8" x2="28" y2="8"/>'
-            '<path class="uml-legend__head uml-legend__head--open" d="M18 8 L30 2 L30 14 Z"/>'
+            '<line class="uml-legend__line" x1="54" y1="8" x2="22" y2="8"/>'
+            '<path class="uml-legend__head uml-legend__head--open" d="M10 8 L22 2 L22 14 Z"/>'
             '</svg>'
             '<span>inheritance (is-a)</span>'
             '</div>'

--- a/scripts/diagram_legend.py
+++ b/scripts/diagram_legend.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+
+def build_relation_legend(
+    *, has_inherit: bool, has_contain: bool, has_refs: bool
+) -> list[str]:
+    """Return HTML legend items that visually track Mermaid relationship arrows."""
+    items: list[str] = []
+
+    if has_inherit:
+        items.append(
+            '<div class="uml-legend__item" role="listitem">'
+            '<svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true">'
+            '<line class="uml-legend__line" x1="50" y1="8" x2="22" y2="8"/>'
+            '<path class="uml-legend__head uml-legend__head--filled" d="M22 8 L32 3 L32 13 Z"/>'
+            '</svg>'
+            '<span><code>Parent &lt;|-- Child</code> is-a relationship, Parent-Child inheritance</span>'
+            '</div>'
+        )
+
+    if has_contain:
+        items.append(
+            '<div class="uml-legend__item" role="listitem">'
+            '<svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true">'
+            '<line class="uml-legend__line" x1="8" y1="8" x2="40" y2="8"/>'
+            '<path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/>'
+            '</svg>'
+            '<span><code>Owner --&gt; SubSection</code> has-a relationship, Owner-SubSection composition</span>'
+            '</div>'
+        )
+
+    if has_refs:
+        items.append(
+            '<div class="uml-legend__item" role="listitem">'
+            '<svg class="uml-legend__swatch" viewBox="0 0 64 16" aria-hidden="true">'
+            '<line class="uml-legend__line uml-legend__line--dashed" x1="8" y1="8" x2="40" y2="8"/>'
+            '<path class="uml-legend__head uml-legend__head--open" d="M40 8 L48 4 M40 8 L48 12"/>'
+            '</svg>'
+            '<span><code>A ..&gt; B</code> references relationship, A depends on B</span>'
+            '</div>'
+        )
+
+    return items
+
+
+def wrap_diagram_card(
+    diagram_lines: list[str], legend_items: list[str] | None = None
+) -> list[str]:
+    """Wrap Mermaid markdown and an optional HTML legend in one visual card."""
+    lines = ['<div class="uml-diagram-card" markdown="1">', '']
+    lines.extend(diagram_lines)
+
+    if legend_items:
+        lines.extend(
+            [
+                '',
+                '<div class="uml-legend" role="list" aria-label="Diagram relationship legend">',
+                '<p class="uml-legend__title">Legend</p>',
+            ]
+        )
+        lines.extend(legend_items)
+        lines.append('</div>')
+
+    lines.extend(['', '</div>'])
+    return lines

--- a/scripts/diagram_legend.py
+++ b/scripts/diagram_legend.py
@@ -54,8 +54,8 @@ def wrap_diagram_card(
         lines.extend(
             [
                 '',
-                '<div class="uml-legend" role="list" aria-label="Diagram relationship legend">',
                 '<p class="uml-legend__title">Legend</p>',
+                '<div class="uml-legend" role="list" aria-label="Diagram relationship legend">',
             ]
         )
         lines.extend(legend_items)

--- a/scripts/gen_diagrams.py
+++ b/scripts/gen_diagrams.py
@@ -437,9 +437,9 @@ def mermaid_for_vertical(
             if a in diagram_nodes and b in diagram_nodes:
                 clean_label = normalize_label(label, b)
                 if clean_label:
-                    diagram_lines.append(f'    {a} --> {b} : {clean_label}')
+                    diagram_lines.append(f'    {a} *-- {b} : {clean_label}')
                 else:
-                    diagram_lines.append(f'    {a} --> {b}')
+                    diagram_lines.append(f'    {a} *-- {b}')
 
         # Add reference edges
         for a, b, label in filtered_edges.get('refs', []):

--- a/scripts/gen_diagrams.py
+++ b/scripts/gen_diagrams.py
@@ -36,6 +36,8 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 
+from diagram_legend import build_relation_legend, wrap_diagram_card
+
 try:
     from verticals import VERTICALS
 except Exception as e:
@@ -365,37 +367,11 @@ def mermaid_for_vertical(
         for a, b, _ in filtered_edges.get('refs', [])
     )
 
-    legend_items = []
-    if has_inherit:
-        legend_items.append(
-            '<div style="display:flex; align-items:center; gap:8px; margin:3px 0;">'
-            '<svg width="56" height="16" aria-hidden="true">'
-            '<line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/>'
-            '<polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/>'
-            '</svg>'
-            '<code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)'
-            '</div>'
-        )
-    if has_contain:
-        legend_items.append(
-            '<div style="display:flex; align-items:center; gap:8px; margin:3px 0;">'
-            '<svg width="56" height="16" aria-hidden="true">'
-            '<line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/>'
-            '<polygon points="46,8 38,4 38,12" fill="currentColor"/>'
-            '</svg>'
-            '<code>Owner --&gt; SubSection</code> containment/subsection'
-            '</div>'
-        )
-    if has_refs:
-        legend_items.append(
-            '<div style="display:flex; align-items:center; gap:8px; margin:3px 0;">'
-            '<svg width="56" height="16" aria-hidden="true">'
-            '<line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8" stroke-dasharray="4 3"/>'
-            '<polygon points="46,8 38,4 38,12" fill="currentColor"/>'
-            '</svg>'
-            '<code>A ..&gt; B</code> dependency/reference'
-            '</div>'
-        )
+    legend_items = build_relation_legend(
+        has_inherit=has_inherit,
+        has_contain=has_contain,
+        has_refs=has_refs,
+    )
 
     lines = []
     if add_header:
@@ -414,8 +390,6 @@ def mermaid_for_vertical(
                 '',
             ]
         )
-        lines.extend(legend_items)
-        lines.append('')
 
     # Generate diagram(s)
     for diagram_idx, diagram_nodes in enumerate(diagram_node_sets):
@@ -431,12 +405,12 @@ def mermaid_for_vertical(
                     ]
                 )
 
-        lines.extend(['```mermaid', 'classDiagram'])
+        diagram_lines = ['```mermaid', 'classDiagram']
 
         # Define classes
         for n in sorted(diagram_nodes):
-            lines.append(f'    class {n} {{')
-            lines.append('    }')
+            diagram_lines.append(f'    class {n} {{')
+            diagram_lines.append('    }')
 
         # Helper function to normalize labels
         def normalize_label(label: str, target: str) -> str:
@@ -454,7 +428,7 @@ def mermaid_for_vertical(
         # Add inheritance edges first (most important for understanding)
         for a, b, _ in filtered_edges.get('inherit', []):
             if a in diagram_nodes and b in diagram_nodes:
-                lines.append(f'    {b} <|-- {a}')
+                diagram_lines.append(f'    {b} <|-- {a}')
 
         # Add containment edges
         for a, b, label in filtered_edges.get('contain', []):
@@ -463,9 +437,9 @@ def mermaid_for_vertical(
             if a in diagram_nodes and b in diagram_nodes:
                 clean_label = normalize_label(label, b)
                 if clean_label:
-                    lines.append(f'    {a} --> {b} : {clean_label}')
+                    diagram_lines.append(f'    {a} --> {b} : {clean_label}')
                 else:
-                    lines.append(f'    {a} --> {b}')
+                    diagram_lines.append(f'    {a} --> {b}')
 
         # Add reference edges
         for a, b, label in filtered_edges.get('refs', []):
@@ -474,23 +448,19 @@ def mermaid_for_vertical(
             if a in diagram_nodes and b in diagram_nodes:
                 clean_label = normalize_label(label, b)
                 if clean_label:
-                    lines.append(f'    {a} ..> {b} : {clean_label}')
+                    diagram_lines.append(f'    {a} ..> {b} : {clean_label}')
                 else:
-                    lines.append(f'    {a} ..> {b}')
+                    diagram_lines.append(f'    {a} ..> {b}')
 
-        lines.append('```')
-
-        # Add notation legend (only after last diagram, and only when header is absent).
-        if diagram_idx == len(diagram_node_sets) - 1 and not add_header:
-            lines.extend(
-                [
-                    '',
-                    '**Legend**',
-                    '',
-                ]
+        diagram_lines.append('```')
+        include_legend = diagram_idx == len(diagram_node_sets) - 1
+        lines.extend(
+            wrap_diagram_card(
+                diagram_lines,
+                legend_items if include_legend else None,
             )
-            lines.extend(legend_items)
-            lines.append('')
+        )
+        lines.append('')
 
     return '\n'.join(lines)
 

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -13,6 +13,7 @@ import yaml
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 
+from diagram_legend import build_relation_legend, wrap_diagram_card
 from gen_diagrams import filter_edges_for_vertical
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from meta_introspect import collect_edges, iter_section_classes
@@ -351,44 +352,14 @@ def mermaid_for_vertical(
             has_refs = True
 
     lines.append('```')
-    # Wrap with blank lines (very important for Markdown parsing)
-    diagram = '\n' + '\n'.join(lines) + '\n'
-    # Use relation-aware legend to match arrow types actually present.
-    legend_items = []
-    if has_inherit:
-        legend_items.append(
-            '<div style="display:flex; align-items:center; gap:8px; margin:3px 0;">'
-            '<svg width="56" height="16" aria-hidden="true">'
-            '<line x1="48" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.8"/>'
-            '<polygon points="18,8 26,4 26,12" fill="white" stroke="currentColor" stroke-width="1.8"/>'
-            '</svg>'
-            '<code>Parent &lt;|-- Child</code> inheritance (Child extends Parent)'
-            '</div>'
-        )
-    if has_contain:
-        legend_items.append(
-            '<div style="display:flex; align-items:center; gap:8px; margin:3px 0;">'
-            '<svg width="56" height="16" aria-hidden="true">'
-            '<line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8"/>'
-            '<polygon points="46,8 38,4 38,12" fill="currentColor"/>'
-            '</svg>'
-            '<code>Owner --&gt; SubSection</code> containment/subsection'
-            '</div>'
-        )
-    if has_refs:
-        legend_items.append(
-            '<div style="display:flex; align-items:center; gap:8px; margin:3px 0;">'
-            '<svg width="56" height="16" aria-hidden="true">'
-            '<line x1="8" y1="8" x2="38" y2="8" stroke="currentColor" stroke-width="1.8" stroke-dasharray="4 3"/>'
-            '<polygon points="46,8 38,4 38,12" fill="currentColor"/>'
-            '</svg>'
-            '<code>A ..&gt; B</code> dependency/reference'
-            '</div>'
-        )
 
-    if legend_items:
-        diagram += '\n**Legend**\n\n' + '\n'.join(legend_items) + '\n'
-    return diagram
+    legend_items = build_relation_legend(
+        has_inherit=has_inherit,
+        has_contain=has_contain,
+        has_refs=has_refs,
+    )
+    diagram_lines = wrap_diagram_card(lines, legend_items)
+    return '\n' + '\n'.join(diagram_lines) + '\n'
 
 
 # ---- main generation --------------------------------------------------------

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -340,7 +340,7 @@ def mermaid_for_vertical(
         if a == b:
             continue
         if a in nodes and b in nodes:
-            lines.append(f'    {a} --> {b} : {label}')
+            lines.append(f'    {a} *-- {b} : {label}')
             has_contain = True
 
     # Add reference edges


### PR DESCRIPTION
## Purpose

Align the Mermaid legend with the diagram styling actually rendered in MkDocs, and make the legend text clearer about the relationship semantics.

## Scope

**Included**

- Update legend arrow glyphs to match the current Mermaid rendering
- Replace the old legend wording with clearer relationship descriptions
- Centralize legend generation in a shared helper
- Regenerate schema docs so the updated legend appears consistently across pages

**Out of scope**

- Changing Mermaid’s actual UML rendering behavior
- Replacing Mermaid with another UML tool
- Broader schema-doc layout/design changes

## Context & Links

- closes #327 

## Reviewer Notes

- The key change is in `scripts/diagram_legend.py`; generated files under `docs/schema/*.md` were updated from that source
- Legend wording now uses:
  - `is-a relationship, Parent-Child inheritance`
  - `has-a relationship, Owner-SubSection composition`

please let me know what should we write there

- This PR intentionally matches current Mermaid output rather than enforcing strict UML notation

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] None (explain):



