### PR TITLE
Fix SCF energy-delta normalization

### DIFF
--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -2,6 +2,37 @@
 
 **Purpose:** Base output structure and common property definitions
 
+## Notes
+
+One `Outputs` section represents the calculated properties of one system
+configuration, identified through `model_system_ref`. A sequence of
+configurations, such as geometry-optimization steps, is represented using
+multiple output sections, normally `WorkflowOutputs`, ordered by
+`WorkflowOutputs.step`.
+
+One `TotalEnergy` represents the converged total energy of that configuration.
+Energy components belong inside that `TotalEnergy` through its `contributions`
+subsections. The listed contributions do not have to be exhaustive, so the total
+energy is not necessarily equal to their sum. Although `Outputs.total_energies`
+has `repeats=True`, the schema currently defines neither an ordering nor a
+sequence meaning for repeated entries.
+
+`SCFSteps.energies_total` is the ordered sequence of total energies from the SCF
+iterations within one configuration. `SCFSteps.delta_energies_total` contains
+differences between consecutive values from that SCF sequence.
+
+Conceptual geometry-optimization layout:
+
+```text
+WorkflowOutputs(step=0)
+    TotalEnergy for configuration 0
+    SCFSteps.energies_total for the SCF iterations of configuration 0
+
+WorkflowOutputs(step=1)
+    TotalEnergy for configuration 1
+    SCFSteps.energies_total for the SCF iterations of configuration 1
+```
+
 
 ## Relationship map
 
@@ -74,7 +105,7 @@ classDiagram
 
 | Section | Description | MetaInfo |
 |---|---|---|
-| `Outputs` | Output properties of a simulation. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.outputs.Outputs){:target="_blank"} |
+| `Outputs` | Output properties of one system configuration. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.outputs.Outputs){:target="_blank"} |
 
 | Quantity | Type | Description |
 |---|---|---|
@@ -89,8 +120,8 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `energies_total` | m_float64(float) (shape: ['*']) | Total energy at each SCF step. |
-| `delta_energies_total` | m_float64(float) (shape: ['*']) | <details><summary>Absolute change of total energy between consecutive SCF steps.</summary>Absolute change of total energy between consecutive SCF steps. When<br>derived from `energies_total`, `delta_energies_total[i] =<br>abs(energies_total[i + 1] - energies_total[i])`, so N SCF energies<br>produce N - 1 energy deltas.</details> |
+| `energies_total` | m_float64(float) (shape: ['*']) | Ordered sequence of total energies from the SCF iterations within one system configuration. |
+| `delta_energies_total` | m_float64(float) (shape: ['*']) | <details><summary>Absolute change of total energy between consecutive SCF steps.</summary>Absolute change of total energy between consecutive SCF steps. When<br>derived from `energies_total`, the values follow<br>$\Delta E_i = \lvert E_{i+1} - E_i \rvert$, so N SCF energies<br>produce N - 1 energy deltas.</details> |
 | `delta_potential_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
 | `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
 | `delta_wavefunction_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of wavefunction coefficients at each SCF step. Dimensionless quantity representing convergence of orbital coefficients. |

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -91,10 +91,10 @@ classDiagram
 |---|---|---|
 | `energies_total` | m_float64(float) (shape: ['*']) | Total energy at each SCF step. |
 | `delta_energies_total` | m_float64(float) (shape: ['*']) | Absolute change of total energy at each SCF step. |
-| `delta_potential_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
-| `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of the integrated charge-density residual at each SCF step. |
+| `delta_potential_rms` | m_float64(float) (shape: ['*']) | Code-reported effective-potential residual at each SCF step, in energy units. The exact norm and normalization are code-specific. |
+| `delta_density_rms` | m_float64(float) (shape: ['*']) | Code-reported charge-density residual at each SCF step, in charge units. The exact norm and normalization are code-specific. |
 | `delta_wavefunction_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of wavefunction coefficients at each SCF step. Dimensionless quantity representing convergence of orbital coefficients. |
-| `delta_force_abs` | m_float64(float) (shape: ['*']) | Absolute change of forces at each SCF step. |
+| `delta_force_abs` | m_float64(float) (shape: ['*']) | Code-reported absolute force-change convergence measure at each SCF step. Values are not inferred from final forces. |
 | `durations` | m_float64(float) (shape: ['*']) | Time spent at each SCF step. |
 | `code_specific_quantities` | JSON | Code specific quantities that are recorded during SCF convergence. |
 

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -90,7 +90,7 @@ classDiagram
 | Quantity | Type | Description |
 |---|---|---|
 | `energies_total` | m_float64(float) (shape: ['*']) | Total energy at each SCF step. |
-| `delta_energies_total` | m_float64(float) (shape: ['*']) | Absolute change of total energy at each SCF step. |
+| `delta_energies_total` | m_float64(float) (shape: ['*']) | <details><summary>Absolute change of total energy between consecutive SCF steps.</summary>Absolute change of total energy between consecutive SCF steps. When<br>derived from `energies_total`, `delta_energies_total[i] =<br>abs(energies_total[i + 1] - energies_total[i])`, so N SCF energies<br>produce N - 1 energy deltas.</details> |
 | `delta_potential_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
 | `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
 | `delta_wavefunction_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of wavefunction coefficients at each SCF step. Dimensionless quantity representing convergence of orbital coefficients. |

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -92,7 +92,7 @@ classDiagram
 | `energies_total` | m_float64(float) (shape: ['*']) | Total energy at each SCF step. |
 | `delta_energies_total` | m_float64(float) (shape: ['*']) | Absolute change of total energy at each SCF step. |
 | `delta_potential_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
-| `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of charge density at each SCF step. |
+| `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of the integrated charge-density residual at each SCF step. |
 | `delta_wavefunction_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of wavefunction coefficients at each SCF step. Dimensionless quantity representing convergence of orbital coefficients. |
 | `delta_force_abs` | m_float64(float) (shape: ['*']) | Absolute change of forces at each SCF step. |
 | `durations` | m_float64(float) (shape: ['*']) | Time spent at each SCF step. |

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -92,7 +92,7 @@ classDiagram
 | `energies_total` | m_float64(float) (shape: ['*']) | Total energy at each SCF step. |
 | `delta_energies_total` | m_float64(float) (shape: ['*']) | Absolute change of total energy at each SCF step. |
 | `delta_potential_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
