### PR TITLE
implement Broken symmetry density functional theory

### DIFF
--- a/docs/snippets/model_method/bs_dft_example.py
+++ b/docs/snippets/model_method/bs_dft_example.py
@@ -1,0 +1,20 @@
+# docs-snippet: runnable
+from nomad_simulations.schema_packages.atoms_state import AtomsState
+from nomad_simulations.schema_packages.model_method import BSDFT, BrokenSymmetryCenter
+
+
+def build_bs_dft_example() -> tuple[object, BSDFT]:
+    """Create a plain DFT-like high-spin reference context and a BSDFT method."""
+    fe1 = AtomsState(chemical_symbol='Fe', label='Fe1')
+    fe2 = AtomsState(chemical_symbol='Fe', label='Fe2')
+
+    method = BSDFT(
+        determinant='unrestricted',
+        is_spin_polarized=True,
+        total_spin_projection=0,
+    )
+    method.spin_centers = [
+        BrokenSymmetryCenter(atom_ref=fe1, spin_sign='up', label='site_a'),
+        BrokenSymmetryCenter(atom_ref=fe2, spin_sign='down', label='site_b'),
+    ]
+    return fe1, method

--- a/docs/snippets/model_method/bs_dft_example.py
+++ b/docs/snippets/model_method/bs_dft_example.py
@@ -1,5 +1,8 @@
 # docs-snippet: runnable
-from nomad_simulations.schema_packages.atoms_state import AtomsState
+from nomad_simulations.schema_packages.atoms_state import (
+    AtomsState,
+    SphericalSymmetryState,
+)
 from nomad_simulations.schema_packages.model_method import BSDFT, BrokenSymmetryCenter
 
 
@@ -14,7 +17,15 @@ def build_bs_dft_example() -> tuple[object, BSDFT]:
         total_spin_projection=0,
     )
     method.spin_centers = [
-        BrokenSymmetryCenter(atom_ref=fe1, spin_sign='up', label='site_a'),
-        BrokenSymmetryCenter(atom_ref=fe2, spin_sign='down', label='site_b'),
+        BrokenSymmetryCenter(
+            atom_ref=fe1,
+            spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
+            label='site_a',
+        ),
+        BrokenSymmetryCenter(
+            atom_ref=fe2,
+            spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
+            label='site_b',
+        ),
     ]
     return fe1, method

