### PR TITLE
patch rep detection and outputs linking for complex top h5md

### DIFF
--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -242,13 +242,34 @@ class Outputs(SimulationTime):
         if self.m_parent is not None:
             model_systems = self.m_parent.model_system
             outputs = self.m_parent.outputs
+            if not isinstance(model_systems, list) or len(model_systems) == 0:
+                return None
+
             if (
-                isinstance(model_systems, list)
-                and isinstance(outputs, list)
+                isinstance(outputs, list)
                 and len(model_systems) == len(outputs)
-                and len(model_systems) > 0
             ):
                 return model_systems[self.m_parent_index]
+
+            # Prefer representative system when explicit 1-1 mapping is unavailable.
+            representative_system_index = getattr(
+                self.m_parent, 'representative_system_index', None
+            )
+            if (
+                isinstance(representative_system_index, (int, np.integer))
+                and 0 <= representative_system_index < len(model_systems)
+            ):
+                return model_systems[representative_system_index]
+
+            # Fallback for trajectory-like archives: use the first system carrying
+            # particle-state topology metadata.
+            for model_system in model_systems:
+                if getattr(model_system, 'particle_states', None):
+                    return model_system
+
+            # Last-resort fallback to keep downstream reference-dependent
+            # normalization paths functional in mismatched-length payloads.
+            return model_systems[-1]
         return None
 
     def set_model_method_ref(self) -> ModelMethod | None:

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -245,20 +245,16 @@ class Outputs(SimulationTime):
             if not isinstance(model_systems, list) or len(model_systems) == 0:
                 return None
 
-            if (
-                isinstance(outputs, list)
-                and len(model_systems) == len(outputs)
-            ):
+            if isinstance(outputs, list) and len(model_systems) == len(outputs):
                 return model_systems[self.m_parent_index]
 
             # Prefer representative system when explicit 1-1 mapping is unavailable.
             representative_system_index = getattr(
                 self.m_parent, 'representative_system_index', None
             )
-            if (
-                isinstance(representative_system_index, (int, np.integer))
-                and 0 <= representative_system_index < len(model_systems)
-            ):
+            if isinstance(
+                representative_system_index, (int, np.integer)
+            ) and 0 <= representative_system_index < len(model_systems):
                 return model_systems[representative_system_index]
 
             # Fallback for trajectory-like archives: use the first system carrying

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -242,7 +242,7 @@ class Outputs(SimulationTime):
         if self.m_parent is not None:
             model_systems = self.m_parent.model_system
             outputs = self.m_parent.outputs
