### PR TITLE
Use multireference type for archive labels and names

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -2198,11 +2198,20 @@ class BaseMultireferenceMethod(BaseModelMethod):
             elif self.n_roots_per_multiplicity is not None:
                 self.n_state_groups = len(self.n_roots_per_multiplicity)
 
+        # Prefer the selected multireference flavor over the generic section
+        # name when no parser-specific name was provided.
+        if self.type is not None and (
+            self.name is None or self.name == self.m_def.name
+        ):
+            self.name = self.type
+
 
 class MultireferenceSCF(BaseMultireferenceMethod):
     """
     Multiconfigurational SCF calculations (e.g., CASSCF, RASSCF, DMRG-SCF).
     """
+
+    m_def = Section(label_quantity='type')
 
     type = Quantity(
         type=MEnum('CASSCF', 'RASSCF', 'DMRGSCF'),
@@ -2219,6 +2228,8 @@ class MultireferenceCI(BaseMultireferenceMethod):
     Multireference configuration interaction methods (e.g., MRCI).
     """
 
+    m_def = Section(label_quantity='type')
+
     type = Quantity(
         type=MEnum('MRCI', 'MR-ACPF', 'MR-AQCC', 'CASCI', 'RASCI', 'DMRGCI'),
         description="""
@@ -2233,6 +2244,8 @@ class MultireferencePT(BaseMultireferenceMethod):
 
     Defaults are PT2-style, but `order` can capture higher-order variants.
     """
+
+    m_def = Section(label_quantity='type')
 
     type = Quantity(
         type=MEnum('CASPT', 'NEVPT', 'RASPT', 'MRMP', 'XMCQDPT'),


### PR DESCRIPTION
## Purpose
Make multireference method sections show their selected subtype in the archive instead of the generic class name. This matters because entries like `CASSCF`, `CASCI`, and `CASPT` are the meaningful identifiers users expect to see when inspecting method sections.


## Scope

**Included**
 
- set `name` from `type` in `BaseMultireferenceMethod.normalize` when `name` is unset or still generic
- set `label_quantity='type'` for `MultireferenceSCF`, `MultireferenceCI`, and `MultireferencePT`


**Out of scope**

- changes to multireference method taxonomy or allowed enum values
- broader archive labeling behavior outside these three sections

## Context & Links

- Improves archive display for multireference method sections in `model_method.py`


## Reviewer Notes

One thing I’d like feedback on: should these sections rely on `type` as the archive label only, or should I more explicitly rewrite `name` from `type` as the preferred schema convention here?


## Status

- [x] Ready for review


## Breaking Changes

- [x] None


## Dependencies / Blockers

- [x] None


## Testing / Validation

- [x] Manual parsing

