### PR TITLE
QC3 (docstring fix): dead references and scientific clarify 

### DIFF
--- a/docs/schema/model_method_electronic.md
+++ b/docs/schema/model_method_electronic.md
@@ -75,7 +75,7 @@ classDiagram
 
 | Quantity | Type | Description |
 |---|---|---|
-| `jacobs_ladder` | Enum | <details><summary>Highest Jacob's ladder rung present among XC components.</summary>Highest Jacob's ladder rung present among XC components.<br>See:<br>- https://doi.org/10.1063/1.1390175 (original paper)<br>- https://doi.org/10.1103/PhysRevLett.91.146401 (meta-GGA)<br>- https://doi.org/10.1063/1.1904565 (hyper-GGA)</details> |
+| `jacobs_ladder` | Enum | <details><summary>Highest Jacob's ladder rung present among XC components.</summary>Highest Jacob's ladder rung present among XC components.<br>See:<br>- https://doi.org/10.1063/1.1390175 (original paper)<br>- https://doi.org/10.1103/PhysRevLett.91.146401 (meta-GGA)</details> |
 | `reference_form` | Enum | <details><summary>Kohn-Sham reference form used for the DFT calculation.</summary>Kohn-Sham reference form used for the DFT calculation.<br>- **RKS**: restricted Kohn-Sham reference<br>- **UKS**: unrestricted Kohn-Sham reference<br>- **ROKS**: restricted open-shell Kohn-Sham reference</details> |
 
 ### `TB`

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -251,7 +251,7 @@ class EmpiricalDispersionModel(BaseModelMethod):
     • S. Grimme, S. Ehrlich, L. Goerigk, J. Comput. Chem. 32, 1456 (2011) - DFT-D3(BJ)
     • A. Tkatchenko, M. Scheffler, Phys. Rev. Lett. 102, 073005 (2009) - TS
     • A. Tkatchenko et al., Phys. Rev. Lett. 108, 236402 (2012) - MBD
-    • C. Steinmann, WIREs Comput. Mol. Sci. 10, e1438 (2020) - overview
+    • S. Grimme, A. Hansen, J. G. Brandenburg, C. Bannwarth, Chem. Rev. 116, 5105 (2016) - overview
     """
 
     model = Quantity(

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -408,8 +408,8 @@ class RelativityModel(BaseModelMethod):
         ),
         default='non-relativistic',
         description="""
