### PR TITLE
fix `PlaneWaveBasisSet.compute_cutoff_radius()`

### DIFF
--- a/docs/schema/numerical_settings.md
+++ b/docs/schema/numerical_settings.md
@@ -167,7 +167,7 @@ classDiagram
 | Quantity | Type | Description |
 |---|---|---|
 | `cutoff_energy` | m_float64(float64) | Cutoff energy for the plane-wave basis set. The simulation uses plane waves with energies below this cutoff. |
-| `cutoff_radius` | m_float64(float64) | Cutoff radius for the plane-wave basis set. Is the less frequently used dual to `cutoff_energy`. |
+| `cutoff_radius` | m_float64(float64) | Cutoff radius of the plane-wave basis set; the reciprocal-space dual to `cutoff_energy`. Uses the 2*pi-inclusive convention of `KSpace.reciprocal_lattice_vectors`. |
 
 ### `APWPlaneWaveBasisSet`
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -101,7 +101,7 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         type=np.float64,
         unit='1/meter',
         description="""
-        Cutoff radius of the plane-wave basis set; the reciprocal-space dual to `cutoff_energy`.     
+        Cutoff radius of the plane-wave basis set; the reciprocal-space dual to `cutoff_energy`.
         Uses the 2*pi-inclusive convention of `KSpace.reciprocal_lattice_vectors`.
         """,
     )

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -116,6 +116,9 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         The cutoff radius is the wavevector magnitude `k_cut` of a plane wave `e^{i k·r}`,
         obtained from the cutoff energy as `k_cut = sqrt(2 * m_e * E_cut) / hbar`. It follows
         the same 2*pi-inclusive convention as `KSpace.reciprocal_lattice_vectors`.
+"""
+        Compute `cutoff_radius` from `cutoff_energy` as the plane-wave wavevector magnitude
+        `k_cut = sqrt(2 * m_e * E_cut) / hbar` (angular wavevector, 2*pi-inclusive).
         """
         if cutoff_energy is None:
             return None

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -113,12 +113,10 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         Compute the cutoff radius for the plane-wave basis set, expressed in reciprocal
         coordinates.
 
-        The cutoff radius is the wavevector magnitude `k_cut` of a plane wave `e^{i k·r}`,
-        obtained from the cutoff energy as `k_cut = sqrt(2 * m_e * E_cut) / hbar`. It follows
-        the same 2*pi-inclusive convention as `KSpace.reciprocal_lattice_vectors`.
-"""
-        Compute `cutoff_radius` from `cutoff_energy` as the plane-wave wavevector magnitude
-        `k_cut = sqrt(2 * m_e * E_cut) / hbar` (angular wavevector, 2*pi-inclusive).
+        The cutoff radius is the wavevector magnitude `k_cut` of a plane wave
+        `e^{i k·r}`, obtained from the cutoff energy as
+        `k_cut = sqrt(2 * m_e * E_cut) / hbar`. It follows the same
+        2*pi-inclusive convention as `KSpace.reciprocal_lattice_vectors`.
         """
         if cutoff_energy is None:
             return None

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -101,8 +101,8 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         type=np.float64,
         unit='1/meter',
         description="""
-        Cutoff radius for the plane-wave basis set.
-        Is the less frequently used dual to `cutoff_energy`.
+        Cutoff radius of the plane-wave basis set; the reciprocal-space dual to `cutoff_energy`.     
+        Uses the 2*pi-inclusive convention of `KSpace.reciprocal_lattice_vectors`.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -115,7 +115,7 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         if cutoff_energy is None:
             return None
         m_e = const.m_e * ureg(const.unit('electron mass'))
-        hbar = const.hbar * ureg(const.unit('reduced Planck constant'))
+        hbar = const.hbar * ureg.joule * ureg.second
         return np.sqrt(2 * m_e * cutoff_energy) / hbar
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -110,7 +110,12 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         self, cutoff_energy: pint.Quantity | None
     ) -> pint.Quantity | None:
         """
