### PR TITLE
Migrate SelfConsistency to flexible_unit pattern

### DIFF
--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -130,8 +130,7 @@ classDiagram
 |---|---|---|
 | `scf_minimization_algorithm` | m_str(str) | Specifies the algorithm used for self consistency minimization. |
 | `n_max_iterations` | m_int32(int32) | Specifies the maximum number of allowed self-consistent iterations. The simulation `is_scf_converged` if the number of iterations is not larger or equal than this quantity. |
-| `threshold_change` | m_float64(float64) | Specifies the threshold for the change between two subsequent self-consistent iterations on a given output property. The simulation `is_scf_converged` if this total change is below this threshold. |
-| `threshold_change_unit` | m_str(str) | Unit using the pint UnitRegistry() notation for the `threshold_change`. |
+| `threshold_change` | m_float64(float64) | Specifies the threshold for the change between two subsequent self-consistent iterations on a given output property. The simulation `is_scf_converged` if this total change is below this threshold. Supports flexible units (e.g., energy in eV/joule, density as dimensionless). |
 
 ### `ForceCalculations`
 

--- a/docs/snippets/tutorials/part2_foundations/assignment_2_4.py
+++ b/docs/snippets/tutorials/part2_foundations/assignment_2_4.py
@@ -1,9 +1,10 @@
+from nomad.units import ureg
 from nomad_simulations.schema_packages.model_method import DFT
 from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
 
-scf = SelfConsistency(threshold_change=1e-3, threshold_change_unit='joule')
+scf = SelfConsistency(threshold_change=1e-3 * ureg.joule)
 dft = DFT(name='DFT', type='KS', numerical_settings=[scf])
 
-assert dft.numerical_settings[0].threshold_change == 1e-3
-assert dft.numerical_settings[0].threshold_change_unit == 'joule'
+assert dft.numerical_settings[0].threshold_change.magnitude == 1e-3
+assert dft.numerical_settings[0].threshold_change.units == ureg.joule
 assert scf.m_parent is dft

--- a/docs/snippets/tutorials/part2_foundations/assignment_2_4.py
+++ b/docs/snippets/tutorials/part2_foundations/assignment_2_4.py
@@ -1,4 +1,5 @@
 from nomad.units import ureg
+
 from nomad_simulations.schema_packages.model_method import DFT
 from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
 

--- a/docs/snippets/tutorials/part2_foundations/assignment_2_7.py
+++ b/docs/snippets/tutorials/part2_foundations/assignment_2_7.py
@@ -26,9 +26,7 @@ simulation.model_system.append(model_system)
 method = DFT(
     name='DFT',
     type='KS',
-    numerical_settings=[
-        SelfConsistency(threshold_change=1e-6, threshold_change_unit='joule')
-    ],
+    numerical_settings=[SelfConsistency(threshold_change=1e-6 * ureg.joule)],
 )
 simulation.model_method.append(method)
 

--- a/docs/tutorials/standalone_schema_tutorial.md
+++ b/docs/tutorials/standalone_schema_tutorial.md
@@ -54,7 +54,7 @@ without parser-plugin complexity. The page ends with a short normalization-metho
 ## Assignment 2.4: `SelfConsistency` in `numerical_settings`
 
 !!! abstract "Assignment 2.4"
-    Add `SelfConsistency(threshold_change=1e-3, threshold_change_unit='joule')`
+    Add `SelfConsistency(threshold_change=1e-3 * ureg.joule)`
     under `DFT.numerical_settings` and verify parent-child linkage.
 
 ### Related schema diagrams

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -948,17 +948,11 @@ class SelfConsistency(NumericalSettings):
 
     threshold_change = Quantity(
         type=np.float64,
+        flexible_unit=True,
         description="""
         Specifies the threshold for the change between two subsequent self-consistent iterations on
         a given output property. The simulation `is_scf_converged` if this total change is below
-        this threshold.
-        """,
-    )
-
-    threshold_change_unit = Quantity(
-        type=str,
-        description="""
-        Unit using the pint UnitRegistry() notation for the `threshold_change`.
+        this threshold. Supports flexible units (e.g., energy in eV/joule, density as dimensionless).
         """,
     )
 


### PR DESCRIPTION
## Purpose

Migrate `SelfConsistency.threshold_change` from split-field pattern to `flexible_unit=True` pattern.

**Before:**
```python
threshold_change = Quantity(type=np.float64)
threshold_change_unit = Quantity(type=str)  # Separate field
```

**After:**
```python
threshold_change = Quantity(type=np.float64, flexible_unit=True)
# threshold_change_unit removed
```

## Context

- Addresses reviewer feedback on [parser PR#177](https://github.com/FAIRmat-NFDI/nomad-parser-plugins-simulation/pull/177#discussion_r3333128525)
- Consistent with `WorkflowConvergenceTarget.threshold` pattern
- FHI-aims is the only parser using `SelfConsistency` (confirmed via search)

## Changes

- Add `flexible_unit=True` to `threshold_change` field
- Remove `threshold_change_unit` field  
- Update 2 tutorial examples + docs
- Regenerate schema documentation

## Breaking Change

Yes - removes `threshold_change_unit` field. Migration:
```python
# Before
SelfConsistency(threshold_change=1e-6, threshold_change_unit='eV')

# After
SelfConsistency(threshold_change=1e-6 * ureg.eV)
```

Impact: Only FHI-aims parser (parallel PR incoming)

## Testing

All 989 schema tests pass. Tutorial examples execute successfully.