-        Non-relativistic (Schrödinger), scalar (spin-free),
-        two-component (spin-orbit couple removed variationally, e.g. X2C),
+        Non-relativistic (Schrödinger), scalar (spin-free, spin-orbit coupling omitted),
+        two-component (spin-orbit coupling included variationally, e.g. X2C),
         or four-component Dirac treatment.
         """,
     )
@@ -598,9 +598,9 @@ class XCComponent(ArchiveSection):
         Functional form of the range-separation kernel used to partition the Coulomb operator.
 
         Common choices:
-        • erf     — error function (used in LC-ωPBE, CAM-B3LYP)
-        • erfc    — complementary error function (equivalent to erf split)
-        • Yukawa  — exponential screening, e.g. HSE-style
+        • erf     — error function (long-range split, e.g. LC-ωPBE, CAM-B3LYP)
+        • erfc    — complementary error function (short-range split; e.g. the screened exchange in HSE03/HSE06)
+        • Yukawa  — exponential (Yukawa) screening, e.g. Yukawa-range-separated hybrids
         • exp     — simple exponential decay
         • Gaussian — Gaussian screening form
         • Slater  — Slater-type exponential

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -124,8 +124,9 @@ class ImplicitSolvationModel(BaseModelMethod):
     References
     ----------
     •  J. Tomasi, B. Mennucci, R. Cammi, *Chem. Rev.* **105**, 2999 (2005) - PCM overview
-    •  A. Klamt, *J. Phys. Chem.* **99**, 2224 (1995) - COSMO
-    •  A. V. Marenich *et al.*, *J. Chem. Phys. B* **113**, 6378 (2009) - SMD
+    •  A. Klamt, G. Schüürmann, *J. Chem. Soc., Perkin Trans. 2*, 799 (1993) - COSMO
+    •  A. Klamt, *J. Phys. Chem.* **99**, 2224 (1995) - COSMO-RS
+    •  A. V. Marenich *et al.*, *J. Phys. Chem. B* **113**, 6378 (2009) - SMD
     """
 
     model = Quantity(
@@ -247,7 +248,7 @@ class EmpiricalDispersionModel(BaseModelMethod):
     ----------
     • S. Grimme, J. Comp. Chem. 27, 1787 (2006) - DFT-D2
     • S. Grimme et al., J. Chem. Phys. 132, 154104 (2010) - DFT-D3
-    • S. Grimme et al., J. Chem. Phys. 136, 154105 (2012) - DFT-D3(BJ)
+    • S. Grimme, S. Ehrlich, L. Goerigk, J. Comput. Chem. 32, 1456 (2011) - DFT-D3(BJ)
     • A. Tkatchenko, M. Scheffler, Phys. Rev. Lett. 102, 073005 (2009) - TS
     • A. Tkatchenko et al., Phys. Rev. Lett. 108, 236402 (2012) - MBD
     • C. Steinmann, WIREs Comput. Mol. Sci. 10, e1438 (2020) - overview
@@ -762,7 +763,6 @@ class DFT(ModelMethodElectronic):
         See:
             - https://doi.org/10.1063/1.1390175 (original paper)
             - https://doi.org/10.1103/PhysRevLett.91.146401 (meta-GGA)
-            - https://doi.org/10.1063/1.1904565 (hyper-GGA)
         """,
     )
 
@@ -2290,7 +2290,7 @@ class ActiveSpace(ArchiveSection):
     Captures just the counts and labeling needed to identify the orbital/electron
     subspace used by CASSCF/CASPT2-style calculations.
 
-    - CAS: complete active space (Roos et al., Chem. Phys. Lett. 48, 157, 1980)
+    - CAS: complete active space (Roos et al., Chem. Phys. 48, 157, 1980)
     - RAS: restricted active space (Olsen et al., J. Chem. Phys. 89, 2185, 1988)
 
     CAS vs RAS

--- a/src/nomad_simulations/schema_packages/model_method.py
+++ b/src/nomad_simulations/schema_packages/model_method.py
@@ -246,7 +246,7 @@ class EmpiricalDispersionModel(BaseModelMethod):
 
     References
     ----------
-    • S. Grimme, J. Comp. Chem. 27, 1787 (2006) - DFT-D2
+    • S. Grimme, J. Comput. Chem. 27, 1787 (2006) - DFT-D2
     • S. Grimme et al., J. Chem. Phys. 132, 154104 (2010) - DFT-D3
     • S. Grimme, S. Ehrlich, L. Goerigk, J. Comput. Chem. 32, 1456 (2011) - DFT-D3(BJ)
     • A. Tkatchenko, M. Scheffler, Phys. Rev. Lett. 102, 073005 (2009) - TS
@@ -2091,7 +2091,7 @@ class LocalCorrelation(ArchiveSection):
     Representative references
     -------------------------
     - M. Schütz, J. Chem. Phys. 113, 9986 (2000).
-    - E. Riplinger and F. Neese, J. Chem. Phys. 138, 034106 (2013).
+    - C. Riplinger and F. Neese, J. Chem. Phys. 138, 034106 (2013).
     """
 
     type = Quantity(

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1554,7 +1554,7 @@ class IntegralDecomposition(ArchiveSection):
         Chem. Phys. Lett. 240, 283 (1995). (RI-J)
       - C. Hättig, F. Weigend, J. Chem. Phys. 113, 5154 (2000). (RI-CC2)
       - Neese et al., "Chain-of-spheres algorithms for HF exchange,"
-        Chem. Phys. 356 (2008), 98-109.
+        Chem. Phys. 356 (2009), 98-109.
     """
 
     approximation_type = Quantity(

--- a/src/nomad_simulations/schema_packages/numerical_settings.py
+++ b/src/nomad_simulations/schema_packages/numerical_settings.py
@@ -1550,7 +1550,9 @@ class IntegralDecomposition(ArchiveSection):
       - F. Weigend, M. Häser, The RI-MP2 method: Algorithmic
         implementation of efficient, approximate MP2 theories,
         Theor. Chem. Acc. 97, 331-340 (1997).
-      - S. Hättig, F. Weigend, J. Chem. Phys. 113, 5154 (2000). (RI-J)
+      - K. Eichkorn, O. Treutler, H. Öhm, M. Häser, R. Ahlrichs,
+        Chem. Phys. Lett. 240, 283 (1995). (RI-J)
+      - C. Hättig, F. Weigend, J. Chem. Phys. 113, 5154 (2000). (RI-CC2)
       - Neese et al., "Chain-of-spheres algorithms for HF exchange,"
         Chem. Phys. 356 (2008), 98-109.
     """


### PR DESCRIPTION
## Purpose

Docstring-only cleanup of the electronic model-method and numerical-settings schemas. Several literature references were wrong, mislabeled, or incomplete, and a few descriptions were scientifically inaccurate.

## Scope

**Included**
- Corrected citations (author initial, journal, or year): `LocalCorrelation` (C. not E. Riplinger), `ActiveSpace` (Roos in *Chem. Phys.*, not *Chem. Phys. Lett.*), `IntegralDecomposition` (C. not S. Hättig; chain-of-spheres year 2009), `EmpiricalDispersionModel` (`J. Comput. Chem.` abbreviation).
- Replaced or relabeled references: `ImplicitSolvationModel` (added the original COSMO paper, Klamt and Schüürmann 1993; relabeled Klamt 1995 as COSMO-RS; fixed SMD journal to *J. Phys. Chem. B*), `EmpiricalDispersionModel` (correct DFT-D3(BJ) paper, Grimme, Ehrlich, Goerigk 2011; overview to Grimme et al. 2016), `IntegralDecomposition` (added the Eichkorn 1995 RI-J paper; relabeled Hättig/Weigend 2000 as RI-CC2).
- Clarified inaccurate physics in descriptions: `RelativityModel` (two-component includes spin-orbit coupling variationally; scalar omits it, was previously stated backwards) and `XCComponent.range_separation` (erf for long-range split, erfc for short-range screened exchange as in HSE03/HSE06, Yukawa distinct from HSE).
- Removed the hyper-GGA reference from `DFT.jacobs_ladder` and regenerated `model_method_electronic.md` to stay in sync.

**Out of scope**
- Any change to quantity types, defaults, or semantics.

## Reviewer Notes

- The substantive corrections (not typo fixes) are the DFT-D3(BJ) reswap (2012 *J. Chem. Phys.* entry was the wrong paper) and the RI-J vs RI-CC2 relabeling in `IntegralDecomposition`. Worth a quick sanity check against the literature.

## Status

- [x] Ready for review

## Breaking Changes

- [x] None (docstrings and generated docs only)

## Dependencies / Blockers

- [x] None