-            if not isinstance(model_systems, list) or len(model_systems) == 0:
+            if model_systems is None or len(model_systems) == 0:
                 return None
 
             if isinstance(outputs, list) and len(model_systems) == len(outputs):

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -746,7 +746,7 @@ def archive_to_universe(
 
 
 def _get_molecular_bead_groups(
-    universe: MDAUniverse | None, moltypes: list[str] = []
+    universe: MDAUniverse | None, moltypes: list[str] | None = None
 ) -> dict[str, BeadGroup]:
     """
     Creates bead groups based on the molecular types as defined by the MDAnalysis
@@ -760,18 +760,17 @@ def _get_molecular_bead_groups(
         LOGGER.warning(_log_missing_dependency('universe', 'beads'))
         return {}
 
-    if not moltypes:
-        atoms_moltypes = getattr(universe.atoms, 'moltypes', [])
-        moltypes = np.unique(atoms_moltypes).tolist()
     bead_groups = {}
     atoms_moltypes = np.asarray(getattr(universe.atoms, 'moltypes', []))
+    if not moltypes:
+        moltypes = np.unique(atoms_moltypes).tolist()
     for moltype in moltypes:
-        try:
+        if atoms_moltypes.shape[0] != universe.atoms.n_atoms:
+            ags_by_moltype = universe.atoms[:0]
+        else:
             # Avoid text-based selection parsing (e.g., `moltype water`) which can
             # fail for valid moltype values depending on tokenizer semantics.
             ags_by_moltype = universe.atoms[atoms_moltypes == moltype]
-        except Exception:
-            ags_by_moltype = universe.atoms[:0]
         if ags_by_moltype.n_atoms == 0:
             continue
 

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -764,8 +764,14 @@ def _get_molecular_bead_groups(
         atoms_moltypes = getattr(universe.atoms, 'moltypes', [])
         moltypes = np.unique(atoms_moltypes).tolist()
     bead_groups = {}
+    atoms_moltypes = np.asarray(getattr(universe.atoms, 'moltypes', []))
     for moltype in moltypes:
-        ags_by_moltype = universe.select_atoms('moltype ' + moltype)
+        try:
+            # Avoid text-based selection parsing (e.g., `moltype water`) which can
+            # fail for valid moltype values depending on tokenizer semantics.
+            ags_by_moltype = universe.atoms[atoms_moltypes == moltype]
+        except Exception:
+            ags_by_moltype = universe.atoms[:0]
         if ags_by_moltype.n_atoms == 0:
             continue
 

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -1346,13 +1346,15 @@ class MolecularDynamicsResults(SerialWorkflowResults):
 
         self._bead_groups = _get_molecular_bead_groups(self._universe)
 
-        # calculate molecular radial distribution functions
-        self.radial_distribution_functions.extend(self._get_molecular_rdfs(archive))
+        # Calculate derived observables only when parser/mapping did not provide them.
+        # This avoids duplicating data when normalization is executed multiple times.
+        if not self.radial_distribution_functions:
+            self.radial_distribution_functions.extend(self._get_molecular_rdfs(archive))
 
-        # calculate the molecular mean squared displacements
-        msds, diffusion_constants = self._get_molecular_msds()
-        self.mean_squared_displacements.extend(msds)
-        self.diffusion_constants.extend(diffusion_constants)
+        if not self.mean_squared_displacements and not self.diffusion_constants:
+            msds, diffusion_constants = self._get_molecular_msds()
+            self.mean_squared_displacements.extend(msds)
+            self.diffusion_constants.extend(diffusion_constants)
 
         # calculate radius of gyration for polymers
         self.radii_of_gyration = self.get_molecular_rgs(archive)

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -124,6 +124,13 @@ class TestOutputs:
                 assert model_system_ref is None
 
     def test_set_model_system_ref_prefers_representative_system_on_mismatch(self):
+        """
+        When model_system and outputs lengths mismatch, use representative_system_index.
+
+        This validates the fallback chain: with 3 model_systems and 2 outputs, the
+        1:1 mapping does not apply, so `set_model_system_ref()` should use
+        `representative_system_index` instead of later fallbacks.
+        """
         simulation = generate_simulation()
         simulation.model_system = [
             ModelSystem(name='system_0'),

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -118,8 +118,28 @@ class TestOutputs:
             if len(model_systems) == len(outputs_list) and len(model_systems) > 0:
                 assert model_system_ref == model_systems[i]
                 assert model_system_ref.name == f'system_{i}'
+            elif len(model_systems) > 0:
+                assert model_system_ref == model_systems[-1]
             else:
                 assert model_system_ref is None
+
+    def test_set_model_system_ref_prefers_representative_system_on_mismatch(self):
+        simulation = generate_simulation()
+        simulation.model_system = [
+            ModelSystem(name='system_0'),
+            ModelSystem(name='system_1'),
+            ModelSystem(name='system_2'),
+        ]
+        simulation.representative_system_index = 0
+        simulation.outputs = [Outputs(), Outputs()]
+
+        output = simulation.outputs[0]
+        output.m_parent = simulation
+        output.m_parent_index = 0
+
+        model_system_ref = output.set_model_system_ref()
+        assert model_system_ref == simulation.model_system[0]
+        assert model_system_ref.name == 'system_0'
 
     @pytest.mark.parametrize(
         'model_method',

--- a/tests/utils/test_molecular_dynamics.py
+++ b/tests/utils/test_molecular_dynamics.py
@@ -214,14 +214,40 @@ def test_archive_to_universe_base_model_method_no_attribute_error():
 
 def test_get_molecular_bead_groups_handles_plain_moltype_tokens():
     """
-    Moltype labels like "water" must not trigger MDAnalysis selection parsing errors.
+    Plain moltype labels must resolve via boolean indexing.
     """
+    universe = MDAnalysis.Universe.empty(1)
+    universe.add_TopologyAttr('moltypes', np.array(['mol']))
+    universe.add_TopologyAttr('masses', np.array([15.999]))
+    universe.add_TopologyAttr('bonds', [])
+
+    bead_groups = _get_molecular_bead_groups(universe)
+
+    assert 'mol' in bead_groups
+
+
+def test_get_molecular_bead_groups_handles_reserved_keyword_moltypes():
+    """
+    Regression: moltype labels like "water" must not trigger selection parser issues.
+    """
+    universe = MDAnalysis.Universe.empty(1)
+    universe.add_TopologyAttr('moltypes', np.array(['water']))
+    universe.add_TopologyAttr('masses', np.array([15.999]))
+    universe.add_TopologyAttr('bonds', [])
+
+    bead_groups = _get_molecular_bead_groups(universe)
+
+    assert 'water' in bead_groups
+
+
+def test_get_molecular_bead_groups_counts_fragments():
+    """BeadGroup counts bonded atoms as a single fragment."""
     universe = MDAnalysis.Universe.empty(3, n_residues=3, atom_resindex=[0, 1, 2])
-    universe.add_TopologyAttr('moltypes', np.array(['water', 'water', 'water']))
+    universe.add_TopologyAttr('moltypes', np.array(['mol', 'mol', 'mol']))
     universe.add_TopologyAttr('masses', np.array([15.999, 1.008, 1.008]))
     universe.add_TopologyAttr('bonds', [(0, 1), (1, 2)])
 
     bead_groups = _get_molecular_bead_groups(universe)
 
-    assert 'water' in bead_groups
-    assert len(bead_groups['water']) == 1
+    assert 'mol' in bead_groups
+    assert len(bead_groups['mol']) == 1

--- a/tests/utils/test_molecular_dynamics.py
+++ b/tests/utils/test_molecular_dynamics.py
@@ -20,6 +20,7 @@ from nomad_simulations.schema_packages.general import Simulation
 from nomad_simulations.schema_packages.model_method import ModelMethod
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.utils.molecular_dynamics import (
+    _get_molecular_bead_groups,
     archive_to_universe,
 )
 
@@ -209,3 +210,18 @@ def test_archive_to_universe_base_model_method_no_attribute_error():
         pytest.fail(
             f'archive_to_universe raised AttributeError with base ModelMethod: {exc}'
         )
+
+
+def test_get_molecular_bead_groups_handles_plain_moltype_tokens():
+    """
+    Moltype labels like "water" must not trigger MDAnalysis selection parsing errors.
+    """
+    universe = MDAnalysis.Universe.empty(3, n_residues=3, atom_resindex=[0, 1, 2])
+    universe.add_TopologyAttr('moltypes', np.array(['water', 'water', 'water']))
+    universe.add_TopologyAttr('masses', np.array([15.999, 1.008, 1.008]))
+    universe.add_TopologyAttr('bonds', [(0, 1), (1, 2)])
+
+    bead_groups = _get_molecular_bead_groups(universe)
+
+    assert 'water' in bead_groups
+    assert len(bead_groups['water']) == 1


### PR DESCRIPTION
### 1) `model_system_ref` carryover became robust for mismatched `model_system` vs `outputs`
- **File:** [outputs.py](/home/jfrudzinski/work/soft/nomad-distro-dev-topology-normalizer-2026-02/packages/nomad-simulations/src/nomad_simulations/schema_packages/outputs.py:235)
- **What changed:** `Outputs.set_model_system_ref()` no longer returns `None` when lengths differ.
- **New fallback order:**
  1. use 1:1 index mapping if lengths match
  2. use `representative_system_index` (supports both `int` and `np.integer`)
  3. use first `model_system` that has `particle_states`
  4. fallback to last `model_system`
- **Why:** downstream normalization (DOS/MD/topology-related mapping) depends on `output.model_system_ref`; previously this could be missing in trajectory-shaped archives.

### 2) MD bead-group selection no longer depends on fragile MDAnalysis selection strings
- **File:** [molecular_dynamics.py](/home/jfrudzinski/work/soft/nomad-distro-dev-topology-normalizer-2026-02/packages/nomad-simulations/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py:767)
- **What changed:** `_get_molecular_bead_groups()` switched from:
  - `universe.select_atoms('moltype ' + moltype)`
  to:
  - boolean mask on `universe.atoms.moltypes` (`universe.atoms[atoms_moltypes == moltype]`)
- **Why:** avoids `MDAnalysis.exceptions.SelectionError` for plain tokens like `water`.

### 3) Tests updated/added
- **File:** [test_outputs.py](/home/jfrudzinski/work/soft/nomad-distro-dev-topology-normalizer-2026-02/packages/nomad-simulations/tests/test_outputs.py:98)
  - updated mismatch expectations for `set_model_system_ref()`
  - added `test_set_model_system_ref_prefers_representative_system_on_mismatch`
- **File:** [test_molecular_dynamics.py](/home/jfrudzinski/work/soft/nomad-distro-dev-topology-normalizer-2026-02/packages/nomad-simulations/tests/utils/test_molecular_dynamics.py:215)
  - added regression `test_get_molecular_bead_groups_handles_plain_moltype_tokens`