--- a/docs/snippets/model_method/bs_dft_example.py
+++ b/docs/snippets/model_method/bs_dft_example.py
@@ -12,8 +12,8 @@ def build_bs_dft_example() -> tuple[object, BSDFT]:
     fe2 = AtomsState(chemical_symbol='Fe', label='Fe2')
 
     method = BSDFT(
-        determinant='unrestricted',
-        is_spin_polarized=True,
+        determinant='unrestricted',  # required for consistency check
+        is_spin_polarized=True,  # required for consistency check
         total_spin_projection=0,
     )
     method.spin_centers = [

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
     from nomad.datamodel.datamodel import EntryArchive
     from structlog.stdlib import BoundLogger
 
-from nomad_simulations.schema_packages.atoms_state import CoreHole, ElectronicState
+from nomad_simulations.schema_packages.atoms_state import (
+    AtomsState,
+    CoreHole,
+    ElectronicState,
+)
 from nomad_simulations.schema_packages.data_types import (
     positive_float,
     positive_int,
@@ -761,6 +765,88 @@ class DFT(ModelMethodElectronic):
             self.jacobs_ladder = hinted
         else:
             self.jacobs_ladder = self.jacobs_ladder or 'unavailable'
+
+
+class BrokenSymmetryCenter(ArchiveSection):
+    """
+    Atom-centered local spin assignment used to describe a broken-symmetry DFT determinant.
+    """
+
+    atom_ref = Quantity(
+        type=Reference(AtomsState),
+        description="""
+        Reference to the atom/site participating in the broken-symmetry assignment.
+        """,
+    )
+
+    spin_sign = Quantity(
+        type=MEnum('up', 'down'),
+        description="""
+        Intended local spin sign assigned to the spin center in the broken-symmetry determinant.
+        """,
+    )
+
+    label = Quantity(
+        type=str,
+        description="""
+        Optional code- or parser-specific identifier for the spin center.
+        """,
+    )
+
+
+class BSDFT(DFT):
+    """
+    Broken-symmetry density functional theory calculation.
+
+    This class specializes a DFT calculation to represent a symmetry-broken,
+    collinear, unrestricted determinant without linking to the high-spin
+    reference. Workflow-level orchestration is handled separately.
+    """
+
+    spin_centers = SubSection(
+        sub_section=BrokenSymmetryCenter.m_def,
+        repeats=True,
+        description="""
+        Atom-centered local spin assignments defining the broken-symmetry pattern.
+        """,
+    )
+
+    total_spin_projection = Quantity(
+        type=np.int32,
+        description="""
+        Total spin projection M_S of the broken-symmetry determinant, stored in doubled
+        form to preserve half-integer values (e.g. M_S = 1/2 is stored as 1).
+        This is not the total spin quantum number S of a spin eigenstate.
+        """,
+    )
+
+    def _validate_spin_centers(self, logger: 'BoundLogger') -> bool:
+        spin_centers = self.spin_centers or []
+
+        if len(spin_centers) < 2:
+            logger.warning(
+                'BSDFT requires at least two spin_centers to define a broken-symmetry assignment.'
+            )
+            return False
+
+        signs = {center.spin_sign for center in spin_centers if center.spin_sign}
+        if 'up' not in signs or 'down' not in signs:
+            logger.warning('BSDFT requires at least one up and one down spin center.')
+            return False
+        return True
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+        self.name = 'BSDFT'
+
+        if self.determinant != 'unrestricted':
+            logger.warning('BSDFT requires determinant to be unrestricted.')
+
+        if self.is_spin_polarized is not True:
+            logger.warning('BSDFT requires is_spin_polarized to be True.')
+
+        self._validate_spin_centers(logger)
 
 
 class TB(ModelMethodElectronic):

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -822,6 +822,13 @@ class BSDFT(DFT):
     This class specializes a DFT calculation to represent a symmetry-broken,
     collinear, unrestricted determinant without linking to the high-spin
     reference. Workflow-level orchestration is handled separately.
+
+    References
+    ----------
+    • L. Noodleman, J. Chem. Phys. 74, 5737 (1981) - broken-symmetry description
+      of antiferromagnetic coupling in transition-metal dimers
+    • S. Yamanaka and K. Yamaguchi, Bull. Chem. Soc. Jpn. 77, 1269 (2004) -
+      extended DFT review of the broken-symmetry approach for strongly correlated systems
     """
 
     spin_centers = SubSection(

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -23,6 +23,7 @@ from nomad_simulations.schema_packages.atoms_state import (
     BaseSpinOrbitalState,
     CoreHole,
     ElectronicState,
+    SphericalSymmetryState,
 )
 from nomad_simulations.schema_packages.data_types import (
     positive_float,
@@ -801,8 +802,10 @@ class BrokenSymmetryCenter(ArchiveSection):
         """
         if self.spin_state is None:
             return None
+        if not isinstance(self.spin_state, SphericalSymmetryState):
+            return None
 
-        ms_quantum_number = getattr(self.spin_state, 'ms_quantum_number', None)
+        ms_quantum_number = self.spin_state.ms_quantum_number
         if ms_quantum_number is None:
             return None
         if ms_quantum_number > 0:

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -860,7 +860,8 @@ class BSDFT(DFT):
         signs = {center.resolve_spin_sign() for center in spin_centers}
         if None in signs:
             logger.warning(
-                'BSDFT spin_centers require spin_state with a non-zero ms_quantum_number.'
+                'BSDFT spin_centers must provide a resolvable spin sign (e.g. via a '
+                'SphericalSymmetryState spin_state with non-zero ms_quantum_number).'
             )
             return False
         if 'up' not in signs or 'down' not in signs:

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 from nomad_simulations.schema_packages.atoms_state import (
     AtomsState,
+    BaseSpinOrbitalState,
     CoreHole,
     ElectronicState,
 )
@@ -779,10 +780,11 @@ class BrokenSymmetryCenter(ArchiveSection):
         """,
     )
 
-    spin_sign = Quantity(
-        type=MEnum('up', 'down'),
+    spin_state = SubSection(
+        section_def=BaseSpinOrbitalState.m_def,
         description="""
-        Intended local spin sign assigned to the spin center in the broken-symmetry determinant.
+        Local spin-state descriptor for this spin center. For collinear BSDFT this is
+        typically a `SphericalSymmetryState` carrying `ms_quantum_number = +/- 0.5`.
         """,
     )
 
@@ -792,6 +794,22 @@ class BrokenSymmetryCenter(ArchiveSection):
         Optional code- or parser-specific identifier for the spin center.
         """,
     )
+
+    def resolve_spin_sign(self) -> str | None:
+        """
+        Resolve the local spin sign from the nested spin state.
+        """
+        if self.spin_state is None:
+            return None
+
+        ms_quantum_number = getattr(self.spin_state, 'ms_quantum_number', None)
+        if ms_quantum_number is None:
+            return None
+        if ms_quantum_number > 0:
+            return 'up'
+        if ms_quantum_number < 0:
+            return 'down'
+        return None
 
 
 class BSDFT(DFT):
@@ -829,7 +847,12 @@ class BSDFT(DFT):
             )
             return False
 
