### PR TITLE
Resolve free-form LibXC XC components; add unidentified marker; fix REVPBE alias

### DIFF
--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -33,6 +33,7 @@ from nomad_simulations.schema_packages.data_types import (
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.numerical_settings import NumericalSettings
 from nomad_simulations.schema_packages.utils.libxc.build import (
+    spec_from_id,
     spec_from_label,
 )
 from nomad_simulations.schema_packages.utils.libxc.expand import (
@@ -617,6 +618,51 @@ class XCComponent(ArchiveSection):
          """,
     )
 
+    unidentified = Quantity(
+        type=bool,
+        description="""
+        `True` when the code reports an XC component at this position that cannot
+        be resolved to a LibXC label (family/kind therefore stay unset). The
+        component is retained as a placeholder so the functional's composition
+        (the number of parts) is not misrepresented as complete.
+        """,
+    )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+        super().normalize(archive, logger)
+
+        # Complete a free-form component from the LibXC registry, keyed by either
+        # the `canonical_label` or the `libxc_id` the code reports. `weight` is a
+        # composition fraction the parser owns, not registry data, so it is
+        # intentionally left untouched.
+        if self.family is not None:
+            return
+
+        spec = None
+        if self.canonical_label:
+            spec = spec_from_label(self.canonical_label)
+        elif self.libxc_id is not None:
+            spec = spec_from_id(int(self.libxc_id))
+
+        if spec is None:
+            # The code reported a component (a label or a LibXC id) the registry
+            # cannot resolve: keep it as a placeholder so it is not silently
+            # dropped, and mark it unidentified.
+            if self.canonical_label or self.libxc_id is not None:
+                logger.debug(
+                    'Unresolvable LibXC component.',
+                    label=self.canonical_label,
+                    libxc_id=self.libxc_id,
+                )
+                self.unidentified = True
+            return
+        self.libxc_id = spec['libxc_id']
+        self.display_name = spec['display_name']
+        self.family = spec['family']
+        self.kind = spec['kind']
+        # canonicalize to the registry spelling (e.g. 'gga_x_pbe' -> 'XC_GGA_X_PBE')
+        self.canonical_label = spec['canonical_label']
+
 
 class XCFunctional(ArchiveSection):
     """
@@ -681,6 +727,12 @@ class XCFunctional(ArchiveSection):
                     )
         except Exception:
             logger.warning('LibXC expansion failed.')
+
+        # Free-form composition: components supplied directly by a parser (raw
+        # LibXC labels the code reports) complete their own taxonomy. Components
+        # created by the name expansion above already carry it and no-op.
+        for comp in self.components or []:
+            comp.normalize(archive, logger)
 
         if self.global_exact_exchange is None:
             alphas = [

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -641,7 +641,7 @@ class XCComponent(ArchiveSection):
         spec = None
         if self.canonical_label:
             spec = spec_from_label(self.canonical_label)
-        elif self.libxc_id is not None:
+        if spec is None and self.libxc_id is not None:
             spec = spec_from_id(int(self.libxc_id))
 
         if spec is None:
@@ -662,6 +662,10 @@ class XCComponent(ArchiveSection):
         self.kind = spec['kind']
         # canonicalize to the registry spelling (e.g. 'gga_x_pbe' -> 'XC_GGA_X_PBE')
         self.canonical_label = spec['canonical_label']
+        # a component that was marked as a placeholder but now resolves is no
+        # longer unidentified
+        if self.unidentified:
+            self.unidentified = False
 
 
 class XCFunctional(ArchiveSection):

--- a/src/nomad_simulations/schema_packages/utils/libxc/aliases.json
+++ b/src/nomad_simulations/schema_packages/utils/libxc/aliases.json
@@ -9,7 +9,7 @@
     "PZ81": ["XC_LDA_X", "XC_LDA_C_PZ"],
     "PBE": ["XC_GGA_X_PBE", "XC_GGA_C_PBE"],
     "PBESOL": ["XC_GGA_X_PBE_SOL", "XC_GGA_C_PBE_SOL"],
-    "REVPBE": ["XC_GGA_X_RPBE", "XC_GGA_C_PBE"],
+    "REVPBE": ["XC_GGA_X_PBE_R", "XC_GGA_C_PBE"],
     "RPBE": ["XC_GGA_X_RPBE", "XC_GGA_C_PBE"],
     "PW91": ["XC_GGA_X_PW91", "XC_GGA_C_PW91"],
     "BLYP": ["XC_GGA_X_B88", "XC_GGA_C_LYP"],

--- a/src/nomad_simulations/schema_packages/utils/libxc/aliases.json
+++ b/src/nomad_simulations/schema_packages/utils/libxc/aliases.json
@@ -5,6 +5,7 @@
     "SVWN": ["XC_LDA_X", "XC_LDA_C_VWN"],
     "SVWN5": ["XC_LDA_X", "XC_LDA_C_VWN"],
     "VWN": ["XC_LDA_X", "XC_LDA_C_VWN"],
+    "VWN-RPA": ["XC_LDA_X", "XC_LDA_C_VWN_RPA"],
     "PW92": ["XC_LDA_C_PW"],
     "PZ81": ["XC_LDA_X", "XC_LDA_C_PZ"],
     "PBE": ["XC_GGA_X_PBE", "XC_GGA_C_PBE"],

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -1333,3 +1333,88 @@ def test_dft_expands_widely_used_functionals_to_expected_labels(
     if expected_family.startswith('hybrid'):
         # Schema must not infer α from names
         assert dft.xc.global_exact_exchange is None
+
+
+@pytest.mark.parametrize(
+    'component_kwargs, expected_labels, expected_family',
+    [
+        # free-form label input is canonicalized (case / missing 'XC_' prefix)
+        (
+            [{'canonical_label': 'gga_x_pbe'}, {'canonical_label': 'XC_GGA_C_PBE'}],
+            {'XC_GGA_X_PBE', 'XC_GGA_C_PBE'},
+            'GGA',
+        ),
+        # arbitrary composition with no shorthand name still resolves per-component
+        (
+            [
+                {'canonical_label': 'XC_MGGA_X_SCAN'},
+                {'canonical_label': 'XC_GGA_C_PBE'},
+            ],
+            {'XC_MGGA_X_SCAN', 'XC_GGA_C_PBE'},
+            'meta-GGA',
+        ),
+        (
+            [{'canonical_label': 'XC_LDA_X'}, {'canonical_label': 'XC_LDA_C_PZ'}],
+            {'XC_LDA_X', 'XC_LDA_C_PZ'},
+            'LDA',
+        ),
+        # a component carrying only a LibXC id (abinit's negative-ixc path)
+        ([{'libxc_id': 101}], {'XC_GGA_X_PBE'}, 'GGA'),
+    ],
+)
+def test_dft_resolves_free_form_components(
+    component_kwargs, expected_labels, expected_family
+):
+    """Components supplied directly (no `functional_key`) complete their LibXC
+    taxonomy from the registry in `XCComponent.normalize`, keyed by either
+    `canonical_label` or `libxc_id`, so arbitrary compositions still yield
+    family/kind and a Jacob's ladder rung."""
+    dft = DFT()
+    dft.xc = XCFunctional(
+        components=[XCComponent(**kwargs) for kwargs in component_kwargs]
+    )
+    dft.normalize(EntryArchive(), logger=logger)
+
+    assert {c.canonical_label for c in dft.xc.components} == expected_labels
+    assert all(c.family is not None and c.kind is not None for c in dft.xc.components)
+    assert dft.jacobs_ladder == expected_family
+    # `weight` is a composition fraction the parser owns, not registry data;
+    # the taxonomy fill must leave it untouched.
+    assert all(c.weight is None for c in dft.xc.components)
+
+
+def test_dft_keeps_unidentified_placeholder_component():
+    """A parser may report a component it cannot name (e.g. abinit's `?` slot).
+    The placeholder (no label, `unidentified=True`) is retained so the number of
+    components is not misrepresented, and it survives normalization untouched."""
+    dft = DFT()
+    dft.xc = XCFunctional(
+        components=[
+            XCComponent(canonical_label='XC_GGA_X_PBE'),
+            XCComponent(unidentified=True),
+        ]
+    )
+    dft.normalize(EntryArchive(), logger=logger)
+
+    assert len(dft.xc.components) == 2
+    named, placeholder = dft.xc.components
+    assert named.canonical_label == 'XC_GGA_X_PBE' and named.family == 'GGA'
+    assert placeholder.unidentified is True
+    assert placeholder.canonical_label is None and placeholder.family is None
+
+
+@pytest.mark.parametrize(
+    'component_kwargs',
+    [{'canonical_label': 'XC_NOT_A_REAL_LABEL'}, {'libxc_id': 999999}],
+)
+def test_dft_marks_unresolvable_component_unidentified(component_kwargs):
+    """A component whose label or id the registry cannot resolve is kept as an
+    unidentified placeholder, without taxonomy, and must not crash normalization."""
+    dft = DFT()
+    dft.xc = XCFunctional(components=[XCComponent(**component_kwargs)])
+    dft.normalize(EntryArchive(), logger=logger)
+
+    comp = dft.xc.components[0]
+    assert comp.unidentified is True
+    assert comp.family is None and comp.kind is None
+    assert dft.jacobs_ladder == 'unavailable'

--- a/tests/test_model_method.py
+++ b/tests/test_model_method.py
@@ -1360,6 +1360,12 @@ def test_dft_expands_widely_used_functionals_to_expected_labels(
         ),
         # a component carrying only a LibXC id (abinit's negative-ixc path)
         ([{'libxc_id': 101}], {'XC_GGA_X_PBE'}, 'GGA'),
+        # an unresolvable label falls back to the id
+        (
+            [{'canonical_label': 'XC_NOT_A_REAL_LABEL', 'libxc_id': 101}],
+            {'XC_GGA_X_PBE'},
+            'GGA',
+        ),
     ],
 )
 def test_dft_resolves_free_form_components(
@@ -1381,6 +1387,22 @@ def test_dft_resolves_free_form_components(
     # `weight` is a composition fraction the parser owns, not registry data;
     # the taxonomy fill must leave it untouched.
     assert all(c.weight is None for c in dft.xc.components)
+    # resolved components are not flagged unidentified
+    assert all(not c.unidentified for c in dft.xc.components)
+
+
+def test_dft_clears_unidentified_when_component_later_resolves():
+    """A component marked `unidentified` that also carries a resolvable identity
+    is completed and the flag is cleared, not left inconsistent."""
+    dft = DFT()
+    dft.xc = XCFunctional(
+        components=[XCComponent(unidentified=True, canonical_label='XC_GGA_X_PBE')]
+    )
+    dft.normalize(EntryArchive(), logger=logger)
+
+    comp = dft.xc.components[0]
+    assert comp.family == 'GGA' and comp.kind == 'exchange'
+    assert not comp.unidentified
 
 
 def test_dft_keeps_unidentified_placeholder_component():


### PR DESCRIPTION
## Purpose

Let DFT parsers report exchange–correlation as the raw LibXC components a code
emits (individual exchange/correlation parts, by label or by LibXC id) without
each parser owning LibXC taxonomy lookups. The schema resolves those components
— filling `family`/`kind` so `DFT.jacobs_ladder` can be derived — and, when a
component cannot be resolved, keeps it as an explicitly marked placeholder
rather than dropping it. Also corrects the `REVPBE` alias, which collided with
`RPBE`.

## Scope

**Included**

- `XCComponent.normalize`: complete a directly-supplied component from the LibXC
  registry, keyed by either `canonical_label` or `libxc_id`; canonicalize the
  label (e.g. `gga_x_pbe` -> `XC_GGA_X_PBE`). `weight` is left untouched.
- New `XCComponent.unidentified` boolean: a component the registry cannot
  resolve (unknown label or id) is retained as a placeholder and marked
  `unidentified`, so a functional's composition is not misrepresented as
  complete (e.g. a two-part functional does not silently become exchange-only).
- Fix `REVPBE` alias: `XC_GGA_X_RPBE` -> `XC_GGA_X_PBE_R` (revPBE is Zhang–Yang).

**Out of scope**

- The parser changes that emit these components (separate PR in
  `nomad-parser-plugins-simulation`).

## Context & Links

- Schema-side enabler for the DFT XC parser migration; the parser PR depends on
  this and should merge after it.

## Reviewer Notes

- Two resolution keys: `canonical_label` and, as a fallback, `libxc_id` via
  `spec_from_id` — the latter lets codes that expose LibXC ids (e.g. abinit's
  negative `ixc`) hand the schema the id and let the registry, which is more
  complete than any parser-local table, resolve it.
- `unidentified` is set by the normalizer when neither key resolves; a parser
  may also set it directly for a slot it knows exists but cannot name at all
  (no label, no id). Such placeholders survive because they carry a set field —
  the normalizer classifies what reaches it but cannot rescue a component pruned
  for being empty.
- `weight` is deliberately not set by the fill — it is a composition fraction
  the parser owns, meaningful only for explicit mixes.
- The `REVPBE` fix changes what `REVPBE` expands to (previously identical to
  `RPBE`); output for revPBE calculations changes accordingly.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None (`unidentified` is additive). Note: the `REVPBE` alias now expands
  differently — see Reviewer Notes.

## Dependencies / Blockers

- [x] None for this PR. The parser-side PR depends on it.

## Testing / Validation

- [x] Unit tests — `tests/test_model_method.py`: free-form resolution by label
  and by id (parametrized), `unidentified` marking of unresolvable label/id,
  placeholder retention/arity. 190 pass.
- [x] Manual testing — verified end-to-end that octopus/abinit/crystal/exciting
  produce resolved components with correct `family`/`kind` and `jacobs_ladder`.
- Docs regenerate with no diff.
