### PR TITLE
Fix ASE velocity import: internal units were stored as Å/s (off by ~1e14)

### DIFF
--- a/src/nomad_simulations/schema_packages/model_system.py
+++ b/src/nomad_simulations/schema_packages/model_system.py
@@ -21,6 +21,7 @@ from hashlib import sha1
 from typing import TYPE_CHECKING
 
 import ase
+import ase.units
 import numpy as np
 from ase.symbols import symbols2numbers
 from matid import Classifier, SymmetryAnalyzer  # pylint: disable=import-error
@@ -2266,7 +2267,11 @@ class ModelSystem(System, Representation):
             try:
                 velocities = ase_atoms.get_velocities()
                 if velocities is not None and len(velocities) == len(positions):
-                    model_system.velocities = velocities * ureg('angstrom/second')
+                    # get_velocities() returns ASE internal units
+                    # (Å per Å·sqrt(amu/eV)); ase.units.fs converts to Å/fs
+                    model_system.velocities = (
+                        velocities * ase.units.fs * ureg('angstrom/fs')
+                    )
             except Exception as e:
                 logger.debug(f'Could not map velocities: {e}')
 

--- a/tests/test_model_system.py
+++ b/tests/test_model_system.py
@@ -1,4 +1,5 @@
 import ase
+import ase.units
 import numpy as np
 import pytest
 from nomad.datamodel import EntryArchive
@@ -206,11 +207,14 @@ class TestModelSystem:
         # Check velocities were mapped
         assert sys.velocities is not None
         assert sys.velocities.shape == (3, 3)
-        expected_velocities = np.array(
-            [[0.1, 0.2, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, 0.1]]
+        # set_velocities() takes ASE internal units (Å per Å·sqrt(amu/eV)),
+        # so the schema must store raw * ase.units.fs in Å/fs
+        expected_velocities = (
+            np.array([[0.1, 0.2, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, 0.1]])
+            * ase.units.fs
         )
         assert np.allclose(
-            sys.velocities.to('angstrom/second').magnitude, expected_velocities
+            sys.velocities.to('angstrom/fs').magnitude, expected_velocities
         )
 
         # Check fractional coordinates were computed


### PR DESCRIPTION
## Purpose

`ModelSystem.from_ase_atoms` stored velocities from ASE with the wrong unit. `ase.Atoms.get_velocities()` returns velocities in ASE internal units (Å per Å·√(amu/eV) ≈ Å/10.18 fs), but the code attached `angstrom/second` to the raw numbers, making every stored velocity wrong by a factor of ~9.8e13. 

## Scope

**Included**

- One-line fix in `from_ase_atoms`: convert with `ase.units.fs` to Å/fs before assigning
- Updated the velocity assertion in `test_from_ase_atoms_enhanced_properties`, which previously asserted raw pass-through in Å/s and therefore encoded the wrong conversion


## Context & Links

- ASE unit convention: https://ase.gitlab.io/ase/ase/units.html ("time is given in units of Å·√(u/eV)"); `get_velocities()` returns `momenta / masses` with no unit conversion

## Reviewer Notes

The declared unit of `ModelSystem.velocities` (m/s) is unchanged, only the conversion factor at import time changes, and pint handles Å/fs → m/s on assignment. Note that the old test would not have caught this: it fed raw numbers in and asserted the same raw numbers out in Å/s, so it validated pass-through rather than physics.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None

## Dependencies / Blockers

- [x] None


## Testing / Validation

- [x] Unit tests
- [x] Manual testing (explain): two sanity checks against the fixed code: an atom set to exactly 1000 m/s is now stored as exactly 1000 m/s (previously 1.018e-11 m/s), and 100 Ar atoms initialized with ASE's `MaxwellBoltzmannDistribution` at 300 K store an RMS speed of ~428 m/s, matching the theoretical √(3kT/m) ≈ 433 m/s. 
