### PR TITLE
Added parsing of n_frames/n_steps and times from XVG files, removed usage of 'getattr'.

### DIFF
--- a/docs/schema/workflow_molecular_dynamics.md
+++ b/docs/schema/workflow_molecular_dynamics.md
@@ -195,6 +195,12 @@ classDiagram
 | `calc_type` | Enum | <details><summary>Specifies the type of workflow.</summary>Specifies the type of workflow. Allowed values are:<br>\| kind          \| Description                               \|<br>\| ---------------------- \| ----------------------------------------- \|<br>\| `"alchemical"`           \| A non-physical transformation between 2 well-defined systems,<br>typically achieved by smoothly interpolating between Hamiltonians or force fields.  \|<br>\| `"umbrella_sampling"`    \| A sampling of the path between 2 well-defined (sub)states of a system,<br>typically achieved by applying a biasing force to the force field along a<br>specified reaction coordinate.</details> |
 | `current_lambda_index` | m_int32(int) | Index into each Lambdas.lambda_values for the current simulation step/state (only valid if all targets share an aligned λ grid). |
 | `current_lambdas` | m_float64(float64) (shape: ['*']) | Scalar λ per Lambdas entry order. |
+| `n_frames` | m_int32(int32) | Number of time frames in the XVG free-energy output. |
+| `n_states` | m_int32(int32) | Number of lambda states in the XVG free-energy differences. |
+| `times` | m_float64(float64) (shape: ['n_frames']) | Simulation time for each frame in the XVG output. |
+| `energy_derivative` | m_float64(float64) (shape: ['n_frames']) | dH/dλ at the current lambda state for each time frame, as written by GROMACS to the XVG file. |
+| `energy_differences` | m_float64(float64) (shape: ['n_frames', 'n_states']) | ΔH between the current lambda state and each other state for each time frame (n_states columns in the XVG file). |
+| `pv_energy` | m_float64(float64) (shape: ['n_frames']) | PV contribution to the free energy for each time frame. |
 
 ### `Lambdas`
 

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1349,10 +1349,8 @@ class ParticleParametersContainer(NumericalSettings):
         for ap in self.particle_parameters or []:
             for ps in ap.species_scope or []:
                 ps_id = id(ps)