-        signs = {center.spin_sign for center in spin_centers if center.spin_sign}
+        signs = {center.resolve_spin_sign() for center in spin_centers}
+        if None in signs:
+            logger.warning(
+                'BSDFT spin_centers require spin_state with a non-zero ms_quantum_number.'
+            )
+            return False
         if 'up' not in signs or 'down' not in signs:
             logger.warning('BSDFT requires at least one up and one down spin center.')
             return False

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -821,7 +821,9 @@ class BSDFT(DFT):
 
     This class specializes a DFT calculation to represent a symmetry-broken,
     collinear, unrestricted determinant without linking to the high-spin
-    reference. Workflow-level orchestration is handled separately.
+    reference. Workflow-level orchestration is handled separately. Consistency
+    checks require `determinant='unrestricted'`, `is_spin_polarized=True`, and
+    `spin_centers` containing at least one up and one down local spin assignment.
 
     References
     ----------
@@ -849,19 +851,22 @@ class BSDFT(DFT):
     )
 
     def _validate_spin_centers(self, logger: 'BoundLogger') -> bool:
+        """
+        Validate that `spin_centers` define a mixed-sign broken-symmetry assignment.
+        """
         spin_centers = self.spin_centers or []
 
         if len(spin_centers) < 2:
             logger.warning(
-                'BSDFT requires at least two spin_centers to define a broken-symmetry assignment.'
+                'BSDFT requires at least two `spin_centers` to define a broken-symmetry assignment.'
             )
             return False
 
         signs = {center.resolve_spin_sign() for center in spin_centers}
         if None in signs:
             logger.warning(
-                'BSDFT spin_centers must provide a resolvable spin sign (e.g. via a '
-                'SphericalSymmetryState spin_state with non-zero ms_quantum_number).'
+                'BSDFT `spin_centers` must provide a resolvable spin sign (e.g. via a '
+                '`SphericalSymmetryState` `spin_state` with non-zero `ms_quantum_number`).'
             )
             return False
         if 'up' not in signs or 'down' not in signs:
@@ -875,10 +880,10 @@ class BSDFT(DFT):
         self.name = 'BSDFT'
 
         if self.determinant != 'unrestricted':
-            logger.warning('BSDFT requires determinant to be unrestricted.')
+            logger.warning('BSDFT requires `determinant` to be `unrestricted`.')
 
         if self.is_spin_polarized is not True:
-            logger.warning('BSDFT requires is_spin_polarized to be True.')
+            logger.warning('BSDFT requires `is_spin_polarized` to be `True`.')
 
         self._validate_spin_centers(logger)
 

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from nomad.datamodel import EntryArchive
 
 from docs.snippets.data_types import error_handling as error_handling_module
 from docs.snippets.data_types.basic_usage import build_valid_section
@@ -17,6 +18,7 @@ from docs.snippets.data_types.standalone_type_roundtrip import (
 )
 from docs.snippets.data_types.validation_behavior import demo_validation_behavior
 from docs.snippets.explanation.general.block_01 import SUPERCODEParser
+from docs.snippets.model_method.bs_dft_example import build_bs_dft_example
 from docs.snippets.model_method.model_method_overview_example import (
     build_model_method_overview_example,
 )
