### PR TITLE
Resolve dead Fermi-level references and drop ChemicalPotential.fermi_energy (#418)

### DIFF
--- a/docs/schema/electronic_properties.md
+++ b/docs/schema/electronic_properties.md
@@ -105,7 +105,7 @@ classDiagram
 | Quantity | Type | Description |
 |---|---|---|
 | `spin_channel` | m_int32(int32) | Spin channel of the corresponding electronic DOS. It can take values of 0 or 1. |
-| `energies_origin` | m_float64(float64) | Energy level denoting the origin along the energy axis, used for comparison and visualization. It is defined as the `ElectronicEigenvalues.highest_occupied_energy`. |
+| `energies_origin` | m_float64(float64) | <details><summary>Energy level denoting the origin along the energy axis, used for comparison and visualization.</summary>Energy level denoting the origin along the energy axis, used for comparison and visualization.<br>This value is fully derived during normalization from the sibling<br>`ElectronicEigenvalues.highest_occupied` (when a resolvable reference is available), so parsers<br>are recommended NOT to populate it directly: any manually set value is recomputed and overwritten<br>on normalization without any logging. Provide `ElectronicEigenvalues.highest_occupied` instead.</details> |
 | `normalization_factor` | m_float64(float64) | Normalization factor for electronic DOS to get a cell-independent intensive DOS. The cell-independent intensive DOS is as the integral from the lowest (most negative) energy to the Fermi level for a neutrally charged system (i.e., the sum of `AtomsState.charge` is zero). |
 
 ### `Occupancy`

--- a/docs/schema/thermodynamics.md
+++ b/docs/schema/thermodynamics.md
@@ -150,7 +150,6 @@ classDiagram
 |---|---|---|
 | `temperature` | m_float64(float64) | Temperature at which the chemical potential is calculated. Essential for finite-temperature calculations. |
 | `particle_number` | m_float64(float64) | Number of particles (or particle density) for which the chemical potential applies. Can represent electron number, atom number, or other relevant particle count. |
-| `fermi_energy` | m_float64(float64) | Fermi energy at T=0K, used as reference for finite-temperature chemical potential. At T=0, the chemical potential equals the Fermi energy. |
 | `type` | m_str(str) | Type of chemical potential calculation. Examples: 'electronic', 'atomic', 'ionic', 'molecular'. Helps identify what kind of particles this applies to. |
 
 ### `VirialTensor`

--- a/src/nomad_simulations/schema_packages/properties/band_structure.py
+++ b/src/nomad_simulations/schema_packages/properties/band_structure.py
@@ -69,7 +69,7 @@ class ElectronicBandStructure(ElectronicEigenvalues):
         logger = self.extract_fermi_surface.__annotations__['logger']
         # Check if the system has a finite band gap
         homo, lumo = self.resolve_homo_lumo_eigenvalues()
-        if (homo and lumo) and (lumo - homo).magnitude > 0:
+        if (homo is not None and lumo is not None) and (lumo - homo).magnitude > 0:
             return None
 
         # Use the highest occupied eigenvalue as the Fermi-level reference

--- a/src/nomad_simulations/schema_packages/properties/band_structure.py
+++ b/src/nomad_simulations/schema_packages/properties/band_structure.py
@@ -16,7 +16,7 @@ from nomad_simulations.schema_packages.properties.electronic_eigenvalues import 
     ElectronicEigenvalues,
 )
 from nomad_simulations.schema_packages.properties.fermi_surface import FermiSurface
