### PR TITLE
fix `APWPlaneWaveBasisSet` issue

### DIFF
--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -1056,11 +1056,11 @@ class BasisSetContainer(NumericalSettings):
         super().normalize(archive, logger)
 
         mt_r_min = self._find_mt_r_min()
-        plane_waves: list[APWPlaneWaveBasisSet] = []
+        apw_plane_waves: list[APWPlaneWaveBasisSet] = []
         has_muffin_tin_region = False
         for component in self.basis_set_components:
             if isinstance(component, APWPlaneWaveBasisSet):
-                plane_waves.append(component)
+                apw_plane_waves.append(component)
             elif isinstance(component, MuffinTinRegion):
                 has_muffin_tin_region = True
                 component.mt_r_min = mt_r_min
@@ -1070,9 +1070,9 @@ class BasisSetContainer(NumericalSettings):
             elif isinstance(component, EffectiveCorePotential):
                 component.normalize(archive, logger)
 
-        if has_muffin_tin_region and len(plane_waves) == 0:
+        if has_muffin_tin_region and len(apw_plane_waves) == 0:
             logger.error('Expected a `APWPlaneWaveBasisSet` instance, but found none.')
-        elif len(plane_waves) > 1:
+        elif len(apw_plane_waves) > 1:
             logger.warning('Multiple plane-wave basis sets were found.')
         self.name = self._determine_apw()
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -1073,7 +1073,9 @@ class BasisSetContainer(NumericalSettings):
         if has_muffin_tin_region and len(apw_plane_waves) == 0:
             logger.error('Expected a `APWPlaneWaveBasisSet` instance, but found none.')
         elif len(apw_plane_waves) > 1:
-            logger.warning('Multiple `APWPlaneWaveBasisSet` components were found.')
+            logger.warning(
+                'Multiple components of `APWPlaneWaveBasisSet` type were found.'
+            )
         self.name = self._determine_apw()
 
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -1059,7 +1059,7 @@ class BasisSetContainer(NumericalSettings):
         plane_waves: list[APWPlaneWaveBasisSet] = []
         has_muffin_tin_region = False
         for component in self.basis_set_components:
-            if isinstance(component, PlaneWaveBasisSet):
+            if isinstance(component, APWPlaneWaveBasisSet):
                 plane_waves.append(component)
             elif isinstance(component, MuffinTinRegion):
                 has_muffin_tin_region = True
@@ -1073,7 +1073,7 @@ class BasisSetContainer(NumericalSettings):
         if has_muffin_tin_region and len(plane_waves) == 0:
             logger.error('Expected a `APWPlaneWaveBasisSet` instance, but found none.')
         elif len(plane_waves) > 1:
-            logger.warning('Multiple plane-wave basis sets found were found.')
+            logger.warning('Multiple plane-wave basis sets were found.')
         self.name = self._determine_apw()
 
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -1073,7 +1073,7 @@ class BasisSetContainer(NumericalSettings):
         if has_muffin_tin_region and len(apw_plane_waves) == 0:
             logger.error('Expected a `APWPlaneWaveBasisSet` instance, but found none.')
         elif len(apw_plane_waves) > 1:
-            logger.warning('Multiple plane-wave basis sets were found.')
+            logger.warning('Multiple `APWPlaneWaveBasisSet` components were found.')
         self.name = self._determine_apw()
 
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -1057,10 +1057,12 @@ class BasisSetContainer(NumericalSettings):
 
         mt_r_min = self._find_mt_r_min()
         plane_waves: list[APWPlaneWaveBasisSet] = []
+        has_muffin_tin_region = False
         for component in self.basis_set_components:
             if isinstance(component, PlaneWaveBasisSet):
                 plane_waves.append(component)
             elif isinstance(component, MuffinTinRegion):
+                has_muffin_tin_region = True
                 component.mt_r_min = mt_r_min
                 component.normalize(archive, logger)
             elif isinstance(component, AtomCenteredBasisSet):
@@ -1068,7 +1070,7 @@ class BasisSetContainer(NumericalSettings):
             elif isinstance(component, EffectiveCorePotential):
                 component.normalize(archive, logger)
 
-        if len(plane_waves) == 0:
+        if has_muffin_tin_region and len(plane_waves) == 0:
             logger.error('Expected a `APWPlaneWaveBasisSet` instance, but found none.')
         elif len(plane_waves) > 1:
             logger.warning('Multiple plane-wave basis sets found were found.')


### PR DESCRIPTION
## Purpose

This PR fixes a misleading normalization error for atom-centered basis set containers:

`ERROR nomad.client Expected a APWPlaneWaveBasisSet instance, but found none.`

Previously, `BasisSetContainer.normalize()` always expected an `APWPlaneWaveBasisSet` to be present and logged an error when it was not. That is incorrect for valid containers that contain only `AtomCenteredBasisSet` components, and it produces false errors in atom-centered simulations.

## Scope

**Included**

- Restrict the missing-plane-wave error in `BasisSetContainer.normalize() (line 1055) `to APW-like containers that actually contain `MuffinTinRegion` components

- Tighten the internal plane-wave collection logic to track `APWPlaneWaveBasisSet` explicitly

**Out of scope**

- Changes to APW basis handling beyond this guard condition

## Context & Links

- This came up while normalizing atom-centered basis set containers produced for quantum-chemistry outputs. The previous logic in `BasisSetContainer`: 

```
        if len(plane_waves) == 0:
            logger.error('Expected a `APWPlaneWaveBasisSet` instance, but found none.')
```

## Reviewer Notes

This is intentionally narrow. The only behavior change is that atom-centered-only containers no longer emit a false APW error during normalization.

APW-like containers still keep the existing validation: if a container has `MuffinTinRegion` content but no plane-wave component, it will still log the error.


## Status

- [x] Ready for review


## Breaking Changes

- [x] None


## Dependencies / Blockers

- [x] None


## Testing / Validation

- [x] Manual testing (explain):
Normalized a `BasisSetContainer` containing only an `AtomCenteredBasisSet` and confirmed it no longer emits the APW-specific error.