@@ -29,6 +31,8 @@ from docs.snippets.model_system.minimal_parser_pattern import (
 from docs.snippets.simulation_entry.program_setup import (
     build_simulation_with_program,
 )
+
+from . import logger as test_logger
 
 SNIPPETS_ROOT = Path('docs/snippets')
 DOCS_ROOT = Path('docs')
@@ -45,6 +49,7 @@ EXECUTED_SNIPPETS = {
     'snippets/data_types/validation_behavior.py',
     'snippets/model_system/alternative_representation_pattern.py',
     'snippets/model_method/model_method_overview_example.py',
+    'snippets/model_method/bs_dft_example.py',
     'snippets/model_system/minimal_parser_pattern.py',
     'snippets/simulation_entry/program_setup.py',
     'snippets/explanation/general/block_01.py',
@@ -182,6 +187,17 @@ def test_model_method_overview_example():
     assert method.numerical_settings is not None
     assert len(method.numerical_settings) == 1
     assert method.numerical_settings[0].n_max_iterations == 80
+
+
+def test_bs_dft_example():
+    _, method = build_bs_dft_example()
+    method.normalize(EntryArchive(), logger=test_logger)
+    assert method.name == 'BSDFT'
+    assert method.determinant == 'unrestricted'
+    assert method.is_spin_polarized is True
+    assert method.total_spin_projection == 0
+    assert len(method.spin_centers) == 2
+    assert {center.spin_sign for center in method.spin_centers} == {'up', 'down'}
 
 
 def test_supercode_parser_parse_example(tmp_path):

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -197,7 +197,10 @@ def test_bs_dft_example():
     assert method.is_spin_polarized is True
     assert method.total_spin_projection == 0
     assert len(method.spin_centers) == 2
-    assert {center.spin_sign for center in method.spin_centers} == {'up', 'down'}
+    assert {center.resolve_spin_sign() for center in method.spin_centers} == {
+        'up',
+        'down',
+    }
 
 
 def test_supercode_parser_parse_example(tmp_path):

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -632,10 +632,12 @@ class TestBSDFT:
             xc=XCFunctional(functional_key='PBE'),
             spin_centers=[
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
                 ),
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='down'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
                 ),
             ],
         )
@@ -657,8 +659,16 @@ class TestBSDFT:
             is_spin_polarized=True,
             total_spin_projection=1,
             spin_centers=[
-                BrokenSymmetryCenter(atom_ref=site_a, spin_sign='up', label='site_a'),
-                BrokenSymmetryCenter(atom_ref=site_b, spin_sign='down', label='site_b'),
+                BrokenSymmetryCenter(
+                    atom_ref=site_a,
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
+                    label='site_a',
+                ),
+                BrokenSymmetryCenter(
+                    atom_ref=site_b,
+                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
+                    label='site_b',
+                ),
             ],
         )
 
@@ -674,10 +684,12 @@ class TestBSDFT:
             is_spin_polarized=True,
             spin_centers=[
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
                 ),
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='down'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
                 ),
             ],
         )
@@ -695,10 +707,12 @@ class TestBSDFT:
             is_spin_polarized=False,
             spin_centers=[
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
                 ),
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='down'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
                 ),
             ],
         )
@@ -716,7 +730,8 @@ class TestBSDFT:
             is_spin_polarized=True,
             spin_centers=[
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
                 )
             ],
         )
@@ -735,10 +750,12 @@ class TestBSDFT:
             is_spin_polarized=True,
             spin_centers=[
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
                 ),
                 BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
                 ),
             ],
         )
@@ -747,6 +764,30 @@ class TestBSDFT:
 
         assert any(
             entry['event'] == 'BSDFT requires at least one up and one down spin center.'
+            for entry in log_output.entries
+        )
+
+    def test_warns_when_spin_state_is_missing_or_zero(self, log_output):
+        bsdft = BSDFT(
+            determinant='unrestricted',
+            is_spin_polarized=True,
+            spin_centers=[
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=0.0),
+                ),
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'),
+                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
+                ),
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert any(
+            entry['event']
+            == 'BSDFT spin_centers require spin_state with a non-zero ms_quantum_number.'
             for entry in log_output.entries
         )
 

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -625,31 +625,19 @@ class TestDFT:
 
 
 class TestBSDFT:
