### PR TITLE
 `Screening.dielectric_infinity` type

### DIFF
--- a/docs/schema/model_method_electronic.md
+++ b/docs/schema/model_method_electronic.md
@@ -152,7 +152,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `dielectric_infinity` | m_int32(int32) | Value of the static dielectric constant at infinite q. For metals, this is infinite (or a very large value), while for insulators is finite. |
+| `dielectric_infinity` | m_float_bounded(float) | <details><summary>Scalar macroscopic electronic dielectric constant in the static,</summary>Scalar macroscopic electronic dielectric constant in the static,<br>long-wavelength limit (ω → 0, q → 0), commonly denoted ε_∞.<br>Finite for insulators and semiconductors; for metals, the static long-wavelength<br>response diverges and may be represented by a large finite value.</details> |
 
 ### `GW`
 

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -1403,7 +1403,7 @@ class Screening(ExcitedStateMethodology):
     """
 
     dielectric_infinity = Quantity(
-        type=np.int32,
+        type=positive_float(),
         description="""
         Value of the static dielectric constant at infinite q. For metals, this is infinite
         (or a very large value), while for insulators is finite.

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -1405,8 +1405,10 @@ class Screening(ExcitedStateMethodology):
     dielectric_infinity = Quantity(
         type=positive_float(),
         description="""
-        Value of the static dielectric constant at infinite q. For metals, this is infinite
-        (or a very large value), while for insulators is finite.
+        Scalar macroscopic electronic dielectric constant in the static,
+        long-wavelength limit (ω → 0, q → 0), commonly denoted ε_∞.
+        Finite for insulators and semiconductors; for metals, the static long-wavelength
+        response diverges and may be represented by a large finite value.
         """,
     )
 


### PR DESCRIPTION
## Purpose

Fix the type and description of `Screening.dielectric_infinity`.

The quantity was defined as an integer and described as the static dielectric constant at infinite momentum transfer. Dielectric constants are generally non-integer values, and the relevant limit is the static, long-wavelength limit, $\omega \to 0$ and $q \to 0$.

## Scope

**Included**

* Change `dielectric_infinity` from `np.int32` to `positive_float()`.
* Correct the description to refer to the macroscopic dielectric constant (\varepsilon_\infty) in the static, long-wavelength limit.
* Clarify that the quantity is a dimensionless relative permittivity.
* Clarify the expected behavior for insulators, semiconductors, and metals.

## Status

* [x] Ready for review

## Breaking Changes

* [x] None

Changing the numerical type from integer to floating point broadens the accepted values and preserves existing integer-valued data.

## Dependencies / Blockers

* [x] None

## Testing / Validation

* [x] None (explain):