-| `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
+| `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of charge density at each SCF step. |
 | `delta_wavefunction_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of wavefunction coefficients at each SCF step. Dimensionless quantity representing convergence of orbital coefficients. |
 | `delta_force_abs` | m_float64(float) (shape: ['*']) | Absolute change of forces at each SCF step. |
 | `durations` | m_float64(float) (shape: ['*']) | Time spent at each SCF step. |

--- a/docs/schema/outputs.md
+++ b/docs/schema/outputs.md
@@ -91,10 +91,10 @@ classDiagram
 |---|---|---|
 | `energies_total` | m_float64(float) (shape: ['*']) | Total energy at each SCF step. |
 | `delta_energies_total` | m_float64(float) (shape: ['*']) | Absolute change of total energy at each SCF step. |
-| `delta_potential_rms` | m_float64(float) (shape: ['*']) | Code-reported effective-potential residual at each SCF step, in energy units. The exact norm and normalization are code-specific. |
-| `delta_density_rms` | m_float64(float) (shape: ['*']) | Code-reported charge-density residual at each SCF step, in charge units. The exact norm and normalization are code-specific. |
+| `delta_potential_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
+| `delta_density_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of potential energy at each SCF step. |
 | `delta_wavefunction_rms` | m_float64(float) (shape: ['*']) | Root mean square of change of wavefunction coefficients at each SCF step. Dimensionless quantity representing convergence of orbital coefficients. |
-| `delta_force_abs` | m_float64(float) (shape: ['*']) | Code-reported absolute force-change convergence measure at each SCF step. Values are not inferred from final forces. |
+| `delta_force_abs` | m_float64(float) (shape: ['*']) | Absolute change of forces at each SCF step. |
 | `durations` | m_float64(float) (shape: ['*']) | Time spent at each SCF step. |
 | `code_specific_quantities` | JSON | Code specific quantities that are recorded during SCF convergence. |
 

--- a/docs/schema/thermodynamics.md
+++ b/docs/schema/thermodynamics.md
@@ -72,7 +72,7 @@ classDiagram
 
 | Section | Description | MetaInfo |
 |---|---|---|
-| `TotalEnergy` | The total energy of a system. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.properties.energies.TotalEnergy){:target="_blank"} |
+| `TotalEnergy` | The converged total energy of one system configuration. | [Open in MetaInfo browser](https://nomad-lab.eu/prod/v1/develop/gui/analyze/metainfo/nomad_simulations/section_definitions@nomad_simulations.schema_packages.properties.energies.TotalEnergy){:target="_blank"} |
 
 *This section has no direct quantities.*
 

--- a/docs/snippets/tutorials/part2_foundations/assignment_2_7.py
+++ b/docs/snippets/tutorials/part2_foundations/assignment_2_7.py
@@ -30,7 +30,7 @@ method = DFT(
 simulation.model_method.append(method)
 
 outputs = Outputs(
-    scf_steps=SCFSteps(energies_total=np.array([1.0, 1.5, 2.0, 2.1, 2.101]) * ureg.eV)
+    scf_steps=SCFSteps(energies_total=[1.0, 1.5, 2.0, 2.1, 2.101] * ureg.eV)
 )
 simulation.outputs.append(outputs)
 

--- a/docs/snippets/tutorials/part2_foundations/assignment_2_7.py
+++ b/docs/snippets/tutorials/part2_foundations/assignment_2_7.py
@@ -9,7 +9,6 @@ from nomad_simulations.schema_packages.model_method import DFT
 from nomad_simulations.schema_packages.model_system import ModelSystem
 from nomad_simulations.schema_packages.numerical_settings import SelfConsistency
 from nomad_simulations.schema_packages.outputs import Outputs, SCFSteps
-from nomad_simulations.schema_packages.properties import TotalEnergy
 
 logger = utils.get_logger(__name__)
 
@@ -30,9 +29,9 @@ method = DFT(
 )
 simulation.model_method.append(method)
 
-outputs = Outputs(scf_steps=SCFSteps())
-for value in [1.0, 1.5, 2.0, 2.1, 2.101]:
-    outputs.total_energies.append(TotalEnergy(value=value * ureg.eV))
+outputs = Outputs(
+    scf_steps=SCFSteps(energies_total=np.array([1.0, 1.5, 2.0, 2.1, 2.101]) * ureg.eV)
+)
 simulation.outputs.append(outputs)
 
 outputs.normalize(archive=EntryArchive(), logger=logger)

--- a/docs/snippets/tutorials/part2_foundations/normalization_exercise_2.py
+++ b/docs/snippets/tutorials/part2_foundations/normalization_exercise_2.py
@@ -8,9 +8,7 @@ from nomad_simulations.schema_packages.outputs import Outputs, SCFSteps
 logger = utils.get_logger(__name__)
 
 # Pattern based on tests/workflow/test_convergence_targets.py.
-outputs = Outputs(
-    scf_steps=SCFSteps(energies_total=np.array([1.0, 1.5, 2.1]) * ureg.eV)
-)
+outputs = Outputs(scf_steps=SCFSteps(energies_total=[1.0, 1.5, 2.1] * ureg.eV))
 
 outputs.normalize(EntryArchive(), logger)
 

--- a/docs/snippets/tutorials/part2_foundations/normalization_exercise_2.py
+++ b/docs/snippets/tutorials/part2_foundations/normalization_exercise_2.py
@@ -4,15 +4,13 @@ from nomad.datamodel import EntryArchive
 from nomad.units import ureg
 
 from nomad_simulations.schema_packages.outputs import Outputs, SCFSteps
-from nomad_simulations.schema_packages.properties import TotalEnergy
 
 logger = utils.get_logger(__name__)
 
 # Pattern based on tests/workflow/test_convergence_targets.py.
-outputs = Outputs(scf_steps=SCFSteps())
-outputs.total_energies.append(TotalEnergy(value=1.0 * ureg.eV))
-outputs.total_energies.append(TotalEnergy(value=1.5 * ureg.eV))
-outputs.total_energies.append(TotalEnergy(value=2.1 * ureg.eV))
+outputs = Outputs(
+    scf_steps=SCFSteps(energies_total=np.array([1.0, 1.5, 2.1]) * ureg.eV)
+)
 
 outputs.normalize(EntryArchive(), logger)
 

--- a/docs/tutorials/standalone_schema_tutorial.md
+++ b/docs/tutorials/standalone_schema_tutorial.md
@@ -106,7 +106,7 @@ without parser-plugin complexity. The page ends with a short normalization-metho
 ## Assignment 2.7: `Outputs`, references, and SCF deltas
 
 !!! abstract "Assignment 2.7"
-    Create an `Outputs` section with `SCFSteps` and `TotalEnergy` values across steps,
+    Create an `Outputs` section with `SCFSteps.energies_total` values across steps,
     normalize, and verify automatic `model_system_ref`, `model_method_ref`, and
     `delta_energies_total` population.
 
@@ -157,11 +157,11 @@ The following exercises focus on practical normalization behavior from current t
     --8<-- "snippets/tutorials/part2_foundations/normalization_exercise_1.py"
     ```
 
-### Exercise N2: `Outputs` SCF deltas from total energies
+### Exercise N2: `Outputs` SCF deltas from SCF total energies
 
 !!! abstract "Exercise N2"