-    def test_inherits_dft_normalization_behavior(self):
-        bsdft = BSDFT(
-            determinant='unrestricted',
-            is_spin_polarized=True,
-            xc=XCFunctional(functional_key='PBE'),
-            spin_centers=[
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
+    @staticmethod
+    def _spin_centers(*ms_quantum_numbers: float | None) -> list[BrokenSymmetryCenter]:
+        return [
+            BrokenSymmetryCenter(
+                atom_ref=AtomsState(chemical_symbol='Fe'),
+                spin_state=(
+                    SphericalSymmetryState(ms_quantum_number=ms_quantum_number)
+                    if ms_quantum_number is not None
+                    else None
                 ),
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
-                ),
-            ],
-        )
-
-        bsdft.normalize(EntryArchive(), logger=logger)
-
-        assert bsdft.name == 'BSDFT'
-        assert bsdft.jacobs_ladder == 'GGA'
-        assert {c.canonical_label for c in (bsdft.xc.components or [])} == {
-            'XC_GGA_X_PBE',
-            'XC_GGA_C_PBE',
-        }
+            )
+            for ms_quantum_number in ms_quantum_numbers
+        ]
 
     def test_valid_bsdft_mixed_spin_centers(self, log_output):
         site_a = AtomsState(chemical_symbol='Fe', label='Fe1')
@@ -678,119 +666,78 @@ class TestBSDFT:
         assert bsdft.total_spin_projection == 1
         assert len(log_output.entries) == 0
 
-    def test_warns_when_restricted(self, log_output):
+    @pytest.mark.parametrize(
+        'determinant, is_spin_polarized, ms_quantum_numbers, expected_event',
+        [
+            pytest.param(
+                'restricted',
+                True,
+                (0.5, -0.5),
+                'BSDFT requires `determinant` to be `unrestricted`.',
+                id='restricted-determinant',
+            ),
+            pytest.param(
+                None,
+                True,
+                (0.5, -0.5),
+                'BSDFT requires `determinant` to be `unrestricted`.',
+                id='missing-determinant',
+            ),
+            pytest.param(
+                'unrestricted',
+                False,
+                (0.5, -0.5),
+                'BSDFT requires `is_spin_polarized` to be `True`.',
+                id='non-spin-polarized',
+            ),
+            pytest.param(
+                'unrestricted',
+                None,
+                (0.5, -0.5),
+                'BSDFT requires `is_spin_polarized` to be `True`.',
+                id='missing-spin-polarization',
+            ),
+            pytest.param(
+                'unrestricted',
+                True,
+                (0.5,),
+                'BSDFT requires at least two `spin_centers` to define a broken-symmetry assignment.',
+                id='too-few-spin-centers',
+            ),
+            pytest.param(
+                'unrestricted',
+                True,
+                (0.5, 0.5),
+                'BSDFT requires at least one up and one down spin center.',
+                id='same-spin-sign',
+            ),
+            pytest.param(
+                'unrestricted',
+                True,
+                (0.0, -0.5),
+                'BSDFT `spin_centers` must provide a resolvable spin sign (e.g. via a '
+                '`SphericalSymmetryState` `spin_state` with non-zero `ms_quantum_number`).',
+                id='unresolvable-spin-sign',
+            ),
+        ],
+    )
+    def test_warns_on_invalid_bsdft_metadata(
+        self,
+        log_output,
+        determinant,
+        is_spin_polarized,
+        ms_quantum_numbers,
+        expected_event,
+    ):
         bsdft = BSDFT(
-            determinant='restricted',
-            is_spin_polarized=True,
-            spin_centers=[
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
-                ),
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
-                ),
-            ],
+            determinant=determinant,
+            is_spin_polarized=is_spin_polarized,
+            spin_centers=self._spin_centers(*ms_quantum_numbers),
         )
 
         bsdft.normalize(EntryArchive(), logger=logger)
 
