### PR TITLE
fix band gap extraction minor bugs

### DIFF
--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -365,7 +365,7 @@ class ElectronicDensityOfStates(DOSProfile):
         band_gap = None
         homo = self.m_cache.get('highest_occupied_energy')
         lumo = self.m_cache.get('lowest_unoccupied_energy')
-        if homo and lumo:
+        if homo is not None and lumo is not None:
             band_gap = ElectronicBandGap()
             band_gap.is_derived = True
             band_gap.physical_property_ref = self

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -290,7 +290,6 @@ class ElectronicDensityOfStates(DOSProfile):
                     except IndexError:
                         break
                     if value > configuration.dos_intensities_threshold:
-                        idx = idx if idx == idx_descend else idx + 1
                         self.m_cache['highest_occupied_energy'] = energies_points[idx]
                         break
                     idx -= 1
@@ -302,7 +301,6 @@ class ElectronicDensityOfStates(DOSProfile):
                     except IndexError:
                         break
                     if value > configuration.dos_intensities_threshold:
-                        idx = idx if idx == idx_ascend else idx - 1
                         self.m_cache['lowest_unoccupied_energy'] = energies_points[idx]
                         break
                     idx += 1

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -284,11 +284,8 @@ class ElectronicDensityOfStates(DOSProfile):
             if not single_peak_fermi:
                 # Look for highest occupied energy below the descend index
                 idx = idx_descend
-                while True:
-                    try:
-                        value = dos_values[idx]
-                    except IndexError:
-                        break
+                while idx >= 0:
+                    value = dos_values[idx]
                     if value > configuration.dos_intensities_threshold:
                         self.m_cache['highest_occupied_energy'] = energies_points[idx]
                         break

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -303,7 +303,7 @@ class ElectronicDensityOfStates(DOSProfile):
                         break
                     if value > configuration.dos_intensities_threshold:
                         idx = idx if idx == idx_ascend else idx - 1
-                        self.m_cache['highest_occupied_energy'] = energies_points[idx]
+                        self.m_cache['lowest_unoccupied_energy'] = energies_points[idx]
                         break
                     idx += 1
 
@@ -356,8 +356,8 @@ class ElectronicDensityOfStates(DOSProfile):
     def extract_band_gap(self) -> ElectronicBandGap | None:
         """
         Extract the electronic band gap from the `highest_occupied_energy` and `lowest_unoccupied_energy` stored
-        in `m_cache` from `resolve_energies_origin()`. If the difference of `highest_occupied_energy` and
-        `lowest_unoccupied_energy` is negative, the band gap `value` is set to 0.0.
+        in `m_cache` from `resolve_energies_origin()`. If the difference of `lowest_unoccupied_energy` and
+        `highest_occupied_energy` is negative, the band gap `value` is set to 0.0.
 
         Returns:
             (Optional[ElectronicBandGap]): The extracted electronic band gap section to be stored in `Outputs`.
@@ -370,10 +370,10 @@ class ElectronicDensityOfStates(DOSProfile):
             band_gap.is_derived = True
             band_gap.physical_property_ref = self
 
-            if (homo - lumo).magnitude < 0:
+            if (lumo - homo).magnitude < 0:
                 band_gap.value = 0.0
             else:
-                band_gap.value = homo - lumo
+                band_gap.value = lumo - homo
         return band_gap
 
     def extract_projected_dos(

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -39,8 +39,9 @@ class TestElectronicDensityOfStates:
 
         The DOS grid runs from -0.5 to 0.5 eV in steps of 0.01 eV, with a valence band
         below -0.2 eV and a conduction band above 0.3 eV. With the Fermi level inside
-        the gap, the HOMO/LUMO stored in `m_cache` are the gap-side grid points
-        adjacent to the band edges.
+        the gap, the HOMO/LUMO stored in `m_cache` are the highest occupied and lowest
+        unoccupied DOS points, i.e., the band-edge grid points where the DOS is
+        non-zero.
         """
         # ! extend to the `ElectronicEigenvalues` sibling path once it is implemented
         electronic_dos = ElectronicDensityOfStates()
@@ -58,14 +59,14 @@ class TestElectronicDensityOfStates:
 
         homo = electronic_dos.m_cache.get('highest_occupied_energy')
         lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