-    Populate only `total_energies` and run `Outputs.normalize(...)` to confirm
-    that `scf_steps.delta_energies_total` is computed automatically.
+    Populate `scf_steps.energies_total` and run `Outputs.normalize(...)` to
+    confirm that `scf_steps.delta_energies_total` is computed automatically.
 
 ??? success "Solution N2"
     ```python

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -383,11 +383,12 @@ def build_vertical(
         title = spec.get('title', vert_key.title())
         sections = list(spec.get('sections', []))
         purpose = spec.get('purpose', '')
+        notes = spec.get('notes', '').strip()
         in_scope = [clean_scope_item(item) for item in spec.get('in_scope', [])]
     else:
         title = vert_key.title()
         sections = list(spec)
-        purpose, in_scope = '', []
+        purpose, notes, in_scope = '', '', []
 
     # Diagram (already fenced and with blank lines)
     mermaid_block = mermaid_for_vertical(
@@ -457,6 +458,7 @@ def build_vertical(
         key=vert_key,
         title=title,
         purpose=purpose,
+        notes=notes,
         in_scope=in_scope,
         sections=sections,
         section_info=section_info,

--- a/scripts/verticals.py
+++ b/scripts/verticals.py
@@ -377,6 +377,36 @@ VERTICALS = {
     'outputs': {
         'title': 'Outputs',
         'purpose': 'Base output structure and common property definitions',
+        'notes': """
+One `Outputs` section represents the calculated properties of one system
+configuration, identified through `model_system_ref`. A sequence of
+configurations, such as geometry-optimization steps, is represented using
+multiple output sections, normally `WorkflowOutputs`, ordered by
+`WorkflowOutputs.step`.
+
+One `TotalEnergy` represents the converged total energy of that configuration.
+Energy components belong inside that `TotalEnergy` through its `contributions`
+subsections. The listed contributions do not have to be exhaustive, so the total
+energy is not necessarily equal to their sum. Although `Outputs.total_energies`
+has `repeats=True`, the schema currently defines neither an ordering nor a
+sequence meaning for repeated entries.
+
+`SCFSteps.energies_total` is the ordered sequence of total energies from the SCF
+iterations within one configuration. `SCFSteps.delta_energies_total` contains
+differences between consecutive values from that SCF sequence.
+
+Conceptual geometry-optimization layout:
+
+```text
+WorkflowOutputs(step=0)
+    TotalEnergy for configuration 0
+    SCFSteps.energies_total for the SCF iterations of configuration 0
+
+WorkflowOutputs(step=1)
+    TotalEnergy for configuration 1
+    SCFSteps.energies_total for the SCF iterations of configuration 1
+```
+""",
         'sections': [
             'Outputs',
             'SCFSteps',

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -44,6 +44,10 @@ from .common import SimulationTime
 class SCFSteps(ArchiveSection):
     """
     Data recorded at each step of a self-consistent DFT calculation.
+
+    The SCF quantities describe the iterative convergence process for one
+    system configuration, i.e. within one `Outputs` section. They do not
+    describe a sequence of configurations such as geometry-optimization steps.
     """
 
     energies_total = Quantity(
@@ -51,7 +55,8 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='joule',
         description="""
-        Total energy at each SCF step.
+        Ordered sequence of total energies from the SCF iterations within one
+        system configuration.
         """,
     )
 
@@ -61,8 +66,8 @@ class SCFSteps(ArchiveSection):
         unit='joule',
         description="""
         Absolute change of total energy between consecutive SCF steps. When
-        derived from `energies_total`, `delta_energies_total[i] =
-        abs(energies_total[i + 1] - energies_total[i])`, so N SCF energies
+        derived from `energies_total`, the values follow
+        $\\Delta E_i = \\lvert E_{i+1} - E_i \\rvert$, so N SCF energies
         produce N - 1 energy deltas.
         """,
     )
@@ -124,11 +129,17 @@ class SCFSteps(ArchiveSection):
 # TODO: Outputs should not be of type time, but the workflow should be instead?
 class Outputs(SimulationTime):
     """
-    Output properties of a simulation. This base class can be used for inheritance in any of the output properties
-    defined in this schema.
+    Output properties of one system configuration.
 
-    It contains references to the specific sections used to obtain the output properties, as well as
-    information if the output `is_derived` from another output section or directly parsed from the simulation output files.
+    One `Outputs` section holds the calculated properties for the
+    configuration identified through `model_system_ref`. A sequence of
+    configurations, such as a geometry optimization, is represented using
+    multiple output sections, normally `WorkflowOutputs`, ordered by
+    `WorkflowOutputs.step`.
+
+    It contains references to the specific sections used to obtain the output
+    properties, as well as information if the output `is_derived` from another
+    output section or directly parsed from the simulation output files.
     """
 
     normalizer_level = 2
@@ -287,8 +298,9 @@ class Outputs(SimulationTime):
         Compute absolute energy differences between consecutive energies.
 
         Given a sequence of `energies`, returns an array of the absolute
-        differences between consecutive entries, i.e. `deltas[i] =
-        abs(energies[i + 1] - energies[i])`, so N energies produce N - 1 deltas.
+        differences between consecutive entries, i.e.
+        $\\Delta E_i = \\lvert E_{i+1} - E_i \\rvert$, so N energies produce
+        N - 1 deltas.
         Accepting the energies as an argument keeps this decoupled from the
         section, so deltas can be computed from various sources (e.g. SCF
         `energies_total` or any other energy sequence). Returns None if fewer
@@ -358,22 +370,17 @@ class Outputs(SimulationTime):
 
         # Populate missing SCF delta quantities from available data
         if self.scf_steps is not None:
-            # Define delta computations: (delta_field, compute_function)
-            delta_computations = [
-                (
-                    'delta_energies_total',
-                    lambda logger: self._compute_energy_deltas(
-                        self.scf_steps.energies_total, logger
-                    ),
-                ),
-                ('delta_force_abs', self._compute_force_norms),
-            ]
+            if self.scf_steps.delta_energies_total is None:
+                delta_energies_total = self._compute_energy_deltas(
+                    self.scf_steps.energies_total, logger
+                )
+                if delta_energies_total is not None:
+                    self.scf_steps.delta_energies_total = delta_energies_total
 
-            for delta_field, compute_func in delta_computations:
-                if getattr(self.scf_steps, delta_field, None) is None:
-                    computed_value = compute_func(logger)
-                    if computed_value is not None:
-                        setattr(self.scf_steps, delta_field, computed_value)
+            if self.scf_steps.delta_force_abs is None:
+                delta_force_abs = self._compute_force_norms(logger)
+                if delta_force_abs is not None:
+                    self.scf_steps.delta_force_abs = delta_force_abs
 
 
 class WorkflowOutputs(Outputs):

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -60,7 +60,10 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='joule',
         description="""
-        Absolute change of total energy at each SCF step.
+        Absolute change of total energy between consecutive SCF steps. When
+        derived from `energies_total`, `delta_energies_total[i] =
+        abs(energies_total[i + 1] - energies_total[i])`, so N SCF energies
+        produce N - 1 energy deltas.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -69,8 +69,7 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='joule',
         description="""
-        Code-reported effective-potential residual at each SCF step, in energy
-        units. The exact norm and normalization are code-specific.
+        Root mean square of change of potential energy at each SCF step.
         """,
     )
 
@@ -79,8 +78,7 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='coulomb',
         description="""
-        Code-reported charge-density residual at each SCF step, in charge units.
-        The exact norm and normalization are code-specific.
+        Root mean square of change of potential energy at each SCF step.
         """,
     )
 
@@ -99,8 +97,7 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='newton',
         description="""
-        Code-reported absolute force-change convergence measure at each SCF step.
-        Values are not inferred from final forces.
+        Absolute change of forces at each SCF step.
         """,
     )
 
@@ -295,14 +292,18 @@ class Outputs(SimulationTime):
             ):
                 return None
 
+            # Extract energy values from each step
             energy_values = self.scf_steps.energies_total
 
+            # Compute differences manually to preserve Pint units
             deltas = []
             for i in range(1, len(energy_values)):
                 delta = np.abs(energy_values[i] - energy_values[i - 1])
                 deltas.append(delta)
 
+            # Convert list to array-like structure
             if len(deltas) > 0 and hasattr(deltas[0], 'magnitude'):
+                # Pint quantities - stack magnitudes and add units
                 magnitudes = [d.magnitude for d in deltas]
                 return np.array(magnitudes) * deltas[0].units
             else:
@@ -310,6 +311,27 @@ class Outputs(SimulationTime):
 
         except (AttributeError, IndexError, TypeError, ValueError) as e:
             logger.debug(f'Could not compute delta_energies_total: {e}')
+            return None
+
+    def _compute_force_norms(self, logger: 'BoundLogger'):
+        """
+        Compute delta_force_abs from total_forces as force norms.
+
+        Returns array of force norms (L2 norm of 3D force vectors).
+        """
+        try:
+            if self.total_forces is None or len(self.total_forces) == 0:
+                return None
+
+            # Get force values (Pint Quantity with shape [n_atoms, 3])
+            force_values = self.total_forces[-1].value
+
+            # Compute force norms (preserves Pint units)
+            force_norms = ((force_values**2).sum(axis=1)) ** 0.5
+
+            return force_norms
+        except (AttributeError, IndexError, TypeError) as e:
+            logger.debug(f'Could not compute delta_force_abs: {e}')
             return None
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
@@ -336,6 +358,7 @@ class Outputs(SimulationTime):
             # Define delta computations: (delta_field, compute_function)
             delta_computations = [
                 ('delta_energies_total', self._compute_energy_deltas),
+                ('delta_force_abs', self._compute_force_norms),
             ]
 
             for delta_field, compute_func in delta_computations:

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -76,9 +76,10 @@ class SCFSteps(ArchiveSection):
     delta_density_rms = Quantity(
         shape=['*'],
         type=float,
-        unit='coulomb / meter ** 3',
+        unit='coulomb',
         description="""
-        Root mean square of change of charge density at each SCF step.
+        Root mean square of the integrated charge-density residual at each SCF
+        step.
         """,
     )
 

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -69,7 +69,8 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='joule',
         description="""
-        Root mean square of change of potential energy at each SCF step.
+        Code-reported effective-potential residual at each SCF step, in energy
+        units. The exact norm and normalization are code-specific.
         """,
     )
 
@@ -78,8 +79,8 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='coulomb',
         description="""
-        Root mean square of the integrated charge-density residual at each SCF
-        step.
+        Code-reported charge-density residual at each SCF step, in charge units.
+        The exact norm and normalization are code-specific.
         """,
     )
 
@@ -98,7 +99,8 @@ class SCFSteps(ArchiveSection):
         type=float,
         unit='newton',
         description="""
-        Absolute change of forces at each SCF step.
+        Code-reported absolute force-change convergence measure at each SCF step.
+        Values are not inferred from final forces.
         """,
     )
 
@@ -295,15 +297,12 @@ class Outputs(SimulationTime):
 
             energy_values = self.scf_steps.energies_total
 
-            # Compute differences manually to preserve Pint units
             deltas = []
             for i in range(1, len(energy_values)):
                 delta = np.abs(energy_values[i] - energy_values[i - 1])
                 deltas.append(delta)
 
-            # Convert list to array-like structure
             if len(deltas) > 0 and hasattr(deltas[0], 'magnitude'):
-                # Pint quantities - stack magnitudes and add units
                 magnitudes = [d.magnitude for d in deltas]
                 return np.array(magnitudes) * deltas[0].units
             else:

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -76,9 +76,9 @@ class SCFSteps(ArchiveSection):
     delta_density_rms = Quantity(
         shape=['*'],
         type=float,
-        unit='coulomb',
+        unit='coulomb / meter ** 3',
         description="""
-        Root mean square of change of potential energy at each SCF step.
+        Root mean square of change of charge density at each SCF step.
         """,
     )
 
@@ -280,16 +280,19 @@ class Outputs(SimulationTime):
 
     def _compute_energy_deltas(self, logger: 'BoundLogger'):
         """
-        Compute delta_energies_total from consecutive total_energies values.
+        Compute delta_energies_total from consecutive SCF total energies.
 
         Returns array of absolute energy differences between consecutive steps.
         """
         try:
-            if self.total_energies is None or len(self.total_energies) < 2:
+            if (
+                self.scf_steps is None
+                or self.scf_steps.energies_total is None
+                or len(self.scf_steps.energies_total) < 2
+            ):
                 return None
 
-            # Extract energy values from each step
-            energy_values = [e.value for e in self.total_energies]
+            energy_values = self.scf_steps.energies_total
 
             # Compute differences manually to preserve Pint units
             deltas = []
@@ -307,27 +310,6 @@ class Outputs(SimulationTime):
 
         except (AttributeError, IndexError, TypeError, ValueError) as e:
             logger.debug(f'Could not compute delta_energies_total: {e}')
-            return None
-
-    def _compute_force_norms(self, logger: 'BoundLogger'):
-        """
-        Compute delta_force_abs from total_forces as force norms.
-
-        Returns array of force norms (L2 norm of 3D force vectors).
-        """
-        try:
-            if self.total_forces is None or len(self.total_forces) == 0:
-                return None
-
-            # Get force values (Pint Quantity with shape [n_atoms, 3])
-            force_values = self.total_forces[-1].value
-
-            # Compute force norms (preserves Pint units)
-            force_norms = ((force_values**2).sum(axis=1)) ** 0.5
-
-            return force_norms
-        except (AttributeError, IndexError, TypeError) as e:
-            logger.debug(f'Could not compute delta_force_abs: {e}')
             return None
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
@@ -354,7 +336,6 @@ class Outputs(SimulationTime):
             # Define delta computations: (delta_field, compute_function)
             delta_computations = [
                 ('delta_energies_total', self._compute_energy_deltas),
-                ('delta_force_abs', self._compute_force_norms),
             ]
 
             for delta_field, compute_func in delta_computations:

--- a/src/nomad_simulations/schema_packages/outputs.py
+++ b/src/nomad_simulations/schema_packages/outputs.py
@@ -281,27 +281,27 @@ class Outputs(SimulationTime):
                 return model_methods[-1]
         return None
 
-    def _compute_energy_deltas(self, logger: 'BoundLogger'):
+    @staticmethod
+    def _compute_energy_deltas(energies, logger: 'BoundLogger'):
         """
-        Compute delta_energies_total from consecutive SCF total energies.
+        Compute absolute energy differences between consecutive energies.
 
-        Returns array of absolute energy differences between consecutive steps.
+        Given a sequence of `energies`, returns an array of the absolute
+        differences between consecutive entries, i.e. `deltas[i] =
+        abs(energies[i + 1] - energies[i])`, so N energies produce N - 1 deltas.
+        Accepting the energies as an argument keeps this decoupled from the
+        section, so deltas can be computed from various sources (e.g. SCF
+        `energies_total` or any other energy sequence). Returns None if fewer
+        than two energies are available.
         """
         try:
-            if (
-                self.scf_steps is None
-                or self.scf_steps.energies_total is None
-                or len(self.scf_steps.energies_total) < 2
-            ):
+            if energies is None or len(energies) < 2:
                 return None
-
-            # Extract energy values from each step
-            energy_values = self.scf_steps.energies_total
 
             # Compute differences manually to preserve Pint units
             deltas = []
-            for i in range(1, len(energy_values)):
-                delta = np.abs(energy_values[i] - energy_values[i - 1])
+            for i in range(1, len(energies)):
+                delta = np.abs(energies[i] - energies[i - 1])
                 deltas.append(delta)
 
             # Convert list to array-like structure
@@ -360,7 +360,12 @@ class Outputs(SimulationTime):
         if self.scf_steps is not None:
             # Define delta computations: (delta_field, compute_function)
             delta_computations = [
-                ('delta_energies_total', self._compute_energy_deltas),
+                (
+                    'delta_energies_total',
+                    lambda logger: self._compute_energy_deltas(
+                        self.scf_steps.energies_total, logger
+                    ),
+                ),
                 ('delta_force_abs', self._compute_force_norms),
             ]
 

--- a/src/nomad_simulations/schema_packages/properties/energies.py
+++ b/src/nomad_simulations/schema_packages/properties/energies.py
@@ -32,8 +32,11 @@ class BaseEnergy(PhysicalProperty):
 #! since kinetic energy lives separately, but I think maybe this is ok?
 class TotalEnergy(BaseEnergy):
     """
-    The total energy of a system. `contributions` specify individual energetic
-    contributions to the `TotalEnergy`.
+    The converged total energy of one system configuration.
+
+    Individual energetic components belong inside this section through its
+    `contributions` subsections. The listed contributions do not have to be
+    exhaustive, so the total energy is not necessarily equal to their sum.
     """
 
     # ? add a generic contributions quantity to PhysicalProperty

--- a/src/nomad_simulations/schema_packages/workflow/general.py
+++ b/src/nomad_simulations/schema_packages/workflow/general.py
@@ -510,7 +510,7 @@ class ChargeConvergenceTarget(WorkflowConvergenceTarget):
     """Convergence target for electron density/charge differences."""
 
     threshold = WorkflowConvergenceTarget.threshold.m_copy(deep=True)
-    threshold.m_annotations['expected_unit'] = 'coulomb / meter ** 3'
+    threshold.m_annotations['expected_unit'] = 'coulomb'
     threshold.m_annotations['convergence'] = {'path': '@.scf_steps.delta_density_rms'}
 
 

--- a/src/nomad_simulations/schema_packages/workflow/general.py
+++ b/src/nomad_simulations/schema_packages/workflow/general.py
@@ -510,7 +510,7 @@ class ChargeConvergenceTarget(WorkflowConvergenceTarget):
     """Convergence target for electron density/charge differences."""
 
     threshold = WorkflowConvergenceTarget.threshold.m_copy(deep=True)
-    threshold.m_annotations['expected_unit'] = 'coulomb'
+    threshold.m_annotations['expected_unit'] = 'coulomb / meter ** 3'
     threshold.m_annotations['convergence'] = {'path': '@.scf_steps.delta_density_rms'}
 
 

--- a/templates/vertical.md.j2
+++ b/templates/vertical.md.j2
@@ -4,6 +4,12 @@
 **Purpose:** {{ purpose }}
 
 {% endif %}
+{% if notes %}
+## Notes
+
+{{ notes }}
+
+{% endif %}
 
 ## Relationship map
 

--- a/tests/workflow/test_convergence_targets.py
+++ b/tests/workflow/test_convergence_targets.py
@@ -158,14 +158,11 @@ class TestForceConvergenceTarget:
         force_target.threshold = threshold
         force_target.threshold_type = threshold_type
 
-        # Create outputs with forces and scf_steps
-        forces = TotalForce(value=force_values * ureg.newton)
-        scf_steps = SCFSteps()  # Empty scf_steps for normalization to populate
-        outputs = Outputs(total_forces=[forces], scf_steps=scf_steps)
+        # Create outputs with explicitly parsed SCF force-change magnitudes.
+        scf_steps = SCFSteps()
+        scf_steps.delta_force_abs = np.sqrt((force_values**2).sum(axis=1)) * ureg.newton
+        outputs = Outputs(scf_steps=scf_steps)
         archive.data.outputs = [outputs]
-
-        # Normalize outputs to compute delta_force_abs from total_forces
-        outputs.normalize(archive, logger)
 
         # Check convergence
         is_reached = force_target.normalize(archive, logger)
@@ -244,13 +241,33 @@ class TestChargeConvergenceTarget:
         'threshold, threshold_type, charge_values, expected_reached',
         [
             # Absolute convergence - converged
-            (1e-7 * ureg.coulomb, 'absolute', np.array([1e-10, 1e-10, 1e-10]), True),
+            (
+                1e-7 * ureg.coulomb / ureg.meter**3,
+                'absolute',
+                np.array([1e-10, 1e-10, 1e-10]),
+                True,
+            ),
             # Absolute convergence - not converged
-            (1e-7 * ureg.coulomb, 'absolute', np.array([1e-5, 1e-5, 1e-5]), False),
+            (
+                1e-7 * ureg.coulomb / ureg.meter**3,
+                'absolute',
+                np.array([1e-5, 1e-5, 1e-5]),
+                False,
+            ),
             # RMS convergence - converged
-            (1e-7 * ureg.coulomb, 'rms', np.array([1e-10, 1e-10, 1e-10, 1e-10]), True),
+            (
+                1e-7 * ureg.coulomb / ureg.meter**3,
+                'rms',
+                np.array([1e-10, 1e-10, 1e-10, 1e-10]),
+                True,
+            ),
             # RMS convergence - not converged
-            (1e-7 * ureg.coulomb, 'rms', np.array([1e-5, 1e-5, 1e-5, 1e-5]), False),
+            (
+                1e-7 * ureg.coulomb / ureg.meter**3,
+                'rms',
+                np.array([1e-5, 1e-5, 1e-5, 1e-5]),
+                False,
+            ),
         ],
     )
     def test_charge_convergence(
@@ -266,7 +283,7 @@ class TestChargeConvergenceTarget:
         Test charge convergence with absolute and RMS types.
 
         Args:
-            threshold: Convergence threshold (dimensionless).
+            threshold: Convergence threshold.
             threshold_type: Type of convergence check ('absolute' or 'rms').
             charge_values: Array of charge difference values.
             expected_reached: Expected value of is_reached flag.
@@ -277,7 +294,7 @@ class TestChargeConvergenceTarget:
 
         # Create SCF steps with density RMS values (charge convergence)
         scf_step = SCFSteps()
-        scf_step.delta_density_rms = charge_values * ureg.coulomb
+        scf_step.delta_density_rms = charge_values * ureg.coulomb / ureg.meter**3
 
         archive.data.outputs = [Outputs(scf_steps=scf_step)]
 
@@ -367,7 +384,7 @@ class TestMissingDataHandling:
             (EnergyConvergenceTarget, 1e-6, ureg.joule),
             (ForceConvergenceTarget, 1e-8, ureg.newton),
             (PotentialConvergenceTarget, 1e-5, ureg.joule),
-            (ChargeConvergenceTarget, 1e-7, ureg.coulomb),
+            (ChargeConvergenceTarget, 1e-7, ureg.coulomb / ureg.meter**3),
             (WavefunctionConvergenceTarget, 1e-8, ureg.dimensionless),
         ],
         ids=['Energy', 'Force', 'Potential', 'Charge', 'Wavefunction'],
@@ -549,24 +566,19 @@ class TestConvergenceInWorkflow:
                 threshold=1e-8 * ureg.newton, threshold_type='maximum'
             ),
             ChargeConvergenceTarget(
-                threshold=1e-7 * ureg.coulomb, threshold_type='rms'
+                threshold=1e-7 * ureg.coulomb / ureg.meter**3,
+                threshold_type='rms',
             ),
         ]
 
         # Create test data
         scf_step = SCFSteps()
         scf_step.delta_energies_total = np.array([5e-7]) * ureg.joule
-        scf_step.delta_density_rms = np.array([1e-8]) * ureg.coulomb
+        scf_step.delta_density_rms = np.array([1e-8]) * ureg.coulomb / ureg.meter**3
+        scf_step.delta_force_abs = np.array([1e-9, 2e-9]) * ureg.newton
 
-        forces = TotalForce(
-            value=np.array([[1e-9, 1e-9, 1e-9], [1e-9, 1e-9, 1e-9]]) * ureg.newton
-        )
-
-        outputs = Outputs(scf_steps=scf_step, total_forces=[forces])
+        outputs = Outputs(scf_steps=scf_step)
         archive.data.outputs = [outputs]
-
-        # Normalize outputs to compute delta_force_abs
-        outputs.normalize(archive, logger)
 
         # Normalize workflow
         workflow.normalize(archive, logger)
@@ -616,16 +628,10 @@ class TestConvergenceInWorkflow:
         # Create test data
         scf_step = SCFSteps()
         scf_step.delta_energies_total = np.array([5e-7]) * ureg.joule  # Converges
+        scf_step.delta_force_abs = np.array([1e-5]) * ureg.newton  # Doesn't converge
 
-        forces = TotalForce(
-            value=np.array([[1e-5, 1e-5, 1e-5]]) * ureg.newton
-        )  # Doesn't converge
-
-        outputs = Outputs(scf_steps=scf_step, total_forces=[forces])
+        outputs = Outputs(scf_steps=scf_step)
         archive.data.outputs = [outputs]
-
-        # Normalize outputs to compute delta_force_abs
-        outputs.normalize(archive, logger)
 
         # Normalize targets and capture results
         convergence_results = []
@@ -656,8 +662,8 @@ class TestFallbackPaths:
         is_reached = force_target.normalize(archive, logger)
         assert is_reached is True  # max([1e-9, 2e-9, 1.5e-9]) < 1e-8
 
-    def test_force_fallback_to_computed(self, archive, logger):
-        """Test that delta_force_abs is computed from total_forces during normalization."""
+    def test_force_is_not_inferred_from_final_total_forces(self, archive, logger):
+        """Test that final total_forces are not treated as SCF force changes."""
         force_target = ForceConvergenceTarget()
         force_target.threshold = 1e-8 * ureg.newton
         force_target.threshold_type = 'maximum'
@@ -670,16 +676,13 @@ class TestFallbackPaths:
         outputs = Outputs(total_forces=[forces], scf_steps=scf_steps)
         archive.data.outputs = [outputs]
 
-        # Normalize outputs to compute delta_force_abs from total_forces
+        # Normalize outputs. A final force vector is not an SCF force-change delta.
         outputs.normalize(archive, logger)
 
-        # Verify delta_force_abs was computed
-        assert outputs.scf_steps.delta_force_abs is not None
+        assert outputs.scf_steps.delta_force_abs is None
 
-        # Check convergence using computed values
         is_reached = force_target.normalize(archive, logger)
-        # max norm ≈ 3.46e-9 < 1e-8
-        assert is_reached is True
+        assert is_reached is None
 
     def test_single_path_backwards_compatible(self, archive, logger):
         """Test that single 'path' annotation still works."""
@@ -696,20 +699,16 @@ class TestFallbackPaths:
         is_reached = energy_target.normalize(archive, logger)
         assert is_reached is True
 
-    def test_energy_delta_computed_from_total_energies(self, archive, logger):
-        """Test that delta_energies_total is computed from total_energies during normalization."""
+    def test_energy_delta_computed_from_scf_energies_total(self, archive, logger):
+        """Test that SCF energy deltas are computed from SCF step energies."""
         energy_target = EnergyConvergenceTarget()
         energy_target.threshold = 1e-6 * ureg.joule
         energy_target.threshold_type = 'absolute'
 
-        # Provide total_energies but not delta_energies_total
-        energies = [
-            TotalEnergy(value=1.0 * ureg.joule),
-            TotalEnergy(value=1.0000001 * ureg.joule),  # Delta: 1e-7
-            TotalEnergy(value=1.0000002 * ureg.joule),  # Delta: 1e-7
-        ]
-        scf_steps = SCFSteps()  # Empty scf_steps for normalization to populate
-        outputs = Outputs(total_energies=energies, scf_steps=scf_steps)
+        scf_steps = SCFSteps(
+            energies_total=np.array([1.0, 1.0000001, 1.0000002]) * ureg.joule
+        )
+        outputs = Outputs(scf_steps=scf_steps)
         archive.data.outputs = [outputs]
 
         # Normalize outputs to compute delta_energies_total
@@ -723,6 +722,21 @@ class TestFallbackPaths:
         is_reached = energy_target.normalize(archive, logger)
         # Last delta is 1e-7 < 1e-6
         assert is_reached is True
+
+    def test_energy_delta_not_computed_from_output_total_energies(
+        self, archive, logger
+    ):
+        """Test that sibling total_energies are not treated as SCF iterations."""
+        energies = [
+            TotalEnergy(value=1.0 * ureg.joule),
+            TotalEnergy(value=2.0 * ureg.joule),
+        ]
+        outputs = Outputs(total_energies=energies, scf_steps=SCFSteps())
+        archive.data.outputs = [outputs]
+
+        outputs.normalize(archive, logger)
+
+        assert outputs.scf_steps.delta_energies_total is None
 
 
 class TestThresholdTypeValidation:

--- a/tests/workflow/test_convergence_targets.py
+++ b/tests/workflow/test_convergence_targets.py
@@ -13,7 +13,7 @@ import pytest
 from nomad.units import ureg
 
 from nomad_simulations.schema_packages.outputs import Outputs, SCFSteps
-from nomad_simulations.schema_packages.properties import TotalEnergy, TotalForce
+from nomad_simulations.schema_packages.properties import TotalForce
 from nomad_simulations.schema_packages.workflow.general import (
     ChargeConvergenceTarget,
     EnergyConvergenceTarget,
@@ -722,21 +722,6 @@ class TestFallbackPaths:
         is_reached = energy_target.normalize(archive, logger)
         # Last delta is 1e-7 < 1e-6
         assert is_reached is True
-
-    def test_energy_delta_not_computed_from_output_total_energies(
-        self, archive, logger
-    ):
-        """Test that sibling total_energies are not treated as SCF iterations."""
-        energies = [
-            TotalEnergy(value=1.0 * ureg.joule),
-            TotalEnergy(value=2.0 * ureg.joule),
-        ]
-        outputs = Outputs(total_energies=energies, scf_steps=SCFSteps())
-        archive.data.outputs = [outputs]
-
-        outputs.normalize(archive, logger)
-
-        assert outputs.scf_steps.delta_energies_total is None
 
 
 class TestThresholdTypeValidation:

--- a/tests/workflow/test_convergence_targets.py
+++ b/tests/workflow/test_convergence_targets.py
@@ -158,11 +158,14 @@ class TestForceConvergenceTarget:
         force_target.threshold = threshold
         force_target.threshold_type = threshold_type
 
-        # Create outputs with explicitly parsed SCF force-change magnitudes.
-        scf_steps = SCFSteps()
-        scf_steps.delta_force_abs = np.sqrt((force_values**2).sum(axis=1)) * ureg.newton
-        outputs = Outputs(scf_steps=scf_steps)
+        # Create outputs with forces and scf_steps
+        forces = TotalForce(value=force_values * ureg.newton)
+        scf_steps = SCFSteps()  # Empty scf_steps for normalization to populate
+        outputs = Outputs(total_forces=[forces], scf_steps=scf_steps)
         archive.data.outputs = [outputs]
+
+        # Normalize outputs to compute delta_force_abs from total_forces
+        outputs.normalize(archive, logger)
 
         # Check convergence
         is_reached = force_target.normalize(archive, logger)
@@ -241,33 +244,13 @@ class TestChargeConvergenceTarget:
         'threshold, threshold_type, charge_values, expected_reached',
         [
             # Absolute convergence - converged
-            (
-                1e-7 * ureg.coulomb,
-                'absolute',
-                np.array([1e-10, 1e-10, 1e-10]),
-                True,
-            ),
+            (1e-7 * ureg.coulomb, 'absolute', np.array([1e-10, 1e-10, 1e-10]), True),
             # Absolute convergence - not converged
-            (
-                1e-7 * ureg.coulomb,
-                'absolute',
-                np.array([1e-5, 1e-5, 1e-5]),
-                False,
-            ),
+            (1e-7 * ureg.coulomb, 'absolute', np.array([1e-5, 1e-5, 1e-5]), False),
             # RMS convergence - converged
-            (
-                1e-7 * ureg.coulomb,
-                'rms',
-                np.array([1e-10, 1e-10, 1e-10, 1e-10]),
-                True,
-            ),
+            (1e-7 * ureg.coulomb, 'rms', np.array([1e-10, 1e-10, 1e-10, 1e-10]), True),
             # RMS convergence - not converged
-            (
-                1e-7 * ureg.coulomb,
-                'rms',
-                np.array([1e-5, 1e-5, 1e-5, 1e-5]),
-                False,
-            ),
+            (1e-7 * ureg.coulomb, 'rms', np.array([1e-5, 1e-5, 1e-5, 1e-5]), False),
         ],
     )
     def test_charge_convergence(
@@ -283,7 +266,7 @@ class TestChargeConvergenceTarget:
         Test charge convergence with absolute and RMS types.
 
         Args:
-            threshold: Convergence threshold.
+            threshold: Convergence threshold (dimensionless).
             threshold_type: Type of convergence check ('absolute' or 'rms').
             charge_values: Array of charge difference values.
             expected_reached: Expected value of is_reached flag.
@@ -566,8 +549,7 @@ class TestConvergenceInWorkflow:
                 threshold=1e-8 * ureg.newton, threshold_type='maximum'
             ),
             ChargeConvergenceTarget(
-                threshold=1e-7 * ureg.coulomb,
-                threshold_type='rms',
+                threshold=1e-7 * ureg.coulomb, threshold_type='rms'
             ),
         ]
 
@@ -575,10 +557,16 @@ class TestConvergenceInWorkflow:
         scf_step = SCFSteps()
         scf_step.delta_energies_total = np.array([5e-7]) * ureg.joule
         scf_step.delta_density_rms = np.array([1e-8]) * ureg.coulomb
-        scf_step.delta_force_abs = np.array([1e-9, 2e-9]) * ureg.newton
 
-        outputs = Outputs(scf_steps=scf_step)
+        forces = TotalForce(
+            value=np.array([[1e-9, 1e-9, 1e-9], [1e-9, 1e-9, 1e-9]]) * ureg.newton
+        )
+
+        outputs = Outputs(scf_steps=scf_step, total_forces=[forces])
         archive.data.outputs = [outputs]
+
+        # Normalize outputs to compute delta_force_abs
+        outputs.normalize(archive, logger)
 
         # Normalize workflow
         workflow.normalize(archive, logger)
@@ -628,10 +616,16 @@ class TestConvergenceInWorkflow:
         # Create test data
         scf_step = SCFSteps()
         scf_step.delta_energies_total = np.array([5e-7]) * ureg.joule  # Converges
-        scf_step.delta_force_abs = np.array([1e-5]) * ureg.newton  # Doesn't converge
 
-        outputs = Outputs(scf_steps=scf_step)
+        forces = TotalForce(
+            value=np.array([[1e-5, 1e-5, 1e-5]]) * ureg.newton
+        )  # Doesn't converge
+
+        outputs = Outputs(scf_steps=scf_step, total_forces=[forces])
         archive.data.outputs = [outputs]
+
+        # Normalize outputs to compute delta_force_abs
+        outputs.normalize(archive, logger)
 
         # Normalize targets and capture results
         convergence_results = []
@@ -662,8 +656,8 @@ class TestFallbackPaths:
         is_reached = force_target.normalize(archive, logger)
         assert is_reached is True  # max([1e-9, 2e-9, 1.5e-9]) < 1e-8
 
-    def test_force_is_not_inferred_from_final_total_forces(self, archive, logger):
-        """Test that final total_forces are not treated as SCF force changes."""
+    def test_force_fallback_to_computed(self, archive, logger):
+        """Test that delta_force_abs is computed from total_forces during normalization."""
         force_target = ForceConvergenceTarget()
         force_target.threshold = 1e-8 * ureg.newton
         force_target.threshold_type = 'maximum'
@@ -676,13 +670,16 @@ class TestFallbackPaths:
         outputs = Outputs(total_forces=[forces], scf_steps=scf_steps)
         archive.data.outputs = [outputs]
 
-        # Normalize outputs. A final force vector is not an SCF force-change delta.
+        # Normalize outputs to compute delta_force_abs from total_forces
         outputs.normalize(archive, logger)
 
-        assert outputs.scf_steps.delta_force_abs is None
+        # Verify delta_force_abs was computed
+        assert outputs.scf_steps.delta_force_abs is not None
 
+        # Check convergence using computed values
         is_reached = force_target.normalize(archive, logger)
-        assert is_reached is None
+        # max norm ≈ 3.46e-9 < 1e-8
+        assert is_reached is True
 
     def test_single_path_backwards_compatible(self, archive, logger):
         """Test that single 'path' annotation still works."""

--- a/tests/workflow/test_convergence_targets.py
+++ b/tests/workflow/test_convergence_targets.py
@@ -13,7 +13,7 @@ import pytest
 from nomad.units import ureg
 
 from nomad_simulations.schema_packages.outputs import Outputs, SCFSteps
-from nomad_simulations.schema_packages.properties import TotalForce
+from nomad_simulations.schema_packages.properties import TotalEnergy, TotalForce
 from nomad_simulations.schema_packages.workflow.general import (
     ChargeConvergenceTarget,
     EnergyConvergenceTarget,
@@ -719,6 +719,26 @@ class TestFallbackPaths:
         is_reached = energy_target.normalize(archive, logger)
         # Last delta is 1e-7 < 1e-6
         assert is_reached is True
+
+    def test_energy_delta_ignores_output_total_energies(self, archive, logger):
+        """Test that generic total_energies are not treated as SCF iterations."""
+        outputs = Outputs(
+            total_energies=[
+                TotalEnergy(value=1.0 * ureg.joule),
+                TotalEnergy(value=2.0 * ureg.joule),
+            ],
+            scf_steps=SCFSteps(
+                energies_total=np.array([10.0, 10.1, 10.3]) * ureg.joule
+            ),
+        )
+        archive.data.outputs = [outputs]
+
+        outputs.normalize(archive, logger)
+
+        assert outputs.scf_steps.delta_energies_total is not None
+        assert list(outputs.scf_steps.delta_energies_total.magnitude) == pytest.approx(
+            [0.1, 0.2]
+        )
 
 
 class TestThresholdTypeValidation:

--- a/tests/workflow/test_convergence_targets.py
+++ b/tests/workflow/test_convergence_targets.py
@@ -697,15 +697,20 @@ class TestFallbackPaths:
         assert is_reached is True
 
     def test_energy_delta_computed_from_scf_energies_total(self, archive, logger):
-        """Test that SCF energy deltas are computed from SCF step energies."""
+        """Test that SCF deltas are computed from SCF energies, not total energies."""
         energy_target = EnergyConvergenceTarget()
         energy_target.threshold = 1e-6 * ureg.joule
         energy_target.threshold_type = 'absolute'
 
-        scf_steps = SCFSteps(
-            energies_total=np.array([1.0, 1.0000001, 1.0000002]) * ureg.joule
+        outputs = Outputs(
+            total_energies=[
+                TotalEnergy(value=1000.0 * ureg.joule),
+                TotalEnergy(value=2500.0 * ureg.joule),
+            ],
+            scf_steps=SCFSteps(
+                energies_total=np.array([10.0, 10.0000002, 10.0000007]) * ureg.joule
+            ),
         )
-        outputs = Outputs(scf_steps=scf_steps)
         archive.data.outputs = [outputs]
 
         # Normalize outputs to compute delta_energies_total
@@ -714,31 +719,17 @@ class TestFallbackPaths:
         # Verify delta_energies_total was computed
         assert outputs.scf_steps.delta_energies_total is not None
         assert len(outputs.scf_steps.delta_energies_total) == 2  # n-1 deltas
+        assert list(outputs.scf_steps.delta_energies_total.magnitude) == pytest.approx(
+            [2e-7, 5e-7]
+        )
+        assert list(outputs.scf_steps.delta_energies_total.magnitude) != pytest.approx(
+            [1500.0]
+        )
 
         # Check convergence using computed values
         is_reached = energy_target.normalize(archive, logger)
-        # Last delta is 1e-7 < 1e-6
+        # Last SCF delta is 5e-7 < 1e-6
         assert is_reached is True
-
-    def test_energy_delta_ignores_output_total_energies(self, archive, logger):
-        """Test that generic total_energies are not treated as SCF iterations."""
-        outputs = Outputs(
-            total_energies=[
-                TotalEnergy(value=1.0 * ureg.joule),
-                TotalEnergy(value=2.0 * ureg.joule),
-            ],
-            scf_steps=SCFSteps(
-                energies_total=np.array([10.0, 10.1, 10.3]) * ureg.joule
-            ),
-        )
-        archive.data.outputs = [outputs]
-
-        outputs.normalize(archive, logger)
-
-        assert outputs.scf_steps.delta_energies_total is not None
-        assert list(outputs.scf_steps.delta_energies_total.magnitude) == pytest.approx(
-            [0.1, 0.2]
-        )
 
 
 class TestThresholdTypeValidation:

--- a/tests/workflow/test_convergence_targets.py
+++ b/tests/workflow/test_convergence_targets.py
@@ -242,28 +242,28 @@ class TestChargeConvergenceTarget:
         [
             # Absolute convergence - converged
             (
-                1e-7 * ureg.coulomb / ureg.meter**3,
+                1e-7 * ureg.coulomb,
                 'absolute',
                 np.array([1e-10, 1e-10, 1e-10]),
                 True,
             ),
             # Absolute convergence - not converged
             (
-                1e-7 * ureg.coulomb / ureg.meter**3,
+                1e-7 * ureg.coulomb,
                 'absolute',
                 np.array([1e-5, 1e-5, 1e-5]),
                 False,
             ),
             # RMS convergence - converged
             (
-                1e-7 * ureg.coulomb / ureg.meter**3,
+                1e-7 * ureg.coulomb,
                 'rms',
                 np.array([1e-10, 1e-10, 1e-10, 1e-10]),
                 True,
             ),
             # RMS convergence - not converged
             (
-                1e-7 * ureg.coulomb / ureg.meter**3,
+                1e-7 * ureg.coulomb,
                 'rms',
                 np.array([1e-5, 1e-5, 1e-5, 1e-5]),
                 False,
@@ -294,7 +294,7 @@ class TestChargeConvergenceTarget:
 
         # Create SCF steps with density RMS values (charge convergence)
         scf_step = SCFSteps()
-        scf_step.delta_density_rms = charge_values * ureg.coulomb / ureg.meter**3
+        scf_step.delta_density_rms = charge_values * ureg.coulomb
 
         archive.data.outputs = [Outputs(scf_steps=scf_step)]
 
@@ -384,7 +384,7 @@ class TestMissingDataHandling:
             (EnergyConvergenceTarget, 1e-6, ureg.joule),
             (ForceConvergenceTarget, 1e-8, ureg.newton),
             (PotentialConvergenceTarget, 1e-5, ureg.joule),
-            (ChargeConvergenceTarget, 1e-7, ureg.coulomb / ureg.meter**3),
+            (ChargeConvergenceTarget, 1e-7, ureg.coulomb),
             (WavefunctionConvergenceTarget, 1e-8, ureg.dimensionless),
         ],
         ids=['Energy', 'Force', 'Potential', 'Charge', 'Wavefunction'],
@@ -566,7 +566,7 @@ class TestConvergenceInWorkflow:
                 threshold=1e-8 * ureg.newton, threshold_type='maximum'
             ),
             ChargeConvergenceTarget(
-                threshold=1e-7 * ureg.coulomb / ureg.meter**3,
+                threshold=1e-7 * ureg.coulomb,
                 threshold_type='rms',
             ),
         ]
@@ -574,7 +574,7 @@ class TestConvergenceInWorkflow:
         # Create test data
         scf_step = SCFSteps()
         scf_step.delta_energies_total = np.array([5e-7]) * ureg.joule
-        scf_step.delta_density_rms = np.array([1e-8]) * ureg.coulomb / ureg.meter**3
+        scf_step.delta_density_rms = np.array([1e-8]) * ureg.coulomb
         scf_step.delta_force_abs = np.array([1e-9, 2e-9]) * ureg.newton
 
         outputs = Outputs(scf_steps=scf_step)


### PR DESCRIPTION
## Purpose

Fix SCF energy-delta normalization so `SCFSteps.delta_energies_total` is derived from the SCF iteration energy history, not from generic output energy sections.

## Scope

### Included

* Make `_compute_energy_deltas` source-agnostic by accepting an explicit `energies` argument.
* Call `_compute_energy_deltas` from `Outputs.normalize` with `scf_steps.energies_total`.
* Update the convergence tests to:

  * provide the SCF iteration history through `scf_steps.energies_total`;
  * verify that generic `Outputs.total_energies` entries are not treated as SCF iterations;
  * verify the resulting convergence behavior.
* Update tutorial snippets that demonstrate automatic SCF energy-delta population.
* Clarify the schema semantics of:

  * `Outputs`;
  * `TotalEnergy`;
  * `SCFSteps.energies_total`;
  * `SCFSteps.delta_energies_total`.
* Add a conceptual geometry-optimization example distinguishing:

  * SCF iterations within one configuration;
  * ordered workflow configurations represented by separate `WorkflowOutputs` sections.
* Update the schema-documentation generator and template so these explanations remain part of the generated documentation.

### Out of scope

* Changing force-convergence fallback behavior.
* Changing `_rms` SCF quantity names, units, or descriptions.

## Context and links

Part of #423.

Previously, repeated `Outputs.total_energies` entries could be interpreted as an ordered sequence of SCF iterations. This is unsafe because `total_energies` may instead contain separately labelled energy variants, such as DFT and dispersion-corrected total energies.

The schema now makes the relevant sequence axes explicit:

* `SCFSteps.energies_total` contains the ordered SCF iteration energies within one system configuration.
* Separate `Outputs` or `WorkflowOutputs` sections represent separate system configurations or workflow steps.
* Repeated `Outputs.total_energies` entries do not currently have a defined ordering or sequence meaning.

## Reviewer notes

The change remains intentionally narrow. Existing `delta_force_abs` behavior and `_rms` metadata are left unchanged for separate follow-up work.

Seven parsers map `SCFSteps.delta_energies_total` directly: VASP, Crystal, exciting, ABINIT, FHI-aims, Quantum ESPRESSO/PWscf, and AMS. Together, these contain ten mapping declarations: three for VASP, two for Quantum ESPRESSO/PWscf, and one for each of the others.

Each parser sets the quantity explicitly, so the normalizer inference, which only runs when the field is unset, was already a no-op for them.

GPAW is the eighth parser that constructs `scf_steps`, and the only one that maps neither `delta_energies_total` nor `energies_total`. Its `get_energies` method returns one total energy plus its contributions. Consequently:

* `Outputs.total_energies` contains only one entry, so the previous `len(total_energies) >= 2` guard returned `None`;
* `scf_steps.energies_total` remains unset, so the new inference also returns `None`.

GPAW's `delta_energies_total` is therefore unset both before and after this change.

FHI-aims similarly returns one total energy plus components rather than sibling total-energy values, and maps the SCF energy delta directly regardless.

## Status

* [x] Ready for review

## Breaking changes

* [x] `delta_energies_total` is no longer inferred from `Outputs.total_energies`.
* [x] It is inferred only when `scf_steps.energies_total` contains at least two values.
* [x] No current parser is affected.

## Dependencies and blockers

* [x] None

## Testing and validation

* [x] Unit tests