-        assert any(
-            entry['event'] == 'BSDFT requires determinant to be unrestricted.'
-            for entry in log_output.entries
-        )
-
-    def test_warns_when_not_spin_polarized(self, log_output):
-        bsdft = BSDFT(
-            determinant='unrestricted',
-            is_spin_polarized=False,
-            spin_centers=[
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
-                ),
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
-                ),
-            ],
-        )
-
-        bsdft.normalize(EntryArchive(), logger=logger)
-
-        assert any(
-            entry['event'] == 'BSDFT requires is_spin_polarized to be True.'
-            for entry in log_output.entries
-        )
-
-    def test_warns_with_too_few_spin_centers(self, log_output):
-        bsdft = BSDFT(
-            determinant='unrestricted',
-            is_spin_polarized=True,
-            spin_centers=[
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
-                )
-            ],
-        )
-
-        bsdft.normalize(EntryArchive(), logger=logger)
-
-        assert any(
-            entry['event']
-            == 'BSDFT requires at least two spin_centers to define a broken-symmetry assignment.'
-            for entry in log_output.entries
-        )
-
-    def test_warns_when_spin_centers_do_not_mix_signs(self, log_output):
-        bsdft = BSDFT(
-            determinant='unrestricted',
-            is_spin_polarized=True,
-            spin_centers=[
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
-                ),
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.5),
-                ),
-            ],
-        )
-
-        bsdft.normalize(EntryArchive(), logger=logger)
-
-        assert any(
-            entry['event'] == 'BSDFT requires at least one up and one down spin center.'
-            for entry in log_output.entries
-        )
-
-    def test_warns_when_spin_state_is_missing_or_zero(self, log_output):
-        bsdft = BSDFT(
-            determinant='unrestricted',
-            is_spin_polarized=True,
-            spin_centers=[
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=0.0),
-                ),
-                BrokenSymmetryCenter(
-                    atom_ref=AtomsState(chemical_symbol='Fe'),
-                    spin_state=SphericalSymmetryState(ms_quantum_number=-0.5),
-                ),
-            ],
-        )
-
-        bsdft.normalize(EntryArchive(), logger=logger)
-
-        assert any(
-            entry['event']
-            == 'BSDFT spin_centers must provide a resolvable spin sign (e.g. via a '
-            'SphericalSymmetryState spin_state with non-zero ms_quantum_number).'
-            for entry in log_output.entries
-        )
+        assert any(entry['event'] == expected_event for entry in log_output.entries)
 
 
 def test_dft_contributions_solvation_dispersion_relativity_normalize():

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -787,7 +787,8 @@ class TestBSDFT:
 
         assert any(
             entry['event']
-            == 'BSDFT spin_centers require spin_state with a non-zero ms_quantum_number.'
+            == 'BSDFT spin_centers must provide a resolvable spin sign (e.g. via a '
+            'SphericalSymmetryState spin_state with non-zero ms_quantum_number).'
             for entry in log_output.entries
         )
 

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -7,9 +7,11 @@ from nomad_simulations.schema_packages.atoms_state import (
     SphericalSymmetryState,
 )
 from nomad_simulations.schema_packages.model_method import (
+    BSDFT,
     DFT,
     TB,
     ActiveSpace,
+    BrokenSymmetryCenter,
     EmpiricalDispersionModel,
     ImplicitSolvationModel,
     MultireferencePT,
@@ -620,6 +622,133 @@ class TestDFT:
             assert dft.xc.global_exact_exchange is None
         else:
             assert dft.xc.global_exact_exchange == pytest.approx(expected_alpha)
+
+
+class TestBSDFT:
+    def test_inherits_dft_normalization_behavior(self):
+        bsdft = BSDFT(
+            determinant='unrestricted',
+            is_spin_polarized=True,
+            xc=XCFunctional(functional_key='PBE'),
+            spin_centers=[
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                ),
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='down'
+                ),
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert bsdft.name == 'BSDFT'
+        assert bsdft.jacobs_ladder == 'GGA'
+        assert {c.canonical_label for c in (bsdft.xc.components or [])} == {
+            'XC_GGA_X_PBE',
+            'XC_GGA_C_PBE',
+        }
+
+    def test_valid_bsdft_mixed_spin_centers(self, log_output):
+        site_a = AtomsState(chemical_symbol='Fe', label='Fe1')
+        site_b = AtomsState(chemical_symbol='Fe', label='Fe2')
+        bsdft = BSDFT(
+            determinant='unrestricted',
+            is_spin_polarized=True,
+            total_spin_projection=1,
+            spin_centers=[
+                BrokenSymmetryCenter(atom_ref=site_a, spin_sign='up', label='site_a'),
+                BrokenSymmetryCenter(atom_ref=site_b, spin_sign='down', label='site_b'),
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert bsdft.name == 'BSDFT'
+        assert bsdft.total_spin_projection == 1
+        assert len(log_output.entries) == 0
+
+    def test_warns_when_restricted(self, log_output):
+        bsdft = BSDFT(
+            determinant='restricted',
+            is_spin_polarized=True,
+            spin_centers=[
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                ),
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='down'
+                ),
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert any(
+            entry['event'] == 'BSDFT requires determinant to be unrestricted.'
+            for entry in log_output.entries
+        )
+
+    def test_warns_when_not_spin_polarized(self, log_output):
+        bsdft = BSDFT(
+            determinant='unrestricted',
+            is_spin_polarized=False,
+            spin_centers=[
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                ),
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='down'
+                ),
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert any(
+            entry['event'] == 'BSDFT requires is_spin_polarized to be True.'
+            for entry in log_output.entries
+        )
+
+    def test_warns_with_too_few_spin_centers(self, log_output):
+        bsdft = BSDFT(
+            determinant='unrestricted',
+            is_spin_polarized=True,
+            spin_centers=[
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                )
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert any(
+            entry['event']
+            == 'BSDFT requires at least two spin_centers to define a broken-symmetry assignment.'
+            for entry in log_output.entries
+        )
+
+    def test_warns_when_spin_centers_do_not_mix_signs(self, log_output):
+        bsdft = BSDFT(
+            determinant='unrestricted',
+            is_spin_polarized=True,
+            spin_centers=[
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                ),
+                BrokenSymmetryCenter(
+                    atom_ref=AtomsState(chemical_symbol='Fe'), spin_sign='up'
+                ),
+            ],
+        )
+
+        bsdft.normalize(EntryArchive(), logger=logger)
+
+        assert any(
+            entry['event'] == 'BSDFT requires at least one up and one down spin center.'
+            for entry in log_output.entries
+        )
 
 
 def test_dft_contributions_solvation_dispersion_relativity_normalize():


### PR DESCRIPTION
## Purpose

add a `BSDFT` model-method class for the broken-symmetry calculation step, without introducing the full workflow orchestration yet.

In NOMAD semantics, `BSDFT` is intrinsically a workflow: a standard high-spin `DFT` calculation is performed first, and the broken-symmetry determinant is then constructed as a follow-up calculation on top of that reference. This PR does not implement that workflow yet. Instead, it introduces the method-level schema needed to represent the broken-symmetry calculation itself, so that a later `DFT` -> `BSDFT` workflow can be modeled cleanly and explicitly.

## Scope

**Included**

- Add `BSDFT(DFT)` to the model-method schema
- Add `BrokenSymmetryCenter` with atom/site reference and local spin base classes from `atoms_state.py`
- Add `BSDFT.spin_centers`
- Add `BSDFT.total_spin_projection` in doubled form
- Normalize `BSDFT.name = 'BSDFT'`
- Validate BSDFT-specific constraints:
_unrestricted determinant_
_spin-polarized calculation_
_at least two spin centers_
_at least one up and one down center_
- Add unit-test coverage for BSDFT behavior
- Add a minimal documentation/example snippet for BSDFT

**Out of scope**

- Any BS workflow class
- Linking a BSDFT calculation to a high-spin reference
- Exchange-coupling (J) extraction
- ⟨S²⟩ handling
- Projected-spin or spin-Hamiltonian analysis

## Context & Links

- Prepares for a later workflow-level orchestration similar to `DFT` -> `GW`
- High-spin reference remains standard `DFT`; only the broken-symmetry calculation is specialized as `BSDFT`
- Reuses existing spin-state schema concepts from `atoms_state.py` instead of introducing a parallel ad hoc spin-sign model

## Reviewer Notes

BSDFT is modeled as a subclass of DFT, not as a flag/subsection on DFT, to keep the method identity explicit and make future workflow detection straightforward.

Validation currently warns on inconsistent BSDFT metadata rather than rewriting or dropping parsed values, matching the general schema style.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Unit tests