-        assert np.isclose(homo.to('eV').magnitude, -0.19)
-        assert np.isclose(lumo.to('eV').magnitude, 0.29)
+        assert np.isclose(homo.to('eV').magnitude, -0.20)
+        assert np.isclose(lumo.to('eV').magnitude, 0.30)
         assert energies_origin == homo
 
         # The cached energies produce a finite DOS-derived band gap
         band_gap = electronic_dos.extract_band_gap()
         assert band_gap is not None
-        assert np.isclose(band_gap.value.to('eV').magnitude, 0.48)
+        assert np.isclose(band_gap.value.to('eV').magnitude, 0.50)
 
     def test_resolve_energies_origin_metallic(self):
         """

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -95,6 +95,25 @@ class TestElectronicDensityOfStates:
         assert band_gap is not None
         assert np.isclose(band_gap.value.to('eV').magnitude, 0.0, atol=1e-12)
 
+    def test_resolve_energies_origin_without_occupied_states(self):
+        """The HOMO search must not wrap around to the end of the DOS array."""
+        electronic_dos = ElectronicDensityOfStates()
+        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
+        dos_values = np.zeros(101)
+        dos_values[80:] = 1.0  # unoccupied states only: E >= 0.30 eV
+        electronic_dos.value = dos_values * ureg('1/joule')
+
+        energies_origin = electronic_dos.resolve_energies_origin(
+            energies_points=energies_points,
+            fermi_level=0.0 * ureg.eV,
+            logger=logger,
+        )
+
+        assert electronic_dos.m_cache.get('highest_occupied_energy') is None
+        lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
+        assert np.isclose(lumo.to('eV').magnitude, 0.30)
+        assert energies_origin == 0.0 * ureg.eV
+
     def test_resolve_energies_origin_no_reference(self):
         """
         Test that `resolve_energies_origin` returns `None` when neither an

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -35,10 +35,80 @@ class TestElectronicDensityOfStates:
 
     def test_resolve_energies_origin(self):
         """
-        Test the `resolve_energies_origin` method.
+        Test the `resolve_energies_origin` method with a synthetic gapped DOS.
+
+        The DOS grid runs from -0.5 to 0.5 eV in steps of 0.01 eV, with a valence band
+        below -0.2 eV and a conduction band above 0.3 eV. With the Fermi level inside
+        the gap, the HOMO/LUMO stored in `m_cache` are the gap-side grid points
+        adjacent to the band edges.
         """
