### PR TITLE
remaining bulky payloads as HDF5

### DIFF
--- a/docs/schema/manybody_properties.md
+++ b/docs/schema/manybody_properties.md
@@ -65,7 +65,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `value` | m_complex128(complex128) | Value of the electronic Green's function matrix. |
+| `value` | HDF5Dataset | Value of the electronic Green's function matrix. The dataset dimensions follow the represented spaces and matrix indices. |
 
 ### `ElectronicSelfEnergy`
 
@@ -75,7 +75,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `value` | m_complex128(complex128) | Value of the electronic self-energy matrix. |
+| `value` | HDF5Dataset | Value of the electronic self-energy matrix. The dataset dimensions follow the represented spaces and matrix indices. |
 
 ### `HybridizationFunction`
 
@@ -85,7 +85,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `value` | m_complex128(complex128) | Value of the electronic hybridization function. |
+| `value` | HDF5Dataset | Value of the electronic hybridization function. The dataset dimensions follow the represented spaces and matrix indices. |
 
 ### `QuasiparticleWeight`
 
@@ -112,7 +112,7 @@ classDiagram
 |---|---|---|
 | `n_orbitals` | m_int32(int32) | Number of orbitals in the tight-binding model. The `entity_ref` reference is used to refer to the `ElectronicState` section, which navigates to the relevant basis orbitals (e.g., `SphericalSymmetryState`). |
 | `degeneracy_factors` | m_int32(int32) (shape: ['*']) | Degeneracy of each Wigner-Seitz point. |
-| `value` | m_complex128(complex128) | Value of the hopping matrix in joules. The elements are complex numbers defined for each Wigner-Seitz point and each pair of orbitals. Note this contains also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the `CrystalFieldSplitting` values. |
+| `value` | HDF5Dataset | Value of the hopping matrix in joules. The elements are complex numbers defined for each Wigner-Seitz point and each pair of orbitals. Note this contains also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the `CrystalFieldSplitting` values. The expected dataset dimensions are the Wigner-Seitz points followed by the two orbital indices. |
 
 ### `CrystalFieldSplitting`
 

--- a/docs/schema/manybody_properties.md
+++ b/docs/schema/manybody_properties.md
@@ -65,7 +65,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `value` | HDF5Dataset | Value of the electronic Green's function matrix. The dataset dimensions follow the represented spaces and matrix indices. |
+| `value` | HDF5Dataset | <details><summary>Value of the electronic Green's function matrix stored as an HDF5 dataset.</summary>Value of the electronic Green's function matrix stored as an HDF5 dataset.<br>The conventional dataset layout is [n_kpoints, n_frequencies, n_orbitals, n_orbitals]<br>for k- and frequency-resolved Green's functions, but the actual dimensions depend on<br>the represented spaces set via the `space_id` field.</details> |
 
 ### `ElectronicSelfEnergy`
 
@@ -75,7 +75,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `value` | HDF5Dataset | Value of the electronic self-energy matrix. The dataset dimensions follow the represented spaces and matrix indices. |
+| `value` | HDF5Dataset | <details><summary>Value of the electronic self-energy matrix stored as an HDF5 dataset.</summary>Value of the electronic self-energy matrix stored as an HDF5 dataset.<br>The conventional dataset layout is [n_kpoints, n_frequencies, n_orbitals, n_orbitals]<br>for k- and frequency-resolved self-energies, but the actual dimensions depend on<br>the represented spaces set via the `space_id` field.</details> |
 
 ### `HybridizationFunction`
 
@@ -85,7 +85,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `value` | HDF5Dataset | Value of the electronic hybridization function. The dataset dimensions follow the represented spaces and matrix indices. |
+| `value` | HDF5Dataset | <details><summary>Value of the electronic hybridization function stored as an HDF5 dataset.</summary>Value of the electronic hybridization function stored as an HDF5 dataset.<br>The conventional dataset layout is [n_kpoints, n_frequencies, n_orbitals, n_orbitals]<br>for k- and frequency-resolved hybridization functions, but the actual dimensions depend on<br>the represented spaces set via the `space_id` field.</details> |
 
 ### `QuasiparticleWeight`
 
@@ -112,7 +112,7 @@ classDiagram
 |---|---|---|
 | `n_orbitals` | m_int32(int32) | Number of orbitals in the tight-binding model. The `entity_ref` reference is used to refer to the `ElectronicState` section, which navigates to the relevant basis orbitals (e.g., `SphericalSymmetryState`). |
 | `degeneracy_factors` | m_int32(int32) (shape: ['*']) | Degeneracy of each Wigner-Seitz point. |
