### PR TITLE
Fix CI failures caused by Ruff

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -114,6 +114,7 @@ jobs:
         - uses: chartboost/ruff-action@v1
           with:
             args: "check ."
+            version: "0.15.22"
   ruff-formatting:
       runs-on: ubuntu-latest
       steps:
@@ -121,3 +122,4 @@ jobs:
         - uses: chartboost/ruff-action@v1
           with:
             args: "format . --check --verbose"
+            version: "0.15.22"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -114,7 +114,6 @@ jobs:
         - uses: chartboost/ruff-action@v1
           with:
             args: "check ."
-            version: "0.15.22"
   ruff-formatting:
       runs-on: ubuntu-latest
       steps:
@@ -122,4 +121,3 @@ jobs:
         - uses: chartboost/ruff-action@v1
           with:
             args: "format . --check --verbose"
-            version: "0.15.22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ docs = [
 ]
 
 [tool.uv]
-constraint-dependencies = ["pymatgen-core!=2026.7.24"]
 build-constraint-dependencies = ["wheel<0.46"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     'pytest-timeout>=1.4.2',
     'pytest-cov>=2.7.1',
     'pytest-asyncio>=0.21.0',
-    'ruff>=0.6',
+    'ruff==0.15.22',
     'structlog>=1.0',
     'typing-extensions>=4.12',
 ]
@@ -68,6 +68,7 @@ docs = [
 ]
 
 [tool.uv]
+constraint-dependencies = ["pymatgen-core<2026.7.24"]
 build-constraint-dependencies = ["wheel<0.46"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ constraint-dependencies = ["pymatgen-core!=2026.7.24"]
 build-constraint-dependencies = ["wheel<0.46"]
 
 [tool.ruff]
-include = ["*.py", "*.pyi", "*.ipynb"]
+include = ["*.py"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     'pytest-timeout>=1.4.2',
     'pytest-cov>=2.7.1',
     'pytest-asyncio>=0.21.0',
-    'ruff==0.15.22',
+    'ruff>=0.6',
     'structlog>=1.0',
     'typing-extensions>=4.12',
 ]
@@ -68,10 +68,12 @@ docs = [
 ]
 
 [tool.uv]
-constraint-dependencies = ["pymatgen-core<2026.7.24"]
+constraint-dependencies = ["pymatgen-core!=2026.7.24"]
 build-constraint-dependencies = ["wheel<0.46"]
 
 [tool.ruff]
+include = ["*.py", "*.pyi", "*.ipynb"]
+
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -121,6 +123,7 @@ ignore = [
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments in function definition
     "PLR0915", # Too many statements
+    "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used instead of constant
     "PLW0603", # Using the global statement
     "PLW2901", # redefined-loop-name


### PR DESCRIPTION
- `include = ["*.py"]` keeps Ruff focused on Python files because Ruff 0.16 started formatting Markdown code blocks.
- `PLR0917` is ignored because Ruff 0.16 newly enabled it, causing 22 failures in existing APIs. Refactoring those signatures is outside this CI-fix PR and could be breaking.