-        Compute the cutoff radius for the plane-wave basis set, expressed in reciprocal coordinates.
+        Compute the cutoff radius for the plane-wave basis set, expressed in reciprocal
+        coordinates.
+
+        The cutoff radius is the wavevector magnitude `k_cut` of a plane wave `e^{i k·r}`,
+        obtained from the cutoff energy as `k_cut = sqrt(2 * m_e * E_cut) / hbar`. It follows
+        the same 2*pi-inclusive convention as `KSpace.reciprocal_lattice_vectors`.
         """
         if cutoff_energy is None:
             return None

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -115,7 +115,7 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         if cutoff_energy is None:
             return None
         m_e = const.m_e * ureg(const.unit('electron mass'))
-        hbar = const.hbar * ureg.joule * ureg.second
+        hbar = const.hbar * ureg(const.unit('reduced Planck constant'))
         return np.sqrt(2 * m_e * cutoff_energy) / hbar
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:

--- a/src/nomad_simulations/schema_packages/basis_set.py
+++ b/src/nomad_simulations/schema_packages/basis_set.py
@@ -115,8 +115,8 @@ class PlaneWaveBasisSet(BasisSetComponent, KMesh):
         if cutoff_energy is None:
             return None
         m_e = const.m_e * ureg(const.unit('electron mass'))
-        h = const.h * ureg(const.unit('Planck constant'))
-        return np.sqrt(2 * m_e * cutoff_energy) / h
+        hbar = const.hbar * ureg.joule * ureg.second
+        return np.sqrt(2 * m_e * cutoff_energy) / hbar
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super().normalize(archive, logger)

--- a/tests/test_basis_set.py
+++ b/tests/test_basis_set.py
@@ -35,7 +35,7 @@ from . import logger
     'ref_cutoff_radius, cutoff_energy',
     [
         (None, None),
-        (1.823 / ureg.angstrom, 500 * ureg.eV),  # reference computed by ChatGPT 4o
+        (11.456 / ureg.angstrom, 500 * ureg.eV),
     ],
 )
 def test_cutoff(
@@ -94,7 +94,7 @@ def test_mt_r_min(mts: list[MuffinTinRegion | None], ref_mt_r_min: float) -> Non
         (None, None, None),
         (None, 500.0 * ureg.eV, None),
         (None, None, 1.0),
-        (1.823, 500.0 * ureg.eV, 1.0 * ureg.angstrom),
+        (11.456, 500.0 * ureg.eV, 1.0 * ureg.angstrom),
     ],
 )
 def test_cutoff_failure(


### PR DESCRIPTION
## Purpose

Fix `PlaneWaveBasisSet.compute_cutoff_radius()` to use `hbar` instead of `h` when converting cutoff energy to reciprocal cutoff radius. For plane waves written as `e^{i k·r}`, using `h` made derived `cutoff_radius` values too small by a factor of `2 pi`.

## Scope

**Included**

- Use `hbar` in `compute_cutoff_radius()`.
- Update cutoff test expectations for `500 eV` from `1.823 / angstrom` to `11.456 / angstrom`.

## Context & Links

- Consistent with `KSpace.reciprocal_lattice_vectors`, which include the `2 pi` prefactor.
- Consistent with the documented plane-wave form `e^{i k·r}`.

## Reviewer Notes

Please verify that the `cutoff_radius` convention is intended to follow the plane-wave form in the docstrings (e^{i\mathbf{k}\cdot\mathbf{r}}). Under this convention, `cutoff_radius` is the wavevector magnitude (k_{\mathrm{cut}}), so the conversion from `cutoff_energy` requires (\hbar). Using (h) would instead correspond to spatial frequency in cycles per unit length and would give values smaller by a factor of (2\pi).

## Status

- [x] Ready for review


## Breaking Changes

- [x] Derived `cutoff_radius` values from `cutoff_energy` increase by a factor of `2 pi`.

## Dependencies / Blockers

- [x] None

## Testing / Validation

- [x] Unit tests