-| `value` | HDF5Dataset | Value of the hopping matrix in joules. The elements are complex numbers defined for each Wigner-Seitz point and each pair of orbitals. Note this contains also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the `CrystalFieldSplitting` values. The expected dataset dimensions are the Wigner-Seitz points followed by the two orbital indices. |
+| `value` | HDF5Dataset | <details><summary>Value of the hopping matrix in joules stored as an HDF5 dataset.</summary>Value of the hopping matrix in joules stored as an HDF5 dataset. The elements are complex<br>numbers defined for each Wigner-Seitz point and each pair of orbitals. Note this contains<br>also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the<br>`CrystalFieldSplitting` values. The conventional dataset layout is<br>[n_wigner_seitz_points, n_orbitals, n_orbitals].</details> |
 
 ### `CrystalFieldSplitting`
 

--- a/src/nomad_simulations/schema_packages/properties/greens_function.py
+++ b/src/nomad_simulations/schema_packages/properties/greens_function.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
+from nomad.datamodel.hdf5 import HDF5Dataset
 from nomad.metainfo import MEnum, Quantity, SubSection
 
 if TYPE_CHECKING:
@@ -170,10 +171,12 @@ class ElectronicGreensFunction(BaseGreensFunction):
     iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicGreensFunction'
 
     value = Quantity(
-        type=np.complex128,
+        type=HDF5Dataset,
+        shape=[],
         unit='1/joule',
         description="""
         Value of the electronic Green's function matrix.
+        The dataset dimensions follow the represented spaces and matrix indices.
         """,
     )
 
@@ -186,10 +189,12 @@ class ElectronicSelfEnergy(BaseGreensFunction):
     iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicSelfEnergy'
 
     value = Quantity(
-        type=np.complex128,
+        type=HDF5Dataset,
+        shape=[],
         unit='joule',
         description="""
         Value of the electronic self-energy matrix.
+        The dataset dimensions follow the represented spaces and matrix indices.
         """,
     )
 