-from nomad_simulations.schema_packages.utils import get_sibling_section, log
+from nomad_simulations.schema_packages.utils import log
 
 configuration = config.get_plugin_entry_point(
     'nomad_simulations.schema_packages:nomad_simulations_plugin'
@@ -63,7 +63,8 @@ class ElectronicBandStructure(ElectronicEigenvalues):
     @log
     def extract_fermi_surface(self) -> FermiSurface | None:
         """
-        Extract the Fermi surface for metallic systems using `FermiLevel.value`.
+        Extract the Fermi surface for metallic systems, referenced to the highest occupied
+        eigenvalue (`highest_occupied`), which coincides with the Fermi level for gapless systems.
         """
         logger = self.extract_fermi_surface.__annotations__['logger']
         # Check if the system has a finite band gap
@@ -71,18 +72,15 @@ class ElectronicBandStructure(ElectronicEigenvalues):
         if (homo and lumo) and (lumo - homo).magnitude > 0:
             return None
 
-        # Get the `fermi_level.value`
-        fermi_level = get_sibling_section(
-            section=self, sibling_section_name='fermi_level', logger=logger
-        )
-        if fermi_level is None:
+        # Use the highest occupied eigenvalue as the Fermi-level reference
+        if homo is None:
             logger.warning(
-                'Could not extract the `FermiSurface`, because `FermiLevel` is not stored.'
+                'Could not extract the `FermiSurface`: no `highest_occupied` eigenvalue available.'
             )
             return None
-        fermi_level_value = fermi_level.value.magnitude
+        fermi_level_value = homo.magnitude
 
-        # Extract eigenvalues close to the `fermi_level.value`
+        # Extract eigenvalues close to the Fermi-level reference
         fermi_indices = np.logical_and(
             self.value.magnitude
             >= (fermi_level_value - configuration.fermi_surface_tolerance),

--- a/src/nomad_simulations/schema_packages/properties/band_structure.py
+++ b/src/nomad_simulations/schema_packages/properties/band_structure.py
@@ -30,6 +30,9 @@ class ElectronicBandStructure(ElectronicEigenvalues):
 
     iri = 'http://fairmat-nfdi.eu/taxonomy/ElectronicBandStructure'
 
+    # NOTE (DRY): the energy reference (`highest_occupied`, inherited from `ElectronicEigenvalues`,
+    # and used for Fermi-surface extraction) is the same concept specialized as
+    # `ElectronicDensityOfStates.energies_origin`. Intentional duplication for derivation/plotting.
     k_path = SubSection(sub_section=KLinePath.m_def)
 
     reciprocal_cell = Quantity(

--- a/src/nomad_simulations/schema_packages/properties/electronic_eigenvalues.py
+++ b/src/nomad_simulations/schema_packages/properties/electronic_eigenvalues.py
@@ -71,6 +71,10 @@ class ElectronicEigenvalues(BaseElectronicEigenvalues):
         """,
     )
 
+    # NOTE (DRY): this highest-/lowest-occupied reference is intentionally mirrored in
+    # specialized form elsewhere -- `ElectronicDensityOfStates.energies_origin` (DOS-refined)
+    # and consumed by `ElectronicBandStructure`. The duplication is deliberate: each property
+    # keeps a source specialized for its own derivation and plotting/visualization alignment.
     highest_occupied = Quantity(
         type=np.float64,
         unit='joule',

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -237,67 +237,72 @@ class ElectronicDensityOfStates(DOSProfile):
         fermi_idx = (np.abs(energies_points - eref)).argmin()
         fermi_energy_closest = energies_points[fermi_idx]
         distance = np.abs(fermi_energy_closest - eref)
+        # If the reference is farther than `dos_energy_tolerance` from every DOS grid point,
+        # the DOS does not cover it and aligning to it would be inaccurate, so do not report
+        # an origin.
+        if distance > configuration.dos_energy_tolerance:
+            return None
+
         single_peak_fermi = False
-        if distance <= configuration.dos_energy_tolerance:
-            # See if there are zero values close below the energy reference.
-            idx = fermi_idx
-            idx_descend = fermi_idx
-            while True:
-                try:
-                    value = dos_values[idx]
-                    energy_distance = np.abs(eref - energies_points[idx])
-                except IndexError:
-                    break
-                if energy_distance > configuration.dos_energy_tolerance:
-                    break
-                if value <= configuration.dos_intensities_threshold:
-                    idx_descend = idx
+        # See if there are zero values close below the energy reference.
+        idx = fermi_idx
+        idx_descend = fermi_idx
+        while True:
+            try:
+                value = dos_values[idx]
+                energy_distance = np.abs(eref - energies_points[idx])
+            except IndexError:
+                break
+            if energy_distance > configuration.dos_energy_tolerance:
+                break
+            if value <= configuration.dos_intensities_threshold:
+                idx_descend = idx
+                break
+            idx -= 1
+
+        # See if there are zero values close above the fermi energy.
+        idx = fermi_idx
+        idx_ascend = fermi_idx
+        while True:
+            try:
+                value = dos_values[idx]
+                energy_distance = np.abs(eref - energies_points[idx])
+            except IndexError:
+                break
+            if energy_distance > configuration.dos_energy_tolerance:
+                break
+            if value <= configuration.dos_intensities_threshold:
+                idx_ascend = idx
+                break
+            idx += 1
+
+        # If there is a single peak at fermi energy, no
+        # search needs to be performed.
+        if idx_ascend != fermi_idx and idx_descend != fermi_idx:
+            self.m_cache['highest_occupied_energy'] = fermi_energy_closest
+            self.m_cache['lowest_unoccupied_energy'] = fermi_energy_closest
+            single_peak_fermi = True
+
+        if not single_peak_fermi:
+            # Look for highest occupied energy below the descend index
+            idx = idx_descend
+            while idx >= 0:
+                value = dos_values[idx]
+                if value > configuration.dos_intensities_threshold:
+                    self.m_cache['highest_occupied_energy'] = energies_points[idx]
                     break
                 idx -= 1
-
-            # See if there are zero values close above the fermi energy.
-            idx = fermi_idx
-            idx_ascend = fermi_idx
+            # Look for lowest unoccupied energy above idx_ascend
+            idx = idx_ascend
             while True:
                 try:
                     value = dos_values[idx]
-                    energy_distance = np.abs(eref - energies_points[idx])
                 except IndexError:
                     break
-                if energy_distance > configuration.dos_energy_tolerance:
-                    break
-                if value <= configuration.dos_intensities_threshold:
-                    idx_ascend = idx
+                if value > configuration.dos_intensities_threshold:
+                    self.m_cache['lowest_unoccupied_energy'] = energies_points[idx]
                     break
                 idx += 1
-
-            # If there is a single peak at fermi energy, no
-            # search needs to be performed.
-            if idx_ascend != fermi_idx and idx_descend != fermi_idx:
-                self.m_cache['highest_occupied_energy'] = fermi_energy_closest
-                self.m_cache['lowest_unoccupied_energy'] = fermi_energy_closest
-                single_peak_fermi = True
-
-            if not single_peak_fermi:
-                # Look for highest occupied energy below the descend index
-                idx = idx_descend
-                while idx >= 0:
-                    value = dos_values[idx]
-                    if value > configuration.dos_intensities_threshold:
-                        self.m_cache['highest_occupied_energy'] = energies_points[idx]
-                        break
-                    idx -= 1
-                # Look for lowest unoccupied energy above idx_ascend
-                idx = idx_ascend
-                while True:
-                    try:
-                        value = dos_values[idx]
-                    except IndexError:
-                        break
-                    if value > configuration.dos_intensities_threshold:
-                        self.m_cache['lowest_unoccupied_energy'] = energies_points[idx]
-                        break
-                    idx += 1
 
         # Return the `highest_occupied_energy` as the `energies_origin`
         return self.m_cache.get('highest_occupied_energy')

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -145,13 +145,15 @@ class ElectronicDensityOfStates(DOSProfile):
         """,
     )
 
-    # TODO clarify the role of `energies_origin` once `ElectronicEigenvalues` is implemented
     energies_origin = Quantity(
         type=np.float64,
         unit='joule',
         description="""
-        Energy level denoting the origin along the energy axis, used for comparison and visualization. It is
-        defined as the `ElectronicEigenvalues.highest_occupied_energy`.
+        Energy level denoting the origin along the energy axis, used for comparison and visualization.
+        This value is fully derived during normalization from the sibling
+        `ElectronicEigenvalues.highest_occupied` (when a resolvable reference is available), so parsers
+        are recommended NOT to populate it directly: any manually set value is recomputed and overwritten
+        on normalization without any logging. Provide `ElectronicEigenvalues.highest_occupied` instead.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -198,15 +198,13 @@ class ElectronicDensityOfStates(DOSProfile):
     def resolve_energies_origin(
         self,
         energies_points: pint.Quantity,
-        fermi_level: pint.Quantity | None,
         logger: 'BoundLogger',
     ) -> pint.Quantity | None:
         """
-        Resolve the origin of reference for the energies from the sibling `ElectronicEigenvalues` section and its
-        `highest_occupied` level, or if this does not exist, from the `fermi_level` value as extracted from the sibling property, `FermiLevel`.
+        Resolve the origin of reference for the energies from the sibling `ElectronicEigenvalues`
+        section and its `highest_occupied` level.
 
         Args:
-            fermi_level (Optional[pint.Quantity]): The resolved Fermi level.
             energies_points (pint.Quantity): The grid points of the `Energy` variable.
             logger (BoundLogger): The logger to log messages.
 
@@ -215,7 +213,6 @@ class ElectronicDensityOfStates(DOSProfile):
         """
 
         # Extract the `ElectronicEigenvalues` section to get the `highest_occupied` and `lowest_unoccupied` energies
-        # TODO implement once `ElectronicEigenvalues` is in the schema
         eigenvalues = get_sibling_section(
             section=self, sibling_section_name='electronic_eigenvalues', logger=logger
         )  # we consider `index_sibling` to be 0
@@ -233,7 +230,7 @@ class ElectronicDensityOfStates(DOSProfile):
 
         # Check that the closest `energies` to the energy reference is not too far away.
         # If it is very far away, normalization may be very inaccurate and we do not report it.
-        eref = highest_occupied_energy if fermi_level is None else fermi_level
+        eref = highest_occupied_energy
         if eref is None:
             return None
         dos_values = self.value.magnitude
@@ -302,11 +299,8 @@ class ElectronicDensityOfStates(DOSProfile):
                         break
                     idx += 1
 
-        # Return the `highest_occupied_energy` as the `energies_origin`, or the `fermi_level` if it is not None
-        energies_origin = self.m_cache.get('highest_occupied_energy')
-        if energies_origin is None:
-            energies_origin = fermi_level
-        return energies_origin
+        # Return the `highest_occupied_energy` as the `energies_origin`
+        return self.m_cache.get('highest_occupied_energy')
 
     @log
     def resolve_normalization_factor(self) -> float | None:
@@ -461,16 +455,9 @@ class ElectronicDensityOfStates(DOSProfile):
         if self.energies is None:
             return
 
-        # Resolve `fermi_level` from a sibling section with respect to `ElectronicDensityOfStates`
-        # Optional sibling lookups use cached results and log at debug level (warn_if_missing=False default).
-        fermi_level = get_sibling_section(
-            section=self, sibling_section_name='fermi_level', logger=logger
-        )  # * we consider `index_sibling` to be 0
-        if fermi_level is not None:
-            fermi_level = fermi_level.value
-        # and the `energies_origin` from the sibling `ElectronicEigenvalues` section
+        # Resolve the `energies_origin` from the sibling `ElectronicEigenvalues` section
         self.energies_origin = self.resolve_energies_origin(
-            self.energies.points, fermi_level, logger
+            self.energies.points, logger
         )
         if self.energies_origin is None:
             logger.info('Could not resolve the `energies_origin` for the DOS')

--- a/src/nomad_simulations/schema_packages/properties/spectral_profile.py
+++ b/src/nomad_simulations/schema_packages/properties/spectral_profile.py
@@ -145,6 +145,9 @@ class ElectronicDensityOfStates(DOSProfile):
         """,
     )
 
+    # NOTE (DRY): specialized copy of the `ElectronicEigenvalues.highest_occupied` reference,
+    # seeded from it and then refined against the DOS grid (band edges). Duplicated on purpose
+    # so the DOS has its own origin for axis derivation and plotting/visualization alignment.
     energies_origin = Quantity(
         type=np.float64,
         unit='joule',

--- a/src/nomad_simulations/schema_packages/properties/thermodynamics.py
+++ b/src/nomad_simulations/schema_packages/properties/thermodynamics.py
@@ -158,15 +158,6 @@ class ChemicalPotential(BaseEnergy):
         """,
     )
 
-    fermi_energy = Quantity(
-        type=np.float64,
-        unit='joule',
-        description="""
-        Fermi energy at T=0K, used as reference for finite-temperature chemical potential.
-        At T=0, the chemical potential equals the Fermi energy.
-        """,
-    )
-
     type = Quantity(
         type=str,
         description="""

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -59,25 +59,27 @@ class TestElectronicDensityOfStates:
             # gapped DOS: valence <= -0.20 eV, conduction >= 0.30 eV, reference in the gap
             pytest.param(
                 np.concatenate([np.ones(31), np.zeros(49), np.ones(21)]),
-                0.0,
+                0.0 * ureg.eV,
                 -0.20,
                 -0.20,
                 0.30,
                 id='gapped',
             ),
             # metallic DOS: finite across the reference -> HOMO == LUMO == reference
-            pytest.param(np.ones(101), 0.0, 0.0, 0.0, 0.0, id='metallic'),
+            pytest.param(np.ones(101), 0.0 * ureg.eV, 0.0, 0.0, 0.0, id='metallic'),
             # only unoccupied states: HOMO stays at the reference, LUMO at the band edge
             pytest.param(
                 np.concatenate([np.zeros(80), np.ones(21)]),
-                0.0,
+                0.0 * ureg.eV,
                 0.0,
                 0.0,
                 0.30,
                 id='without_occupied',
             ),
             # reference farther than `dos_energy_tolerance` from the grid -> no origin
-            pytest.param(np.ones(101), 10.0, None, 10.0, None, id='outside_window'),
+            pytest.param(
+                np.ones(101), 10.0 * ureg.eV, None, 10.0, None, id='outside_window'
+            ),
             # no resolvable reference on the sibling -> no origin
             pytest.param(np.ones(101), None, None, None, None, id='no_reference'),
         ],
@@ -97,8 +99,7 @@ class TestElectronicDensityOfStates:
         resolved. `highest_occupied=None` means the sibling exposes no reference.
         """
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        reference = None if highest_occupied is None else highest_occupied * ureg.eV
-        electronic_dos = self._dos_with_reference(dos_values, reference)
+        electronic_dos = self._dos_with_reference(dos_values, highest_occupied)
 
         energies_origin = electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
@@ -125,12 +126,12 @@ class TestElectronicDensityOfStates:
         [
             pytest.param(
                 np.concatenate([np.ones(31), np.zeros(49), np.ones(21)]),
-                0.0,
+                0.0 * ureg.eV,
                 0.50,
                 id='gapped',
             ),
             # regression: a gap of exactly 0 eV must not be discarded by `extract_band_gap`
-            pytest.param(np.ones(101), 0.0, 0.0, id='metallic'),
+            pytest.param(np.ones(101), 0.0 * ureg.eV, 0.0, id='metallic'),
         ],
     )
     def test_resolve_energies_origin_band_gap(
@@ -140,9 +141,7 @@ class TestElectronicDensityOfStates:
         The DOS-derived band gap from the cached HOMO/LUMO after resolving the energy origin.
         """
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        electronic_dos = self._dos_with_reference(
-            dos_values, highest_occupied * ureg.eV
-        )
+        electronic_dos = self._dos_with_reference(dos_values, highest_occupied)
         electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
             logger=logger,

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -38,9 +38,10 @@ class TestElectronicDensityOfStates:
     def _dos_with_reference(self, dos_values, highest_occupied):
         """
         Build an `ElectronicDensityOfStates` attached to an `Outputs` parent that also holds an
-        `ElectronicEigenvalues` sibling exposing `highest_occupied`. This lets
-        `resolve_energies_origin` resolve its energy reference internally, as it does in
-        production (there is no parsed Fermi-level fallback).
+        `ElectronicEigenvalues` sibling. When `highest_occupied` is None the sibling exposes no
+        reference, so `resolve_energies_origin` returns None; otherwise it sets `highest_occupied`.
+        This mirrors production, where the origin is resolved internally (no parsed Fermi-level
+        fallback).
         """
         outputs = Outputs()
         electronic_dos = ElectronicDensityOfStates()
@@ -52,111 +53,104 @@ class TestElectronicDensityOfStates:
         outputs.electronic_eigenvalues.append(eigenvalues)
         return electronic_dos
 
-    def test_resolve_energies_origin(self):
+    @pytest.mark.parametrize(
+        'dos_values, highest_occupied, expected_origin, expected_homo, expected_lumo',
+        [
+            # gapped DOS: valence <= -0.20 eV, conduction >= 0.30 eV, reference in the gap
+            pytest.param(
+                np.concatenate([np.ones(31), np.zeros(49), np.ones(21)]),
+                0.0,
+                -0.20,
+                -0.20,
+                0.30,
+                id='gapped',
+            ),
+            # metallic DOS: finite across the reference -> HOMO == LUMO == reference
+            pytest.param(np.ones(101), 0.0, 0.0, 0.0, 0.0, id='metallic'),
+            # only unoccupied states: HOMO stays at the reference, LUMO at the band edge
+            pytest.param(
+                np.concatenate([np.zeros(80), np.ones(21)]),
+                0.0,
+                0.0,
+                0.0,
+                0.30,
+                id='without_occupied',
+            ),
+            # reference farther than `dos_energy_tolerance` from the grid -> no origin
+            pytest.param(np.ones(101), 10.0, None, 10.0, None, id='outside_window'),
+            # no resolvable reference on the sibling -> no origin
+            pytest.param(np.ones(101), None, None, None, None, id='no_reference'),
+        ],
+    )
+    def test_resolve_energies_origin(
+        self,
+        dos_values,
+        highest_occupied,
+        expected_origin,
+        expected_homo,
+        expected_lumo,
+    ):
         """
-        Test the `resolve_energies_origin` method with a synthetic gapped DOS.
+        Resolve the DOS energy origin from the sibling `ElectronicEigenvalues.highest_occupied`.
 
-        The DOS grid runs from -0.5 to 0.5 eV in steps of 0.01 eV, with a valence band
-        below -0.2 eV and a conduction band above 0.3 eV. With the reference (the sibling
-        `ElectronicEigenvalues.highest_occupied`) inside the gap, the HOMO/LUMO stored in
-        `m_cache` are the band-edge grid points where the DOS is non-zero.
+        The DOS grid runs from -0.5 to 0.5 eV. Expected values are in eV, or None when nothing is
+        resolved. `highest_occupied=None` means the sibling exposes no reference.
         """
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        dos_values = np.zeros(101)
-        dos_values[:31] = 1.0  # valence band: E <= -0.20 eV
-        dos_values[80:] = 1.0  # conduction band: E >= 0.30 eV
-        electronic_dos = self._dos_with_reference(dos_values, 0.0 * ureg.eV)
+        reference = None if highest_occupied is None else highest_occupied * ureg.eV
+        electronic_dos = self._dos_with_reference(dos_values, reference)
 
         energies_origin = electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
             logger=logger,
         )
 
-        homo = electronic_dos.m_cache.get('highest_occupied_energy')
-        lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
-        assert np.isclose(homo.to('eV').magnitude, -0.20)
-        assert np.isclose(lumo.to('eV').magnitude, 0.30)
-        assert energies_origin == homo
+        def _matches(actual, expected):
+            if expected is None:
+                return actual is None
+            return actual is not None and np.isclose(
+                actual.to('eV').magnitude, expected, atol=1e-9
+            )
 
-        # The cached energies produce a finite DOS-derived band gap
+        assert _matches(energies_origin, expected_origin)
+        assert _matches(
+            electronic_dos.m_cache.get('highest_occupied_energy'), expected_homo
+        )
+        assert _matches(
+            electronic_dos.m_cache.get('lowest_unoccupied_energy'), expected_lumo
+        )
+
+    @pytest.mark.parametrize(
+        'dos_values, highest_occupied, expected_gap',
+        [
+            pytest.param(
+                np.concatenate([np.ones(31), np.zeros(49), np.ones(21)]),
+                0.0,
+                0.50,
+                id='gapped',
+            ),
+            # regression: a gap of exactly 0 eV must not be discarded by `extract_band_gap`
+            pytest.param(np.ones(101), 0.0, 0.0, id='metallic'),
+        ],
+    )
+    def test_resolve_energies_origin_band_gap(
+        self, dos_values, highest_occupied, expected_gap
+    ):
+        """
+        The DOS-derived band gap from the cached HOMO/LUMO after resolving the energy origin.
+        """
+        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
+        electronic_dos = self._dos_with_reference(
+            dos_values, highest_occupied * ureg.eV
+        )
+        electronic_dos.resolve_energies_origin(
+            energies_points=energies_points,
+            logger=logger,
+        )
+
         band_gap = electronic_dos.extract_band_gap()
         assert band_gap is not None
-        assert np.isclose(band_gap.value.to('eV').magnitude, 0.50)
-
-    def test_resolve_energies_origin_metallic(self):
-        """
-        Test `resolve_energies_origin` with a DOS that is finite across the reference:
-        HOMO and LUMO both resolve to the reference energy and the derived band gap is 0
-        (regression test: HOMO/LUMO of exactly 0 eV must not be discarded by the
-        truthiness check in `extract_band_gap`).
-        """
-        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        electronic_dos = self._dos_with_reference(np.ones(101), 0.0 * ureg.eV)
-
-        energies_origin = electronic_dos.resolve_energies_origin(
-            energies_points=energies_points,
-            logger=logger,
-        )
-
-        homo = electronic_dos.m_cache.get('highest_occupied_energy')
-        lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
-        assert np.isclose(homo.to('eV').magnitude, 0.0, atol=1e-12)
-        assert np.isclose(lumo.to('eV').magnitude, 0.0, atol=1e-12)
-        assert energies_origin == homo
-
-        band_gap = electronic_dos.extract_band_gap()
-        assert band_gap is not None
-        assert np.isclose(band_gap.value.to('eV').magnitude, 0.0, atol=1e-12)
-
-    def test_resolve_energies_origin_without_occupied_states(self):
-        """
-        The HOMO search must not wrap around to the end of the DOS array. When the DOS
-        window contains no occupied states, the reference `highest_occupied` is retained.
-        """
-        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        dos_values = np.zeros(101)
-        dos_values[80:] = 1.0  # unoccupied states only: E >= 0.30 eV
-        electronic_dos = self._dos_with_reference(dos_values, 0.0 * ureg.eV)
-
-        energies_origin = electronic_dos.resolve_energies_origin(
-            energies_points=energies_points,
-            logger=logger,
-        )
-
-        homo = electronic_dos.m_cache.get('highest_occupied_energy')
-        lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
-        assert np.isclose(homo.to('eV').magnitude, 0.0, atol=1e-12)
-        assert np.isclose(lumo.to('eV').magnitude, 0.30)
-        assert energies_origin == homo
-
-    def test_resolve_energies_origin_no_reference(self):
-        """
-        Test that `resolve_energies_origin` returns `None` when there is no
-        `ElectronicEigenvalues` sibling to provide a reference.
-        """
-        electronic_dos = ElectronicDensityOfStates()
-        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        electronic_dos.value = np.ones(101) * ureg('1/joule')
-
-        energies_origin = electronic_dos.resolve_energies_origin(
-            energies_points=energies_points,
-            logger=logger,
-        )
-        assert energies_origin is None
-
-    def test_resolve_energies_origin_reference_outside_window(self):
-        """
-        When the `highest_occupied` reference lies farther than `dos_energy_tolerance` from
-        every DOS grid point (i.e. outside the sampled window), no origin is reported.
-        """
-        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        electronic_dos = self._dos_with_reference(np.ones(101), 10.0 * ureg.eV)
-
-        energies_origin = electronic_dos.resolve_energies_origin(
-            energies_points=energies_points,
-            logger=logger,
-        )
-        assert energies_origin is None
+        assert np.isclose(band_gap.value.to('eV').magnitude, expected_gap, atol=1e-9)
 
     def test_resolve_normalization_factor(self, simulation_electronic_dos: Simulation):
         """

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -4,11 +4,15 @@ from nomad.units import ureg
 
 from nomad_simulations.schema_packages.atoms_state import AtomsState
 from nomad_simulations.schema_packages.general import Simulation
+from nomad_simulations.schema_packages.outputs import Outputs
 from nomad_simulations.schema_packages.properties import (
     AbsorptionSpectrum,
     DOSProfile,
     ElectronicDensityOfStates,
     XASSpectrum,
+)
+from nomad_simulations.schema_packages.properties.electronic_eigenvalues import (
+    ElectronicEigenvalues,
 )
 from nomad_simulations.schema_packages.variables import Energy2 as Energy
 
@@ -31,27 +35,40 @@ class TestElectronicDensityOfStates:
             == 'http://fairmat-nfdi.eu/taxonomy/ElectronicDensityOfStates'
         )
 
+    def _dos_with_reference(self, dos_values, highest_occupied):
+        """
+        Build an `ElectronicDensityOfStates` attached to an `Outputs` parent that also holds an
+        `ElectronicEigenvalues` sibling exposing `highest_occupied`. This lets
+        `resolve_energies_origin` resolve its energy reference internally, as it does in
+        production (there is no parsed Fermi-level fallback).
+        """
+        outputs = Outputs()
+        electronic_dos = ElectronicDensityOfStates()
+        electronic_dos.value = dos_values * ureg('1/joule')
+        outputs.electronic_dos.append(electronic_dos)
+        eigenvalues = ElectronicEigenvalues()
+        if highest_occupied is not None:
+            eigenvalues.highest_occupied = highest_occupied
+        outputs.electronic_eigenvalues.append(eigenvalues)
+        return electronic_dos
+
     def test_resolve_energies_origin(self):
         """
         Test the `resolve_energies_origin` method with a synthetic gapped DOS.
 
         The DOS grid runs from -0.5 to 0.5 eV in steps of 0.01 eV, with a valence band
-        below -0.2 eV and a conduction band above 0.3 eV. With the Fermi level inside
-        the gap, the HOMO/LUMO stored in `m_cache` are the highest occupied and lowest
-        unoccupied DOS points, i.e., the band-edge grid points where the DOS is
-        non-zero.
+        below -0.2 eV and a conduction band above 0.3 eV. With the reference (the sibling
+        `ElectronicEigenvalues.highest_occupied`) inside the gap, the HOMO/LUMO stored in
+        `m_cache` are the band-edge grid points where the DOS is non-zero.
         """
-        # ! extend to the `ElectronicEigenvalues` sibling path once it is implemented
-        electronic_dos = ElectronicDensityOfStates()
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
         dos_values = np.zeros(101)
         dos_values[:31] = 1.0  # valence band: E <= -0.20 eV
         dos_values[80:] = 1.0  # conduction band: E >= 0.30 eV
-        electronic_dos.value = dos_values * ureg('1/joule')
+        electronic_dos = self._dos_with_reference(dos_values, 0.0 * ureg.eV)
 
         energies_origin = electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
-            fermi_level=0.0 * ureg.eV,
             logger=logger,
         )
 
@@ -68,18 +85,16 @@ class TestElectronicDensityOfStates:
 
     def test_resolve_energies_origin_metallic(self):
         """
-        Test `resolve_energies_origin` with a DOS that is finite across the Fermi
-        level: HOMO and LUMO both resolve to the Fermi energy and the derived band
-        gap is 0 (regression test: HOMO/LUMO of exactly 0 eV must not be discarded
-        by the truthiness check in `extract_band_gap`).
+        Test `resolve_energies_origin` with a DOS that is finite across the reference:
+        HOMO and LUMO both resolve to the reference energy and the derived band gap is 0
+        (regression test: HOMO/LUMO of exactly 0 eV must not be discarded by the
+        truthiness check in `extract_band_gap`).
         """
-        electronic_dos = ElectronicDensityOfStates()
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
-        electronic_dos.value = np.ones(101) * ureg('1/joule')
+        electronic_dos = self._dos_with_reference(np.ones(101), 0.0 * ureg.eV)
 
         energies_origin = electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
-            fermi_level=0.0 * ureg.eV,
             logger=logger,
         )
 
@@ -94,28 +109,30 @@ class TestElectronicDensityOfStates:
         assert np.isclose(band_gap.value.to('eV').magnitude, 0.0, atol=1e-12)
 
     def test_resolve_energies_origin_without_occupied_states(self):
-        """The HOMO search must not wrap around to the end of the DOS array."""
-        electronic_dos = ElectronicDensityOfStates()
+        """
+        The HOMO search must not wrap around to the end of the DOS array. When the DOS
+        window contains no occupied states, the reference `highest_occupied` is retained.
+        """
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
         dos_values = np.zeros(101)
         dos_values[80:] = 1.0  # unoccupied states only: E >= 0.30 eV
-        electronic_dos.value = dos_values * ureg('1/joule')
+        electronic_dos = self._dos_with_reference(dos_values, 0.0 * ureg.eV)
 
         energies_origin = electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
-            fermi_level=0.0 * ureg.eV,
             logger=logger,
         )
 
-        assert electronic_dos.m_cache.get('highest_occupied_energy') is None
+        homo = electronic_dos.m_cache.get('highest_occupied_energy')
         lumo = electronic_dos.m_cache.get('lowest_unoccupied_energy')
+        assert np.isclose(homo.to('eV').magnitude, 0.0, atol=1e-12)
         assert np.isclose(lumo.to('eV').magnitude, 0.30)
-        assert energies_origin == 0.0 * ureg.eV
+        assert energies_origin == homo
 
     def test_resolve_energies_origin_no_reference(self):
         """
-        Test that `resolve_energies_origin` returns `None` when neither an
-        `ElectronicEigenvalues` sibling nor a Fermi level is available.
+        Test that `resolve_energies_origin` returns `None` when there is no
+        `ElectronicEigenvalues` sibling to provide a reference.
         """
         electronic_dos = ElectronicDensityOfStates()
         energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
@@ -123,7 +140,6 @@ class TestElectronicDensityOfStates:
 
         energies_origin = electronic_dos.resolve_energies_origin(
             energies_points=energies_points,
-            fermi_level=None,
             logger=logger,
         )
         assert energies_origin is None

--- a/tests/properties/test_spectral_profile.py
+++ b/tests/properties/test_spectral_profile.py
@@ -144,6 +144,20 @@ class TestElectronicDensityOfStates:
         )
         assert energies_origin is None
 
+    def test_resolve_energies_origin_reference_outside_window(self):
+        """
+        When the `highest_occupied` reference lies farther than `dos_energy_tolerance` from
+        every DOS grid point (i.e. outside the sampled window), no origin is reported.
+        """
+        energies_points = np.linspace(-0.5, 0.5, 101) * ureg.eV
+        electronic_dos = self._dos_with_reference(np.ones(101), 10.0 * ureg.eV)
+
+        energies_origin = electronic_dos.resolve_energies_origin(
+            energies_points=energies_points,
+            logger=logger,
+        )
+        assert energies_origin is None
+
     def test_resolve_normalization_factor(self, simulation_electronic_dos: Simulation):
         """
         Test the `resolve_normalization_factor` method.


### PR DESCRIPTION
## Purpose

Resolve #418. The DOS and band-structure normalizers look up a `fermi_level` sibling that no longer exists: `FermiLevel` was removed in #201 (commit `74f1835`), which in the same change folded a Fermi energy into `ChemicalPotential.fermi_energy`, but the consumers were left dangling. `get_sibling_section(..., 'fermi_level')` resolves `m_parent.fermi_level`, which does not exist, so it always returns `None` in production — the DOS energy origin already relies solely on `ElectronicEigenvalues.highest_occupied`. This PR makes that explicit, removes the dead code, and drops the now-redundant `fermi_energy`.

## Scope

**Included**

- Remove the dead `get_sibling_section(..., 'fermi_level')` lookups in `spectral_profile.py` and `band_structure.py`, and fix docstrings that referenced the removed `FermiLevel`.
- Drop the `fermi_level` parameter from `ElectronicDensityOfStates.resolve_energies_origin`; the energy origin is derived solely from `ElectronicEigenvalues.highest_occupied`.
- `ElectronicBandStructure.extract_fermi_surface` now references the highest occupied eigenvalue (which coincides with the Fermi level for gapless systems) instead of the removed `FermiLevel`.
- Remove `ChemicalPotential.fermi_energy` (redundant with `ChemicalPotential.value`).
- Reorient the `resolve_energies_origin` tests onto the `ElectronicEigenvalues` sibling path; regenerate schema docs.

**Out of scope**

- Denoting which species/reservoir a `ChemicalPotential` applies to (electronic vs atomic/ionic) — to be tracked separately (candidate: a proper `entity_ref` rather than the free-text `type`).
- Finalizing the `FermiSurface` property; `extract_fermi_surface` remains disabled in `normalize`.

## Context & Links

- Closes #418.
- Origin of the current layout: PR #201 (`FermiLevel` removed, `fermi_energy` folded into `ChemicalPotential`).

## Breaking Changes

- Removes `ChemicalPotential.fermi_energy`. No parser or normalizer in this repo populated or read it.

## Testing / Validation

- Unit tests reoriented to the eigenvalues path; full suite passes (1065 passed, 9 skipped). `mypy` and `ruff` clean. Docs regenerated (docs-integrity clean).
