### PR TITLE
Prune long trajectory

### DIFF
--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -495,13 +495,13 @@ def archive_to_universe(
             _charges_list.append(0.0)
     if _missing_masses:
         LOGGER.warning(
-            '%d particle(s) missing mass; atomic particles fall back to ASE defaults, '
-            'CG particles default to 0.0.',
-            _missing_masses,
+            'particles missing mass; atomic fall back to ASE defaults, CG default to 0.0',
+            count=_missing_masses,
         )
     if _missing_charges:
         LOGGER.warning(
-            '%d particle(s) missing charge; defaulting to 0.0.', _missing_charges
+            'particles missing charge; defaulting to 0.0',
+            count=_missing_charges,
         )
 
     masses = np.array(_masses_list)

--- a/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/utils/molecular_dynamics.py
@@ -427,7 +427,7 @@ def archive_to_universe(
         return None
     particle_names = [ps.label for ps in particle_states]
     particle_types = [
-        ps.chemical_symbol or (ps.bead_symbol if isinstance(ps, CGBeadState) else 'CGX')
+        (ps.bead_symbol if isinstance(ps, CGBeadState) else ps.chemical_symbol) or 'CGX'
         for ps in particle_states
     ]
 
@@ -475,9 +475,9 @@ def archive_to_universe(
             )
         else:
             _missing_masses += 1
-            symbol = ps.chemical_symbol or (
-                ps.bead_symbol if isinstance(ps, CGBeadState) else 'CGX'
-            )
+            symbol = (
+                ps.bead_symbol if isinstance(ps, CGBeadState) else ps.chemical_symbol
+            ) or 'CGX'
             ase_mass = (
                 ase.data.atomic_masses[ase.data.atomic_numbers.get(symbol, 0)]
                 if symbol is not None

--- a/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
+++ b/src/nomad_simulations/schema_packages/workflow/molecular_dynamics.py
@@ -1172,12 +1172,19 @@ class MolecularDynamicsResults(SerialWorkflowResults):
             return self.radial_distribution_functions
 
         n_traj_split = 10  # number of intervals to split trajectory into for averaging
+        _ANALYSIS_MAX_FRAMES = 100
         try:
             n_prune = int(
                 self._universe.trajectory.n_frames / len(archive.data.model_system)
             )
         except Exception:
             n_prune = 1
+        n_universe_frames = self._universe.trajectory.n_frames
+        if n_universe_frames > _ANALYSIS_MAX_FRAMES:
+            n_prune = max(
+                n_prune,
+                int(np.ceil(n_universe_frames / _ANALYSIS_MAX_FRAMES)),
+            )
 
         interval_indices: list[
             np.ndarray


### PR DESCRIPTION
## Purpose
Long trajectories caused parsing to hang indefinitely. Pair generation for molecular RDF calculation failed if codes didn't provide clear molecule type identifiers (Lammps).

## Scope

### Root cause: incorrect molecule type detection for LAMMPS archives

`get_fragtypes()` in `mdanalysisparser.py` used order-sensitive array comparison to
identify molecule types by composition. For LAMMPS, where atom ordering within a
molecule is not canonical, each molecule was assigned a unique type. For
hexane/cyclohexane (36 molecules), this produced 666 RDF pairs instead of 3,
causing the normalizer to hang.

**Fix:** sort atom type arrays before comparing so composition-based matching is
order-independent.

### Downstream fix: molecule names in LAMMPS hierarchy

`archive_to_universe` reconstructs MDAnalysis moltypes from `mol.name`. The LAMMPS
parser was setting each molecule's name to its integer molecule ID, so even after
`get_fragtypes` produced 2 unique types, the 36 unique IDs reintroduced 36 unique
moltypes at the archive level.

**Fix:** `_create_molecule` accepts a `moltype_name` parameter; `_create_molecule_group`
passes `str(moltype)` so all molecules within a group share the same name — matching
the convention already used by parsers with named topologies (e.g. GROMACS).

### Safety net: frame downsampling for large trajectories

`_get_molecular_rdfs` in `MolecularDynamicsResults` always passed `n_prune=1` for
trajectories where every model system maps to one universe frame. For large
trajectories this makes RDF computation scale linearly with frame count.

**Fix:** when `universe.n_frames > 100`, `n_prune` is increased to
`ceil(n_frames / 100)` so at most ~100 frames are sampled per RDF interval.

### Files changed

| File | Location |
|------|----------|
| `parsers/utils/mdanalysisparser.py` | `get_fragtypes()` |
| `parsers/lammps/parser.py` | `_create_molecule()`, `_create_molecule_group()` |
| `nomad_simulations/workflow/molecular_dynamics.py` | `MolecularDynamicsResults._get_molecular_rdfs()` |


## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

_How was this change validated?_

- [x] Unit tests
- [x] Integration tests