@@ -202,10 +207,12 @@ class HybridizationFunction(BaseGreensFunction):
     iri = 'http://fairmat-nfdi.eu/taxonomy/HybridizationFunction'
 
     value = Quantity(
-        type=np.complex128,
+        type=HDF5Dataset,
+        shape=[],
         unit='joule',
         description="""
         Value of the electronic hybridization function.
+        The dataset dimensions follow the represented spaces and matrix indices.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/properties/greens_function.py
+++ b/src/nomad_simulations/schema_packages/properties/greens_function.py
@@ -175,8 +175,10 @@ class ElectronicGreensFunction(BaseGreensFunction):
         shape=[],
         unit='1/joule',
         description="""
-        Value of the electronic Green's function matrix.
-        The dataset dimensions follow the represented spaces and matrix indices.
+        Value of the electronic Green's function matrix stored as an HDF5 dataset.
+        The conventional dataset layout is [n_kpoints, n_frequencies, n_orbitals, n_orbitals]
+        for k- and frequency-resolved Green's functions, but the actual dimensions depend on
+        the represented spaces set via the `space_id` field.
         """,
     )
 
@@ -193,8 +195,10 @@ class ElectronicSelfEnergy(BaseGreensFunction):
         shape=[],
         unit='joule',
         description="""
-        Value of the electronic self-energy matrix.
-        The dataset dimensions follow the represented spaces and matrix indices.
+        Value of the electronic self-energy matrix stored as an HDF5 dataset.
+        The conventional dataset layout is [n_kpoints, n_frequencies, n_orbitals, n_orbitals]
+        for k- and frequency-resolved self-energies, but the actual dimensions depend on
+        the represented spaces set via the `space_id` field.
         """,
     )
 
@@ -211,8 +215,10 @@ class HybridizationFunction(BaseGreensFunction):
         shape=[],
         unit='joule',
         description="""
-        Value of the electronic hybridization function.
-        The dataset dimensions follow the represented spaces and matrix indices.
+        Value of the electronic hybridization function stored as an HDF5 dataset.
+        The conventional dataset layout is [n_kpoints, n_frequencies, n_orbitals, n_orbitals]
+        for k- and frequency-resolved hybridization functions, but the actual dimensions depend on
+        the represented spaces set via the `space_id` field.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/properties/hopping_matrix.py
+++ b/src/nomad_simulations/schema_packages/properties/hopping_matrix.py
@@ -44,9 +44,11 @@ class HoppingMatrix(PhysicalProperty):
         shape=[],
         unit='joule',
         description="""
-        Value of the hopping matrix in joules. The elements are complex numbers defined for each Wigner-Seitz point and
-        each pair of orbitals. Note this contains also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the `CrystalFieldSplitting` values.
-        The expected dataset dimensions are the Wigner-Seitz points followed by the two orbital indices.
+        Value of the hopping matrix in joules stored as an HDF5 dataset. The elements are complex
+        numbers defined for each Wigner-Seitz point and each pair of orbitals. Note this contains
+        also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the
+        `CrystalFieldSplitting` values. The conventional dataset layout is
+        [n_wigner_seitz_points, n_orbitals, n_orbitals].
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/properties/hopping_matrix.py
+++ b/src/nomad_simulations/schema_packages/properties/hopping_matrix.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
+from nomad.datamodel.hdf5 import HDF5Dataset
 from nomad.metainfo import Quantity
 
 if TYPE_CHECKING:
@@ -39,11 +40,13 @@ class HoppingMatrix(PhysicalProperty):
     )
 
     value = Quantity(
-        type=np.complex128,
+        type=HDF5Dataset,
+        shape=[],
         unit='joule',
         description="""
         Value of the hopping matrix in joules. The elements are complex numbers defined for each Wigner-Seitz point and
         each pair of orbitals. Note this contains also the onsite values, i.e., it includes the Wigner-Seitz point (0, 0, 0), hence the `CrystalFieldSplitting` values.
+        The expected dataset dimensions are the Wigner-Seitz points followed by the two orbital indices.
         """,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,15 @@
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Any
 
 import numpy as np
 import pytest
 import structlog
+from nomad import files, processing
 from nomad.datamodel import EntryArchive
+from nomad.datamodel.context import ServerContext
 from nomad.units import ureg
+from nomad.utils import create_uuid
 from structlog.testing import LogCapture
 
 from nomad_simulations.schema_packages.atoms_state import (
@@ -501,6 +504,46 @@ refs_apw = [
         ],
     },
 ]
+
+
+@pytest.fixture(scope='module')
+def hdf5_server_context() -> Generator[ServerContext, None, None]:
+    """
+    Module-scoped ServerContext backed by a temporary staging upload.
+
+    Use this fixture in any test module that needs to write HDF5 datasets to
+    the archive (e.g. tests for quantities typed as HDF5Dataset).  The upload
+    files are deleted after the module finishes.
+    """
+    upload_id = f'test_upload_hdf5_{create_uuid()}'
+    upload_files = files.StagingUploadFiles(upload_id, create=True)
+    upload = processing.Upload(upload_id=upload_id)
+    try:
+        yield ServerContext(upload=upload)
+    finally:
+        upload_files.delete()
+
+
+def assert_hdf5_dataset_matches(dataset_ref, expected: np.ndarray, dtype=None) -> None:
+    """
+    Open an HDF5Dataset reference and assert it matches *expected*.
+
+    Parameters
+    ----------
+    dataset_ref:
+        The HDF5Dataset value (HDF5Wrapper) returned by a quantity accessor.
+    expected:
+        NumPy array the dataset should equal.
+    dtype:
+        If given, assert ``dataset.dtype == np.dtype(dtype)``.  When *None*
+        the dtype check is skipped (useful for testing pass-through of
+        non-standard dtypes).
+    """
+    with dataset_ref as dataset:
+        if dtype is not None:
+            assert dataset.dtype == np.dtype(dtype)
+        assert dataset.shape == expected.shape
+        assert np.array_equal(dataset[()], expected)
 
 
 @pytest.fixture

--- a/tests/properties/test_hdf5_matrix_properties.py
+++ b/tests/properties/test_hdf5_matrix_properties.py
@@ -28,14 +28,23 @@ class MatrixPropertiesTestEntry(EntryData):
     molecular_orbitals = SubSection(sub_section=MolecularOrbitals.m_def)
 
 
-@pytest.fixture
-def archive_with_matrix_properties() -> Generator[
-    tuple[EntryArchive, MatrixPropertiesTestEntry, str, str], None, None
-]:
+@pytest.fixture(scope='module')
+def server_context() -> Generator[ServerContext, None, None]:
     upload_id = f'test_upload_matrix_properties_h5_{create_uuid()}'
-    entry_id = 'test_entry_matrix_properties_h5'
     upload_files = files.StagingUploadFiles(upload_id, create=True)
     upload = processing.Upload(upload_id=upload_id)
+    try:
+        yield ServerContext(upload=upload)
+    finally:
+        upload_files.delete()
+
+
+@pytest.fixture
+def archive_with_matrix_properties(
+    server_context: ServerContext,
+) -> tuple[EntryArchive, MatrixPropertiesTestEntry, str, str]:
+    upload_id = server_context.upload.upload_id
+    entry_id = 'test_entry_matrix_properties_h5'
     data = MatrixPropertiesTestEntry(
         electronic_greens_function=ElectronicGreensFunction(),
         electronic_self_energy=ElectronicSelfEnergy(),
@@ -44,14 +53,11 @@ def archive_with_matrix_properties() -> Generator[
         molecular_orbitals=MolecularOrbitals(),
     )
     archive = EntryArchive(
-        m_context=ServerContext(upload=upload),
+        m_context=server_context,
         metadata=EntryMetadata(upload_id=upload_id, entry_id=entry_id),
         data=data,
     )
-    try:
-        yield archive, data, upload_id, entry_id
-    finally:
-        upload_files.delete()
+    return archive, data, upload_id, entry_id
 
 
 def test_complex_matrix_properties_are_stored_in_hdf5(

--- a/tests/properties/test_hdf5_matrix_properties.py
+++ b/tests/properties/test_hdf5_matrix_properties.py
@@ -1,0 +1,106 @@
+from collections.abc import Generator
+
+import numpy as np
+import pytest
+from nomad import files, processing
+from nomad.datamodel import EntryArchive, EntryMetadata
+from nomad.datamodel.context import ServerContext
+from nomad.datamodel.data import EntryData
+from nomad.metainfo import SubSection
+from nomad.utils import create_uuid
+
+from nomad_simulations.schema_packages.properties import (
+    ElectronicGreensFunction,
+    ElectronicSelfEnergy,
+    HoppingMatrix,
+    HybridizationFunction,
+)
+from nomad_simulations.schema_packages.properties.molecular_orbitals import (
+    MolecularOrbitals,
+)
+
+
+class MatrixPropertiesTestEntry(EntryData):
+    electronic_greens_function = SubSection(sub_section=ElectronicGreensFunction.m_def)
+    electronic_self_energy = SubSection(sub_section=ElectronicSelfEnergy.m_def)
+    hybridization_function = SubSection(sub_section=HybridizationFunction.m_def)
+    hopping_matrix = SubSection(sub_section=HoppingMatrix.m_def)
+    molecular_orbitals = SubSection(sub_section=MolecularOrbitals.m_def)
+
+
+@pytest.fixture
+def archive_with_matrix_properties() -> Generator[
+    tuple[EntryArchive, MatrixPropertiesTestEntry, str, str], None, None
+]:
+    upload_id = f'test_upload_matrix_properties_h5_{create_uuid()}'
+    entry_id = 'test_entry_matrix_properties_h5'
+    upload_files = files.StagingUploadFiles(upload_id, create=True)
+    upload = processing.Upload(upload_id=upload_id)
+    data = MatrixPropertiesTestEntry(
+        electronic_greens_function=ElectronicGreensFunction(),
+        electronic_self_energy=ElectronicSelfEnergy(),
+        hybridization_function=HybridizationFunction(),
+        hopping_matrix=HoppingMatrix(),
+        molecular_orbitals=MolecularOrbitals(),
+    )
+    archive = EntryArchive(
+        m_context=ServerContext(upload=upload),
+        metadata=EntryMetadata(upload_id=upload_id, entry_id=entry_id),
+        data=data,
+    )
+    try:
+        yield archive, data, upload_id, entry_id
+    finally:
+        upload_files.delete()
+
+
+def test_complex_matrix_properties_are_stored_in_hdf5(
+    archive_with_matrix_properties,
+):
+    archive, data, upload_id, entry_id = archive_with_matrix_properties
+    values = {
+        'electronic_greens_function': np.array(
+            [[[[1.0 + 2.0j, 3.0 - 4.0j]]]], dtype=np.complex128
+        ),
+        'electronic_self_energy': np.array(
+            [[[[5.0 - 6.0j, 7.0 + 8.0j]]]], dtype=np.complex128
+        ),
+        'hybridization_function': np.array(
+            [[[[9.0 + 10.0j, 11.0 - 12.0j]]]], dtype=np.complex128
+        ),
+        'hopping_matrix': np.array(
+            [[[13.0 + 14.0j, 15.0 - 16.0j]]], dtype=np.complex128
+        ),
+    }
+    mo_coefficients = np.array([[1.0, 0.0], [0.1, 0.9]], dtype=np.float64)
+    mo_coefficients_im = np.array([[0.0, 0.0], [0.2, -0.2]], dtype=np.float64)
+
+    for quantity_name, value in values.items():
+        getattr(data, quantity_name).value = value
+    data.molecular_orbitals.mo_coefficients = mo_coefficients
+    data.molecular_orbitals.mo_coefficients_im = mo_coefficients_im
+
+    serialized = archive.m_to_dict()
+
+    for quantity_name, expected in values.items():
+        assert (
+            serialized['data'][quantity_name]['value']
+            == f'/uploads/{upload_id}/archive/{entry_id}#/data/{quantity_name}/value'
+        )
+        with getattr(data, quantity_name).value as dataset:
+            assert dataset.dtype == np.dtype(np.complex128)
+            assert dataset.shape == expected.shape
+            assert np.array_equal(dataset[()], expected)
+
+    for quantity_name, expected in (
+        ('mo_coefficients', mo_coefficients),
+        ('mo_coefficients_im', mo_coefficients_im),
+    ):
+        assert (
+            serialized['data']['molecular_orbitals'][quantity_name]
+            == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/{quantity_name}'
+        )
+        with getattr(data.molecular_orbitals, quantity_name) as dataset:
+            assert dataset.dtype == np.dtype(np.float64)
+            assert dataset.shape == expected.shape
+            assert np.array_equal(dataset[()], expected)

--- a/tests/properties/test_hdf5_matrix_properties.py
+++ b/tests/properties/test_hdf5_matrix_properties.py
@@ -1,13 +1,21 @@
-from collections.abc import Generator
+"""
+Tests for matrix quantities migrated to HDF5Dataset:
+  ElectronicGreensFunction.value, ElectronicSelfEnergy.value,
+  HybridizationFunction.value, HoppingMatrix.value.
+
+Key behavioral notes (documented here, not enforced by infrastructure):
+- HDF5Dataset accepts any numpy array without dtype enforcement.  If you
+  pass complex64 instead of complex128 it will be stored as complex64.
+- Empty arrays (zero-size leading dimension) are stored and read back
+  correctly.
+"""
 
 import numpy as np
 import pytest
-from nomad import files, processing
 from nomad.datamodel import EntryArchive, EntryMetadata
 from nomad.datamodel.context import ServerContext
 from nomad.datamodel.data import EntryData
 from nomad.metainfo import SubSection
-from nomad.utils import create_uuid
 
 from nomad_simulations.schema_packages.properties import (
     ElectronicGreensFunction,
@@ -19,6 +27,8 @@ from nomad_simulations.schema_packages.properties.molecular_orbitals import (
     MolecularOrbitals,
 )
 
+from ..conftest import assert_hdf5_dataset_matches
+
 
 class MatrixPropertiesTestEntry(EntryData):
     electronic_greens_function = SubSection(sub_section=ElectronicGreensFunction.m_def)
@@ -28,23 +38,16 @@ class MatrixPropertiesTestEntry(EntryData):
     molecular_orbitals = SubSection(sub_section=MolecularOrbitals.m_def)
 
 
-@pytest.fixture(scope='module')
-def server_context() -> Generator[ServerContext, None, None]:
-    upload_id = f'test_upload_matrix_properties_h5_{create_uuid()}'
-    upload_files = files.StagingUploadFiles(upload_id, create=True)
-    upload = processing.Upload(upload_id=upload_id)
-    try:
-        yield ServerContext(upload=upload)
-    finally:
-        upload_files.delete()
+# ---------------------------------------------------------------------------
+# Helper that builds a fresh archive for each test to avoid HDF5 path clashes
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def archive_with_matrix_properties(
+def _make_archive(
     server_context: ServerContext,
-) -> tuple[EntryArchive, MatrixPropertiesTestEntry, str, str]:
+    entry_id: str,
+) -> tuple[EntryArchive, MatrixPropertiesTestEntry]:
     upload_id = server_context.upload.upload_id
-    entry_id = 'test_entry_matrix_properties_h5'
     data = MatrixPropertiesTestEntry(
         electronic_greens_function=ElectronicGreensFunction(),
         electronic_self_energy=ElectronicSelfEnergy(),
@@ -57,56 +60,152 @@ def archive_with_matrix_properties(
         metadata=EntryMetadata(upload_id=upload_id, entry_id=entry_id),
         data=data,
     )
-    return archive, data, upload_id, entry_id
+    return archive, data
 
 
-def test_complex_matrix_properties_are_stored_in_hdf5(
-    archive_with_matrix_properties,
-):
-    archive, data, upload_id, entry_id = archive_with_matrix_properties
-    values = {
-        'electronic_greens_function': np.array(
-            [[[[1.0 + 2.0j, 3.0 - 4.0j]]]], dtype=np.complex128
-        ),
-        'electronic_self_energy': np.array(
-            [[[[5.0 - 6.0j, 7.0 + 8.0j]]]], dtype=np.complex128
-        ),
-        'hybridization_function': np.array(
-            [[[[9.0 + 10.0j, 11.0 - 12.0j]]]], dtype=np.complex128
-        ),
-        'hopping_matrix': np.array(
-            [[[13.0 + 14.0j, 15.0 - 16.0j]]], dtype=np.complex128
-        ),
-    }
-    mo_coefficients = np.array([[1.0, 0.0], [0.1, 0.9]], dtype=np.float64)
-    mo_coefficients_im = np.array([[0.0, 0.0], [0.2, -0.2]], dtype=np.float64)
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
-    for quantity_name, value in values.items():
-        getattr(data, quantity_name).value = value
-    data.molecular_orbitals.mo_coefficients = mo_coefficients
-    data.molecular_orbitals.mo_coefficients_im = mo_coefficients_im
 
-    serialized = archive.m_to_dict()
+class TestMatrixHDF5Storage:
+    """Happy-path and edge-case tests for HDF5-backed matrix quantities."""
 
-    for quantity_name, expected in values.items():
-        assert (
-            serialized['data'][quantity_name]['value']
-            == f'/uploads/{upload_id}/archive/{entry_id}#/data/{quantity_name}/value'
-        )
-        with getattr(data, quantity_name).value as dataset:
-            assert dataset.dtype == np.dtype(np.complex128)
-            assert dataset.shape == expected.shape
-            assert np.array_equal(dataset[()], expected)
-
-    for quantity_name, expected in (
-        ('mo_coefficients', mo_coefficients),
-        ('mo_coefficients_im', mo_coefficients_im),
+    def test_valid_complex128_arrays_stored_and_read_back(
+        self, hdf5_server_context: ServerContext
     ):
-        assert (
-            serialized['data']['molecular_orbitals'][quantity_name]
-            == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/{quantity_name}'
+        """Valid complex128 arrays are stored and round-trip through HDF5."""
+        archive, data = _make_archive(hdf5_server_context, 'entry_valid_complex128')
+        upload_id = hdf5_server_context.upload.upload_id
+
+        values = {
+            'electronic_greens_function': np.array(
+                [[[[1.0 + 2.0j, 3.0 - 4.0j]]]], dtype=np.complex128
+            ),
+            'electronic_self_energy': np.array(
+                [[[[5.0 - 6.0j, 7.0 + 8.0j]]]], dtype=np.complex128
+            ),
+            'hybridization_function': np.array(
+                [[[[9.0 + 10.0j, 11.0 - 12.0j]]]], dtype=np.complex128
+            ),
+            'hopping_matrix': np.array(
+                [[[13.0 + 14.0j, 15.0 - 16.0j]]], dtype=np.complex128
+            ),
+        }
+        mo_coefficients = np.array([[1.0, 0.0], [0.1, 0.9]], dtype=np.float64)
+        mo_coefficients_im = np.array([[0.0, 0.0], [0.2, -0.2]], dtype=np.float64)
+
+        for quantity_name, value in values.items():
+            getattr(data, quantity_name).value = value
+        data.molecular_orbitals.mo_coefficients = mo_coefficients
+        data.molecular_orbitals.mo_coefficients_im = mo_coefficients_im
+
+        serialized = archive.m_to_dict()
+        entry_id = archive.metadata.entry_id
+
+        for quantity_name, expected in values.items():
+            assert (
+                serialized['data'][quantity_name]['value']
+                == f'/uploads/{upload_id}/archive/{entry_id}#/data/{quantity_name}/value'
+            )
+            assert_hdf5_dataset_matches(
+                getattr(data, quantity_name).value,
+                expected,
+                dtype=np.complex128,
+            )
+
+        for quantity_name, expected in (
+            ('mo_coefficients', mo_coefficients),
+            ('mo_coefficients_im', mo_coefficients_im),
+        ):
+            assert (
+                serialized['data']['molecular_orbitals'][quantity_name]
+                == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/{quantity_name}'
+            )
+            assert_hdf5_dataset_matches(
+                getattr(data.molecular_orbitals, quantity_name),
+                expected,
+                dtype=np.float64,
+            )
+
+    def test_empty_complex_array_stored_and_read_back(
+        self, hdf5_server_context: ServerContext
+    ):
+        """An empty leading dimension is stored and read back with the correct shape."""
+        archive, data = _make_archive(hdf5_server_context, 'entry_empty_array')
+
+        # shape (0, 2, 2, 2): zero k-points, but well-formed orbital dimensions
+        empty_gf = np.zeros((0, 2, 2, 2), dtype=np.complex128)
+        data.electronic_greens_function.value = empty_gf
+        archive.m_to_dict()
+
+        assert_hdf5_dataset_matches(
+            data.electronic_greens_function.value,
+            empty_gf,
+            dtype=np.complex128,
         )
-        with getattr(data.molecular_orbitals, quantity_name) as dataset:
-            assert dataset.dtype == np.dtype(np.float64)
-            assert dataset.shape == expected.shape
-            assert np.array_equal(dataset[()], expected)
+
+    def test_dtype_passthrough_not_enforced(self, hdf5_server_context: ServerContext):
+        """
+        HDF5Dataset does not enforce dtype at the schema level.
+
+        Since the quantity type changed from Quantity(type=np.complex128) to
+        Quantity(type=HDF5Dataset), dtype validation no longer happens
+        automatically.  Whatever dtype the caller provides is stored as-is.
+        This test documents the current behavior: a complex64 array is accepted
+        and stored with dtype complex64, not upcasted to complex128.
+        """
+        archive, data = _make_archive(hdf5_server_context, 'entry_dtype_passthrough')
+
+        arr_c64 = np.array([[[[1.0 + 2.0j]]]], dtype=np.complex64)
+        data.electronic_greens_function.value = arr_c64
+        archive.m_to_dict()
+
+        # No dtype constraint passed — just verify shape and values round-trip
+        assert_hdf5_dataset_matches(
+            data.electronic_greens_function.value,
+            arr_c64,
+        )
+        # Document explicitly that the stored dtype is the caller's dtype
+        with data.electronic_greens_function.value as ds:
+            assert ds.dtype == np.dtype(np.complex64), (
+                'HDF5Dataset stores the array with the caller-supplied dtype; '
+                'no automatic upcasting to complex128 occurs.'
+            )
+
+    def test_hopping_matrix_expected_shape(self, hdf5_server_context: ServerContext):
+        """HoppingMatrix.value stores [n_wigner_seitz_points, n_orbitals, n_orbitals]."""
+        archive, data = _make_archive(hdf5_server_context, 'entry_hopping_shape')
+
+        n_r, n_orb = 3, 2
+        hopping = np.arange(n_r * n_orb * n_orb, dtype=np.complex128).reshape(
+            n_r, n_orb, n_orb
+        )
+        data.hopping_matrix.value = hopping
+        archive.m_to_dict()
+
+        assert_hdf5_dataset_matches(
+            data.hopping_matrix.value,
+            hopping,
+            dtype=np.complex128,
+        )
+
+    def test_greens_function_expected_shape(self, hdf5_server_context: ServerContext):
+        """ElectronicGreensFunction.value stores [n_kpoints, n_freq, n_orb, n_orb]."""
+        archive, data = _make_archive(hdf5_server_context, 'entry_gf_shape')
+
+        n_k, n_f, n_o = 2, 4, 3
+        gf = (
+            np.arange(n_k * n_f * n_o * n_o, dtype=np.float64).reshape(
+                n_k, n_f, n_o, n_o
+            )
+            + 1j * np.ones((n_k, n_f, n_o, n_o))
+        ).astype(np.complex128)
+        data.electronic_greens_function.value = gf
+        archive.m_to_dict()
+
+        assert_hdf5_dataset_matches(
+            data.electronic_greens_function.value,
+            gf,
+            dtype=np.complex128,
+        )

--- a/tests/properties/test_hdf5_matrix_properties.py
+++ b/tests/properties/test_hdf5_matrix_properties.py
@@ -114,17 +114,17 @@ class TestMatrixHDF5Storage:
                 dtype=np.complex128,
             )
 
-        for quantity_name, expected in (
+        for mo_name, mo_expected in (
             ('mo_coefficients', mo_coefficients),
             ('mo_coefficients_im', mo_coefficients_im),
         ):
             assert (
-                serialized['data']['molecular_orbitals'][quantity_name]
-                == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/{quantity_name}'
+                serialized['data']['molecular_orbitals'][mo_name]
+                == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/{mo_name}'
             )
             assert_hdf5_dataset_matches(
-                getattr(data.molecular_orbitals, quantity_name),
-                expected,
+                getattr(data.molecular_orbitals, mo_name),
+                mo_expected,
                 dtype=np.float64,
             )
 

--- a/tests/properties/test_molecular_orbitals.py
+++ b/tests/properties/test_molecular_orbitals.py
@@ -54,32 +54,6 @@ def archive_with_mo() -> Generator[
 
 
 class TestMolecularOrbitals:
-    def test_mo_coefficients_are_stored_in_hdf5(self, archive_with_mo):
-        archive, molecular_orbitals, upload_id, entry_id = archive_with_mo
-        coeff_real = np.array([[1.0, 0.0], [0.1, 0.9]], dtype=np.float64)
-        coeff_imag = np.array([[0.0, 0.0], [0.2, -0.2]], dtype=np.float64)
-
-        molecular_orbitals.mo_coefficients = coeff_real
-        molecular_orbitals.mo_coefficients_im = coeff_imag
-
-        serialized = archive.m_to_dict()
-        assert (
-            serialized['data']['molecular_orbitals']['mo_coefficients']
-            == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/mo_coefficients'
-        )
-        assert (
-            serialized['data']['molecular_orbitals']['mo_coefficients_im']
-            == f'/uploads/{upload_id}/archive/{entry_id}#/data/molecular_orbitals/mo_coefficients_im'
-        )
-
-        with molecular_orbitals.mo_coefficients as dataset:
-            assert dataset.shape == (2, 2)
-            assert np.allclose(dataset[()], coeff_real)
-
-        with molecular_orbitals.mo_coefficients_im as dataset:
-            assert dataset.shape == (2, 2)
-            assert np.allclose(dataset[()], coeff_imag)
-
     def test_normalize_infers_dimensions_from_hdf5_coefficients(self, archive_with_mo):
         _, molecular_orbitals, _, _ = archive_with_mo
         coeff_real = np.array(


### PR DESCRIPTION
## Purpose

Reduce archive JSON size and serialization overhead for large matrix-valued properties by storing their numerical payloads as `HDF5Dataset` references.

## Scope

**Included**

- Migrate the following complex-valued quantities to `HDF5Dataset`:
  - `ElectronicGreensFunction.value`
  - `ElectronicSelfEnergy.value`
  - `HybridizationFunction.value`
  - `HoppingMatrix.value`
- Verify native `complex128` HDF5 serialization and reading.
- Consolidate HDF5 round-trip testing for migrated properties and molecular-orbital coefficients.

**Out of scope**

- Migrating the following moderate-sized quantities:
  - `contraction_coefficients`
  - ECP projector `coefficient`
  - `u_matrix`

These quantities are typically small, and storing them as separate HDF5 datasets would add reference and access overhead without meaningfully reducing archive size. Existing normalization logic also accesses them directly through operations such as `len()` and array indexing.

- Parser changes. No active parser assignments to the migrated quantities were found.

## Context & Links

- Resolves #397
- Follows the `HDF5Dataset` migration pattern established in #364.

## Reviewer Notes

The migrated quantities now serialize as HDF5 references instead of inline complex arrays.

## Status

- [x] Ready for review


## Breaking Changes

- [x] The migrated quantities now serialize as HDF5 references. Downstream code assuming direct array values must dereference the HDF5 datasets.

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Unit tests
- [x] Manual testing: verified native `complex128` HDF5 serialization and round-trip reading.