-                if ps_id in seen:
-                    duplicates.add(
-                        str(ap.particle_type) if ap.particle_type is not None else None
-                    )
+                if ps_id in seen and ap.particle_type is not None:
+                    duplicates.add(str(ap.particle_type))
                 seen.add(ps_id)
         if duplicates:
             logger.error(

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1350,7 +1350,9 @@ class ParticleParametersContainer(NumericalSettings):
             for ps in ap.species_scope or []:
                 ps_id = id(ps)
                 if ps_id in seen:
-                    duplicates.add(str(ap.particle_type) or None)
+                    duplicates.add(
+                        str(ap.particle_type) if ap.particle_type is not None else None
+                    )
                 seen.add(ps_id)
         if duplicates:
             logger.error(

--- a/src/nomad_simulations/schema_packages/force_field.py
+++ b/src/nomad_simulations/schema_packages/force_field.py
@@ -1350,7 +1350,7 @@ class ParticleParametersContainer(NumericalSettings):
             for ps in ap.species_scope or []:
                 ps_id = id(ps)
                 if ps_id in seen:
-                    duplicates.add(str(getattr(ap, 'particle_type', None)))
+                    duplicates.add(str(ap.particle_type) or None)
                 seen.add(ps_id)
         if duplicates:
             logger.error(

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -43,6 +43,7 @@ from nomad.metainfo import MEnum, MSection, Quantity, Reference, Section, SubSec
 from nomad.units import ureg
 from nomad.utils import get_logger
 
+from nomad_simulations.schema_packages.atoms_state import CGBeadState
 from nomad_simulations.schema_packages.model_system import ModelSystem
 
 LOGGER = get_logger(__name__)
@@ -206,18 +207,14 @@ def get_bond_list_from_model_contributions(
     bond_list: list[tuple[int, ...]] = []
     if sec_method is None:
         return bond_list
-    contributions = getattr(sec_method, 'contributions', None)
+    contributions = sec_method.contributions
     if contributions is None or len(contributions) == 0:
         return bond_list
     for contribution in contributions:
-        if getattr(contribution, 'type', None) != 'bond':
+        if contribution.type != 'bond':
             continue
-        pi = getattr(contribution, 'particle_indices', None)
+        pi = contribution.particle_indices
         if pi is None:
-            continue
-        try:
-            pi = np.asarray(pi)
-        except Exception:
             continue
         if pi.ndim != 2 or pi.shape[1] != 2:
             continue
@@ -429,7 +426,8 @@ def archive_to_universe(
         return None
     particle_names = [ps.label for ps in particle_states]
     particle_types = [
-        ps.chemical_symbol or ps.bead_symbol or 'CGX' for ps in particle_states
+        ps.chemical_symbol or (ps.bead_symbol if isinstance(ps, CGBeadState) else 'CGX')
+        for ps in particle_states
     ]
 
     _ppc = (
@@ -476,7 +474,9 @@ def archive_to_universe(
             )
         else:
             _missing_masses += 1
-            symbol = ps.chemical_symbol or ps.bead_symbol or 'CGX'
+            symbol = ps.chemical_symbol or (
+                ps.bead_symbol if isinstance(ps, CGBeadState) else 'CGX'
+            )
             ase_mass = (
                 ase.data.atomic_masses[ase.data.atomic_numbers.get(symbol, 0)]
                 if symbol is not None
@@ -507,9 +507,7 @@ def archive_to_universe(
     charges = np.array(_charges_list)
 
     system_times = [
-        t
-        for out in (archive.data.outputs or [])
-        if (t := getattr(out, 'time', None)) is not None
+        t for out in (archive.data.outputs or []) if (t := out.time) is not None
     ]
     n_frames = len(sec_system)
 

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -45,6 +45,7 @@ from nomad.utils import get_logger
 
 from nomad_simulations.schema_packages.atoms_state import CGBeadState
 from nomad_simulations.schema_packages.model_system import ModelSystem
+from nomad_simulations.schema_packages.outputs import TrajectoryOutputs
 
 LOGGER = get_logger(__name__)
 
@@ -507,7 +508,9 @@ def archive_to_universe(
     charges = np.array(_charges_list)
 
     system_times = [
-        t for out in (archive.data.outputs or []) if (t := out.time) is not None
+        out.time
+        for out in (archive.data.outputs or [])
+        if isinstance(out, TrajectoryOutputs) and out.time is not None
     ]
     n_frames = len(sec_system)
 

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -652,14 +652,62 @@ class FreeEnergyCalculationParameters(MDSettings):
     current_lambda_index = Quantity(
         type=int,
         shape=[],
-        description='Index into each Lambdas.lambda_values for the current simulation step/state '
+        description='Index into each Lambdas.lambda_values for the current simulation '
+        'step/state '
         '(only valid if all targets share an aligned λ grid).',
     )
-    # Otherwise, prefer per-target scalar λ values for the current state (one scalar per Lambdas entry):
+    # Otherwise, prefer per-target scalar λ values for the current state (one scalar per
+    # Lambdas entry):
     current_lambdas = Quantity(
         type=np.float64, shape=['*'], description='Scalar λ per Lambdas entry order.'
     )
     # TODO not really sure how to deal with this, cause it corresponds to a hierarchical workflow that may not be contained in the same upload
+
+    n_frames = Quantity(
+        type=np.int32,
+        shape=[],
+        description='Number of time frames in the XVG free-energy output.',
+    )
+
+    n_states = Quantity(
+        type=np.int32,
+        shape=[],
+        description='Number of lambda states in the XVG free-energy differences.',
+    )
+
+    times = Quantity(
+        type=np.float64,
+        shape=['n_frames'],
+        unit='picosecond',
+        description='Simulation time for each frame in the XVG output.',
+    )
+
+    energy_derivative = Quantity(
+        type=np.float64,
+        shape=['n_frames'],
+        unit='kilojoule / avogadro_number',
+        description=(
+            'dH/dλ at the current lambda state for each time frame, '
+            'as written by GROMACS to the XVG file.'
+        ),
+    )
+
+    energy_differences = Quantity(
+        type=np.float64,
+        shape=['n_frames', 'n_states'],
+        unit='kilojoule / avogadro_number',
+        description=(
+            'ΔH between the current lambda state and each other state '
+            'for each time frame (n_states columns in the XVG file).'
+        ),
+    )
+
+    pv_energy = Quantity(
+        type=np.float64,
+        shape=['n_frames'],
+        unit='kilojoule / avogadro_number',
+        description='PV contribution to the free energy for each time frame.',
+    )
 
     # TODO make sure this is covered in the outputs
     # atom_indices = Quantity(
@@ -714,10 +762,9 @@ class FreeEnergyCalculationParameters(MDSettings):
         # Alignment check for single current_lambda_index
         if self.current_lambda_index is not None:
             grids = [
-                tuple(v)
+                tuple(lam.lambda_values)
                 for lam in self.lambdas
-                for v in [getattr(lam, 'lambda_values', None)]
-                if v is not None
+                if lam.lambda_values is not None
             ]
             non_empty = [g for g in grids if len(g) > 0]
             if len(non_empty) > 1 and any(g != non_empty[0] for g in non_empty[1:]):
@@ -1339,6 +1386,12 @@ class MolecularDynamicsResults(SerialWorkflowResults):
 
     def normalize(self, archive, logger):
         super().normalize(archive, logger)
+
+        # Populate n_steps and trajectory references from parsed model_system list
+        model_systems = archive.data.model_system if archive.data else []
+        if model_systems and self.n_steps is None:
+            self.n_steps = len(model_systems)
+            self.trajectory = model_systems
 
         self._universe = self.get_universe(archive)
         if self._universe is None:


### PR DESCRIPTION
## Purpose

Eliminate `getattr` calls on NOMAD metainfo sections, Nomad style is direct attribute access.
(`getattr` with a default silently masks `AttributeError` that would otherwise expose schema mismatches or cross-type access bugs.)

## Scope

**Included**

- Replace `getattr(lam, 'lambda_values', None)` in `FreeEnergyCalculationParameters.normalize`
  with direct access guarded by `is not None`
- Replace `getattr(sec_method, 'contributions', None)`, `getattr(contribution, 'type', None)`,
  and `getattr(contribution, 'particle_indices', None)` in
  `get_bond_list_from_model_contributions` with direct attribute access; remove unreachable
  `try/except` around `np.asarray`
- Replace `getattr(out, 'time', None)` in `archive_to_universe` with `out.time`
- Fix cross-type `ps.bead_symbol` access in `archive_to_universe`: guard with
  `isinstance(ps, CGBeadState)` to prevent `AttributeError` when iterating mixed
  `AtomsState`/`CGBeadState` particle lists
- Replace `getattr(ap, 'particle_type', None)` in `ParticleParametersContainer.normalize`
  (`force_field.py`) with direct access
- Add `FreeEnergyCalculationParameters` XVG time-series quantities: `n_frames`, `n_states`,
  `times`, `energy_derivative`, `energy_differences`, `pv_energy`
- Populate `MolecularDynamicsResults.n_steps` and `trajectory` in `normalize` from
  `archive.data.model_system`

**Out of scope**

- `getattr` calls on non-metainfo objects (MDAnalysis `Universe`, `Trajectory`, plain Python
  objects) — these are legitimate and untouched
- `getattr` calls using a runtime string key (`getattr(self, property_name)`) — no alternative
  exists for dynamic dispatch

## Context & Links

- Companion PR in `nomad-parser-plugins-simulation`: adds `XVG_KEY` constant, annotations, and
  `get_fep_xvg_data` transformer to connect the new XVG quantities to the GROMACS parser

## Reviewer Notes
- The new XVG quantities on `FreeEnergyCalculationParameters` have no unit conversion in the
  parser yet — magnitudes are written directly; units are declared on the schema quantities.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None
- [x] Open design questions:
  - `n_steps`/`trajectory` on `MolecularDynamicsResults` are populated in `normalize` rather
    than by the parser; if `archive.data.model_system` is empty at normalize time these will remain unset.

## Testing / Validation

- [x] Unit tests — existing `tests/workflow/test_molecular_dynamics.py` and
  `tests/utils/test_molecular_dynamics.py` cover the modified paths
