### PR TITLE
fix nonexistent outputs attributes

### DIFF
--- a/src/nomad_simulations/schema_packages/properties/permittivity.py
+++ b/src/nomad_simulations/schema_packages/properties/permittivity.py
@@ -97,4 +97,4 @@ class Permittivity(PhysicalProperty):
         # `AbsorptionSpectrum` extraction
         absorption_spectra = self.extract_absorption_spectra(logger)
         if absorption_spectra is not None:
-            self.m_parent.absorption_spectra.extend(absorption_spectra)
+            self.m_parent.m_append('absorption_spectra', absorption_spectra)

--- a/src/nomad_simulations/schema_packages/properties/permittivity.py
+++ b/src/nomad_simulations/schema_packages/properties/permittivity.py
@@ -97,4 +97,4 @@ class Permittivity(PhysicalProperty):
         # `AbsorptionSpectrum` extraction
         absorption_spectra = self.extract_absorption_spectra(logger)
         if absorption_spectra is not None:
-            self.m_parent.absorption_spectrum = absorption_spectra
+            self.m_parent.absorption_spectra.extend(absorption_spectra)

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -487,7 +487,7 @@ class ElectronicDensityOfStates(DOSProfile):
         # `ElectronicBandGap` extraction
         band_gap = self.extract_band_gap()
         if band_gap is not None:
-            self.m_parent.electronic_band_gap.append(band_gap)
+            self.m_parent.electronic_band_gaps.append(band_gap)
 
         # Total `value` extraction from `projected_dos`
         value_from_pdos = self.generate_from_projected_dos(logger)

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -487,7 +487,7 @@ class ElectronicDensityOfStates(DOSProfile):
         # `ElectronicBandGap` extraction
         band_gap = self.extract_band_gap()
         if band_gap is not None:
-            self.m_parent.electronic_band_gaps.append(band_gap)
+            self.m_parent.m_append('electronic_band_gaps', band_gap)
 
         # Total `value` extraction from `projected_dos`
         value_from_pdos = self.generate_from_projected_dos(logger)


### PR DESCRIPTION
## Purpose

`ElectronicDensityOfStates.normalize` and `Permittivity.normalize` store their derived
property on `self.m_parent` under singular attribute names (`electronic_band_gap`,
`absorption_spectrum`), while `Outputs` only declares the plural repeating subsections
(`electronic_band_gaps`, `absorption_spectra`). As a result, DOS band-gap extraction
crashes with `AttributeError` whenever a gap is derivable, and derived absorption
spectra are silently dropped and never reach the archive.

## Scope

**Included**

- `spectral_profile.py`: append the derived band gap to `Outputs.electronic_band_gaps`
- `permittivity.py`: extend `Outputs.absorption_spectra` with the derived spectra


## Context & Links

-  Two one-line attribute-name fixes; reproduced and verified against a minimal
  `Outputs` + sibling `ElectronicEigenvalues` / `Permittivity` setup.

## Status

- [x] Ready for review

## Breaking Changes

- [x] Fix

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Manual testing (explain):
  before the fix, DOS normalization raised `AttributeError: electronic_band_gap` and
  permittivity-derived spectra were lost on serialization; after the fix, both land in
  the declared `Outputs` subsections and appear in `m_to_dict()`

