### PR TITLE
fixed AtomsState/CGBeadState type check sequence in archive_to_universe

### DIFF
--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -427,7 +427,7 @@ def archive_to_universe(
         return None
     particle_names = [ps.label for ps in particle_states]
     particle_types = [
-        ps.chemical_symbol or (ps.bead_symbol if isinstance(ps, CGBeadState) else 'CGX')
+        (ps.bead_symbol if isinstance(ps, CGBeadState) else ps.chemical_symbol) or 'CGX'
         for ps in particle_states
     ]
 
@@ -475,9 +475,9 @@ def archive_to_universe(
             )
         else:
             _missing_masses += 1
-            symbol = ps.chemical_symbol or (
-                ps.bead_symbol if isinstance(ps, CGBeadState) else 'CGX'
-            )
+            symbol = (
+                ps.bead_symbol if isinstance(ps, CGBeadState) else ps.chemical_symbol
+            ) or 'CGX'
             ase_mass = (
                 ase.data.atomic_masses[ase.data.atomic_numbers.get(symbol, 0)]
                 if symbol is not None


### PR DESCRIPTION
## Purpose
Previously, `archive_to_universe` tried to access `chemical_symbol` without checking if the archive contained `AtomsState` objects (`chemical_symbol` exists), or `CGBeadState` objects (`c hemical_symbol` not defined, crash).

## Scope

**Included**
Changed sequence of checks, now the object type is evaluated first, dependent Quantities are conditionally accessed depending on the outcome of the first check.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Testing / Validation

_How was this change validated?_

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (explain):


