### PR TITLE
tiny fix: Promote `OrbitalLocalization` to `ModelMethod`

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -488,7 +488,7 @@ class NonlocalCorrelation(BaseModelMethod):
     )
 
 
-class OrbitalLocalization(BaseModelMethod):
+class OrbitalLocalization(ModelMethod):
     """Transforming canonical MOs into a localized representation.
 
     Localized orbitals are used by local correlation methods such as


### PR DESCRIPTION
## Purpose
This PR promotes `OrbitalLocalization` to a first-class `ModelMethod`

This matters because orbital localization is used as an explicit methodological step in workflows such as local MP2 and local coupled-cluster, but it was previously modeled only as a `BaseModelMethod`, which made it awkward to represent alongside other electronic-structure methods in `data.model_method`.

This is also broadly consistent with the existing schema treatment of Wannier-based methods, where orbital-transformation-related methodology is already represented as a first-class `ModelMethod`.

## Scope

**Included**

- Change `OrbitalLocalization` to inherit from `ModelMethod` instead of `BaseModelMethod`

## Context & Links

- This is intended as a small preparatory schema change for better workflow representation of calculations that include an explicit orbital-localization step.

Follow-up context: local-correlation workflows such as `HF` -> `OrbitalLocalization` -> `Local MP2/Local CC`

## Reviewer Notes

This is intentionally minimal. It only changes the inheritance level of `OrbitalLocalization`.

The goal is to make orbital localization structurally eligible to appear as a top-level method in `data.model_method`. 

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

_How was this change validated?_

- [x] None (explain):