-        # ! add test when `ElectronicEigenvalues` is implemented
-        pass
+        # ! extend to the `ElectronicEigenvalues` sibling path once it is implemented
+        electronic_dos = ElectronicDensityOfStates()
+        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
+        dos_values = np.zeros(101)
+        dos_values[:31] = 1.0  # valence band: E <= -0.20 eV
+        dos_values[80:] = 1.0  # conduction band: E >= 0.30 eV
+        electronic_dos.value = dos_values * ureg('1/joule')
+
+        energies_origin = electronic_dos.resolve_energies_origin(
+            energies_points=energies_points,
+            fermi_level=0.0 * ureg.eV,
+            logger=logger,
+        )
+
+        homo = electronic_dos.m_cache.get('highest_occupied_energy')
+        lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
+        assert np.isclose(homo.to('eV').magnitude, -0.19)
+        assert np.isclose(lumo.to('eV').magnitude, 0.29)
+        assert energies_origin == homo
+
+        # The cached energies produce a finite DOS-derived band gap
+        band_gap = electronic_dos.extract_band_gap()
+        assert band_gap is not None
+        assert np.isclose(band_gap.value.to('eV').magnitude, 0.48)
+
+    def test_resolve_energies_origin_metallic(self):
+        """
+        Test `resolve_energies_origin` with a DOS that is finite across the Fermi
+        level: HOMO and LUMO both resolve to the Fermi energy and the derived band
+        gap is 0 (regression test: HOMO/LUMO of exactly 0 eV must not be discarded
+        by the truthiness check in `extract_band_gap`).
+        """
+        electronic_dos = ElectronicDensityOfStates()
+        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
+        electronic_dos.value = np.ones(101) * ureg('1/joule')
+
+        energies_origin = electronic_dos.resolve_energies_origin(
+            energies_points=energies_points,
+            fermi_level=0.0 * ureg.eV,
+            logger=logger,
+        )
+
+        homo = electronic_dos.m_cache.get('highest_occupied_energy')
+        lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
+        assert np.isclose(homo.to('eV').magnitude, 0.0, atol=1e-12)
+        assert np.isclose(lumo.to('eV').magnitude, 0.0, atol=1e-12)
+        assert energies_origin == homo
+
+        band_gap = electronic_dos.extract_band_gap()
+        assert band_gap is not None
+        assert np.isclose(band_gap.value.to('eV').magnitude, 0.0, atol=1e-12)
+
+    def test_resolve_energies_origin_no_reference(self):
+        """
+        Test that `resolve_energies_origin` returns `None` when neither an
+        `ElectronicEigenvalues` sibling nor a Fermi level is available.
+        """
+        electronic_dos = ElectronicDensityOfStates()
+        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
+        electronic_dos.value = np.ones(101) * ureg('1/joule')
+
+        energies_origin = electronic_dos.resolve_energies_origin(
+            energies_points=energies_points,
+            fermi_level=None,
+            logger=logger,
+        )
+        assert energies_origin is None
 
     def test_resolve_normalization_factor(self, simulation_electronic_dos: Simulation):
         """
@@ -83,12 +153,41 @@ class TestElectronicDensityOfStates:
         model_system.particle_states = original_particles
         electronic_dos.spin_channel = original_spin
 
-    def test_extract_band_gap(self):
+    @pytest.mark.parametrize(
+        'homo, lumo, result',
+        [
+            # gapped system
+            (1.0, 2.0, 1.0),
+            # overlapping bands: negative difference is clamped to 0
+            (2.0, 1.0, 0.0),
+            # HOMO exactly at 0 eV must not be skipped (regression for truthiness check)
+            (0.0, 1.0, 1.0),
+            # missing either energy reference means no derived band gap
+            (None, 1.0, None),
+            (1.0, None, None),
+            (None, None, None),
+        ],
+    )
+    def test_extract_band_gap(
+        self, homo: float | None, lumo: float | None, result: float | None
+    ):
         """
-        Test the `extract_band_gap` method.
+        Test the `extract_band_gap` method from the `highest_occupied_energy` and
+        `lowest_unoccupied_energy` values stored in `m_cache`.
         """
-        # ! add test when `ElectronicEigenvalues` is implemented
-        pass
+        electronic_dos = ElectronicDensityOfStates()
+        if homo is not None:
+            electronic_dos.m_cache['highest_occupied_energy'] = homo * ureg.eV
+        if lumo is not None:
+            electronic_dos.m_cache['lowest_unoccupied_energy'] = lumo * ureg.eV
+
+        band_gap = electronic_dos.extract_band_gap()
+        if result is None:
+            assert band_gap is None
+        else:
+            assert band_gap.is_derived
+            assert band_gap.physical_property_ref == electronic_dos
+            assert np.isclose(band_gap.value.to('eV').magnitude, result)
 
     def test_resolve_pdos_name(self, simulation_electronic_dos: Simulation):
         """


### PR DESCRIPTION
# Title

Fix DOS-derived band gap: sign inversion and wrong cache key

## Purpose

Band gaps derived from the electronic DOS were always 0 or missing. `extract_band_gap` computed `homo - lumo` (negative for any gapped system, so clamped to 0), and the LUMO search in `resolve_energies_origin` stored its result under the HOMO cache key, so the LUMO was never cached and `energies_origin` pointed at the conduction band edge.

## Scope

**Included**

- `spectral_profile.py`: compute `lumo - homo` in `extract_band_gap` (consistent with `ElectronicEigenvalues`), store the LUMO search result under `lowest_unoccupied_energy`, docstring updated.


## Reviewer Notes

DOS-derived gap values and `energies_origin` change for all affected entries; anything processed with the old code needs re-normalization. No existing test covered this path, which is why both bugs went unnoticed.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Manual testing (explain): reproduced both bugs with a synthetic gapped DOS (band edges ±1 eV, Fermi at 0), verified the fix gives the right HOMO/LUMO and a ~2 eV gap.