### PR TITLE
fix `BaseMultireferenceMethod`

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -2356,7 +2356,7 @@ class ActiveSpace(ArchiveSection):
                     )
 
 
-class BaseMultireferenceMethod(BaseModelMethod):
+class BaseMultireferenceMethod(ModelMethod):
     """
     Shared multireference parameters (active space, state-averaging, symmetry).
     """


### PR DESCRIPTION
## Purpose

Fix `SyntaxWarning` messages when storing multireference methods under `Simulation.model_method`.

`BaseMultireferenceMethod` previously inherited directly from `BaseModelMethod`, making its derived classes incompatible with the `ModelMethod` subsection definition.

## Scope

**Included**

- Change `BaseMultireferenceMethod` to inherit from `ModelMethod`.


## Context & Links

- Resolves warnings when parsing multireference calculations such as ORCA CASCI/NEVPT2 outputs.

## Reviewer Notes

This is a one-line inheritance correction. Multireference methods are method-defining sections intended to be stored under `Simulation.model_method`.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation


- [x] Integration tests : https://github.com/FAIRmat-NFDI/nomad-parser-plugins-simulation/pull/182
